### PR TITLE
Comment out willTransition action for workspaces_new_route

### DIFF
--- a/app/routes/workspaces_new_route.js
+++ b/app/routes/workspaces_new_route.js
@@ -9,8 +9,8 @@ Encompass.WorkspacesNewRoute = Ember.Route.extend({
   },
 
   actions: {
-    willTransition: function() {
-      this.send('reload');
-    }
+    // willTransition: function() {
+    //   this.send('reload');
+    // }
   }
 });


### PR DESCRIPTION
This is to prevent the "nothing handled action 'reload'" error when navigating from the workspaces/new route