### PR TITLE
Request handler now uses sendError as an object with error handling methods inside

### DIFF
--- a/app/datasource/api/requestHandler.js
+++ b/app/datasource/api/requestHandler.js
@@ -22,9 +22,11 @@ var userApi = require('./userApi'),
   * @param {ServerResponse} res The response object
   * @param {Object} data The data to send
  */
-function sendResponse(res, data) {
-  if(!data) {
-    res.send(404);
+function sendResponse(req, res, data) {
+  if (!data) {
+    res.status(404).json({
+      error: 'Not found'
+    });
   } else {
     res.send(data);
   }
@@ -33,21 +35,62 @@ function sendResponse(res, data) {
 /**
   * @public
   * @method sendError
-  * @description Utility callback to respond with an error and log it
+  * @description Send error has a bunch of methods to return specific error types
+  * @description The error types are copies of the restify error types to reduce refactoring https: //github.com/restify/errors
   * @param {HttpError} error The error to send
   * @param {ServerResponse} res The response object
   * @todo We shouldn't need to fix the error code with res.send - The error bubbled up should
   *       always be an instance of HttpError with its own error code.
-  */ 
-function sendError(error, res) {
-  logger.error(error);
-  res.send(500, error);
+  */
+
+const sendError = {
+  InternalError: function (req, res, err) {
+      res.status(500).json({
+        error: err || 'Internal Error'
+      });
+    },
+  BadMethodError: function (req, res, err) {
+    res.status(405).json({
+      error: err || 'Bad Method'
+    });
+  },
+  NotAuthorizedError: function (req, res, err) {
+    res.status(403).json({
+      error: err || 'Not Authorized'
+    });
+  },
+  InvalidCredentialsError: function (req, res, err) {
+    res.status(401).json({
+      error: err || 'Invalid Credentials'
+    });
+  },
+  InvalidArgumentError: function (req, res, err) {
+    res.status(409).json({
+      error: err || 'Invalid Argument'
+    });
+  },
+  InvalidContentError: function (req, res, err) {
+    res.status(400).json({
+      error: err || 'Invalid Content'
+    });
+  },
+  RestError: function (req, res, err) {
+    res.status(400).json({
+      error: err || 'Rest error'
+    });
+    }
+
 }
 
-function sendCustomError(code, error, res) {
-  logger.error(error);
-  res.send(code, error);
-}
+// function sendError(error, res) {
+//   logger.error(error);
+//   res.send(500, error);
+// }
+
+// function sendCustomError(code, error, res) {
+//   logger.error(error);
+//   res.send(code, error);
+// }
 
 /**
   * @public
@@ -56,14 +99,14 @@ function sendCustomError(code, error, res) {
   * @param {HttpError} error The error to send
   * @param {ServerRequest} req The resquest object
   * @todo At the moment, the only criteria we have is ID. Ideally we should support more criteria
-  *       for greater filtering on request. We also need default criteria in place so people can't 
+  *       for greater filtering on request. We also need default criteria in place so people can't
   *       just get everything
   * @howto Ideally, this should go hand in hand with the type of grouping provided by the [Mongoose
-  *        aggregate method](http://mongoosejs.com/docs/api.html#aggregate_Aggregate): 
+  *        aggregate method](http://mongoosejs.com/docs/api.html#aggregate_Aggregate):
   *        Allowing for matching, sorting, and ordering of requested objects.
-  */ 
+  */
 function buildCriteria(req) {
-  var criteria = {}; 
+  var criteria = {};
   criteria.$and = [ //ENC-494
     {
       $or: [
@@ -91,7 +134,7 @@ function buildCriteria(req) {
 /**
   * @public
   * @method modelize
-  * @description This takes an external submission and recursively massages 
+  * @description This takes an external submission and recursively massages
   *              all of its properties to conform to our own JSON standards.
   * @param {Object} obj The external submission we're formatting (only from the PoWs for now)
   * @param {String} currentField The name of the current field we're formatting
@@ -105,7 +148,7 @@ function modelize(obj, currentField) {
   var recurse = function(elem, index, arr) {
     return modelize(elem, currentField);
   };
-  
+
   for (var key in obj) {
     if( obj.hasOwnProperty(key) ) {
       var value = obj[key];
@@ -115,11 +158,11 @@ function modelize(obj, currentField) {
         property = singular[currentField];
       }
 
-      /* If the field we're looking at has a property containing any keyword, 
-         rename the property using camelcase. 
-         
+      /* If the field we're looking at has a property containing any keyword,
+         rename the property using camelcase.
+
          i.e obj.prop.id => obj.prop.propId
-      */ 
+      */
       if(keywords.indexOf(key) > -1) {
         var splitKey = [
           key.charAt(0).toUpperCase(),
@@ -137,7 +180,7 @@ function modelize(obj, currentField) {
         var array = model[key].map(recurse);
 
         model[key] = array;
-      } 
+      }
       else { model[property] = value; }
     }
   }
@@ -148,10 +191,10 @@ function modelize(obj, currentField) {
 /**
   * @public
   * @method generateApiSecret
-  * @description This method generates an encrypted string using a given `time` 
+  * @description This method generates an encrypted string using a given `time`
   *              for communication between Encompass and the PoWs
-  * @param {Int} time A timestamp 
-  * @return {String} The encrypted secret 
+  * @param {Int} time A timestamp
+  * @return {String} The encrypted secret
   */
 function generateApiSecret(time) {
   var timestamp = (!!arguments.length) ? time : Date.now(),
@@ -165,14 +208,14 @@ function generateApiSecret(time) {
 /**
   * @public
   * @method generateApiKey
-  * @description This method generates an api `key` object 
+  * @description This method generates an api `key` object
   *               consisting of all necessary fields for validating an API key
-  * @howto The real key generation is done by `generateApiSecret` 
-  *        This function merely provides a consistent way to define what we expect 
+  * @howto The real key generation is done by `generateApiSecret`
+  *        This function merely provides a consistent way to define what we expect
   *        in the request header sending the key
   * @see [generateApiSecret](./requestHandler.js)
-  * @param {Int} time A timestamp 
-  * @return {Object} An "API key" object.  
+  * @param {Int} time A timestamp
+  * @return {Object} An "API key" object.
   */
 function generateApiKey(time) {
   var key = {
@@ -187,12 +230,12 @@ function generateApiKey(time) {
 /**
   * @public
   * @method isValidApiKey
-  * @description This method verifies that an API key is valid. 
+  * @description This method verifies that an API key is valid.
   * @see [generateApiSecret](./requestHandler.js)
-  * @todo Accept an "API key" object instead 
+  * @todo Accept an "API key" object instead
   * @param {String} secret An encypted secret key
   * @param {Int} timestamp The timestamp from which the `secret` was generated
-  * @return {Boolean} True if valid, otherwise false.  
+  * @return {Boolean} True if valid, otherwise false.
   */
 function isValidApiKey(secret, timestamp) {
   if( _.isUndefined(secret) ) {
@@ -201,13 +244,13 @@ function isValidApiKey(secret, timestamp) {
 
   var now = Date.now(),
       diff = now - timestamp,
-      expiry = 5000, // Keys within this time (in ms) are acceptable 
+      expiry = 5000, // Keys within this time (in ms) are acceptable
       expected = generateApiSecret(timestamp);
 
   //  console.log(diff, expiry);
   if ( diff <= expiry ) {
     return (secret === expected);
-  }   
+  }
 
   return false;
 }


### PR DESCRIPTION
* To handle errors in the API calls use the requestHandler.js api file. 
* This is imported to all of the api calls as `utils`
* Current error handling looks like this `utils.sendError(new errors.InternalError(err.message), res);`
* Refactored error handling looks like this `utils.sendError.InternalError(req, res);`