### PR TITLE
Modify restoredb script

### DIFF
--- a/server/datasource/api/auth.js
+++ b/server/datasource/api/auth.js
@@ -44,7 +44,6 @@ function requireUser(req) {
 */
 function processToken(options) {
   function _processToken(req, res, next) {
-    console.log('inside processToken');
     if(!path.apiRequest(req)) {
       return next();
     }
@@ -74,7 +73,6 @@ function processToken(options) {
 */
 function fetchUser(options) {
   function _fetchUser(req, res, next) {
-    console.log('inside fetch user');
     if(!path.apiRequest(req)) {
       return next();
     }
@@ -125,7 +123,6 @@ function protect(options) {
     if(!path.apiRequest(req)) {
       return next();
     }
-    console.log('isapi:', path.apiRequest(req));
     _.defaults(req, { mf: { auth: {} } });
 
     var user = getUser(req);
@@ -133,7 +130,6 @@ function protect(options) {
     // /api/user - people need this to login; allows new users to see the user list
     // /api/stats - nagios checks this
     var openRequest = _.contains(openPaths, req.path);
-    console.log('isOpenRequest: ', req.path, ' : ', openRequest);
     if(openRequest && req.method === 'GET') {
       return next();
     }
@@ -141,8 +137,6 @@ function protect(options) {
 
     var notAuthn = !user;
     var notAuthz = !userAuthz;
-    console.log('isNotAuthenticated', notAuthn );
-    console.log('is not Authorized: ', notAuthz);
     if(notAuthn) {
       res.setHeader('www-authenticate', 'CasLogin');
       res.send(401);
@@ -150,7 +144,6 @@ function protect(options) {
     }
 
     if(notAuthz) {
-      console.log('not authorized in protected');
       res.send(403);
       //return next(false); //stop the chain
     }
@@ -172,7 +165,6 @@ function accessibleWorkspacesQuery(user) {
 function loadAccessibleWorkspaces(options) {
 
   function _loadAccessibleWorkspaces(req, res, next) {
-    console.log(`running loadAccessibleWorkspaces`);
     var user = getUser(req);
     var schema = path.getSchema(req);
     if(!user || !path.schemaHasWorkspace(schema)) {

--- a/server/datasource/api/cache.js
+++ b/server/datasource/api/cache.js
@@ -334,7 +334,6 @@ function cache(options) {
       headers: key
     };
 
-    console.log(params.uri);
     readUrl(params)
       .then(processResponse)
       .then(processJSON)

--- a/server/datasource/api/folderApi.js
+++ b/server/datasource/api/folderApi.js
@@ -120,8 +120,6 @@ function putFolder(req, res, next) {
 
   var user = auth.requireUser(req);
   models.Workspace.findOne({owner: user._id, folders: req.params.id}).lean().populate('owner').populate('editors').exec(function(err, ws){
-
-    console.log('USER: ', user, 'WS: ', ws);
     logger.warn("PUTTING FOLDER: " + JSON.stringify(req.body.folder) );
     if(permissions.userCan(user, ws, "FOLDERS")) {
       models.Folder.findById(req.params.id,

--- a/server/datasource/api/path.js
+++ b/server/datasource/api/path.js
@@ -41,11 +41,9 @@ function prep(options) {
 */
 function processPath(options) {
   function _processPath(req, res, next) {
-    console.log('in process path');
     if(!apiRequest(req)) {
       return next();
     }
-    console.log('path', req.path);
     _.defaults(req, { mf: {} });
     _.defaults(req.mf, { path: {} });
 
@@ -66,7 +64,6 @@ function processPath(options) {
 */
 function validateId(options) {
   function _validateId(req, res, next) {
-    console.log('inside validate Id', req.params);
     var match = idRequest(req);
     if(!match) {
       return next();
@@ -79,7 +76,6 @@ function validateId(options) {
       //TODO this is sending a 500 error although its a 4xx
       return utils.sendError.InvalidArgumentError('bad object id', res);
     }
-    console.log('calling next');
     return next();
 
   }
@@ -118,7 +114,6 @@ function schemaHasWorkspace(schema) {
 
 function validateContent(options) {
   function _validateContent(req, res, next) {
-    console.log('inside validateContent');
     var checkForModRequest = /POST|PUT/;
 
 

--- a/server/datasource/api/submissionApi.js
+++ b/server/datasource/api/submissionApi.js
@@ -98,7 +98,6 @@ function toPDSubmission(obj, index, arr) {
   * @throws {RestError} Something? went wrong
   */
 function getSubmissions(req, res, next) {
-  console.log('GETTING SUBMISSIONS getSubmissions');
   var criteria = utils.buildCriteria(req);
 
   logger.debug('Get Submission Criteria: ' + JSON.stringify(criteria) );

--- a/server/datasource/api/userApi.js
+++ b/server/datasource/api/userApi.js
@@ -87,7 +87,6 @@ function sendUsers(req, res, next) {
   * @throws {RestError} Something? went wrong
   */
 function sendUser(req, res, next) {
-  console.log('id',req.params.id);
   var user = auth.getUser(req);
   models.User.findById(req.params.id)
     .lean()
@@ -95,7 +94,6 @@ function sendUser(req, res, next) {
       if (err) {
         return utils.sendError.InternalError(err, res);
       }
-      console.log('after err if block', doc);
       var data = {'user': doc};
       delete data.user.key; //hide key
       delete data.user.history; // hide history
@@ -165,7 +163,6 @@ function putUser(req, res, next) {
           logger.error(err);
           return utils.sendError.InternalError(err, res);
         }
-        console.log('after err, ', doc);
         var data = {'user': doc};
         utils.sendResponse(res, data);
       });

--- a/server/datasource/api/workspaceApi.js
+++ b/server/datasource/api/workspaceApi.js
@@ -33,7 +33,6 @@ module.exports.put = {};
   * @todo This should really accept a node-style callback
   */
 function getWorkspace(id, callback) {
-  console.log('in getWorkspace', id);
   models.Workspace.findById(id)
     .populate('selections')
     .populate('submissions')
@@ -102,7 +101,6 @@ function getWorkspace(id, callback) {
   *       + Could be simpler. Needs refactoring
   */
 function getWorkspaceWithDependencies(id, callback) {
-  console.log('id in get ws with depends', id);
   models.Workspace.findById(id)
     .exec(
       function(err, workspace) {
@@ -150,7 +148,6 @@ function getWorkspaceWithDependencies(id, callback) {
 function sendWorkspace(req, res, next) {
 
   var user = auth.requireUser(req);
-  console.log('in sendWorkspace', user.username);
   models.Workspace.findById(req.params.id).lean().populate('owner').populate('editors').exec(function(err, ws){
     if(!permissions.userCanLoadWorkspace(user, ws)) {
       logger.info("permission denied");
@@ -430,8 +427,6 @@ function handleSubmissionSet(submissionSet, user, folderSetName) {
   // See prepareAndUpdateWorkspaces for what criteria we're looking at here
   for (var key in submissionSet.criteria) {
     if( submissionSet.criteria.hasOwnProperty(key) ) {
-      console.log('key: ', key);
-      console.log('key value: ', submissionSet.criteria[key]);
       var criterion = {};
       if (!_.isEmpty(submissionSet.criteria[key])) {
         criterion[prefix.concat(key)] = submissionSet.criteria[key];
@@ -444,7 +439,6 @@ function handleSubmissionSet(submissionSet, user, folderSetName) {
 //  criteria.$and.push({pdSet: submissionSet.description.pdSource}); //limit this to workspaces for the current user only
 
   // Looks for existing workspaces for this user for the submission set
-  console.log('CRITERIA', criteria);
   models.Workspace.find(criteria).exec(function(err, workspaces){
 
     if(err){
@@ -520,7 +514,6 @@ function prepareUserSubmissions(user, pdSet, folderSet, callback) {
     if(err) {logger.error(err); callback(err);}
 
     if(docs.length) {
-      console.log('docs[0]: ', docs[0]);
       logger.info('user: ' + user.username + ' already has ' + docs.length + ' pd submissions for ' + pdSet + ', not copying');
       logger.debug('... in workspaces ' + docs[0].get('workspaces'));
       callback();
@@ -820,7 +813,6 @@ function newWorkspaceRequest(req, res, next) {
   logger.info('in getWorkspaces');
   logger.debug('looking for workspaces for user id' + user._id);
   let criteria = utils.buildCriteria(req);
-  console.log('criteria getWses', criteria);
     models.Workspace.find(auth.accessibleWorkspacesQuery(user)).exec(function(err, workspaces) {
       var response = {
         workspaces: workspaces,

--- a/test/data/restore.js
+++ b/test/data/restore.js
@@ -35,9 +35,24 @@ const restoreDb = function (dbName, backupPath) {
 //   });
 // }
 
+const dropAndRestoreDb = function () {
+  return new Promise((resolve, reject) => {
+    exec(`mongorestore --db ${testDb} --drop ${pathToBackup}`, (err, stdout, stderr) => {
+      if (err) {
+        reject(err);
+      }
+      console.log('db drop results: ', stdout);
+      //console.log('db drop errors: ', stderr);
+      resolve('Dropped encompass_test database successfully!');
+    });
+  });
+};
+
+
 const prepTestDb = async function () {
   try {
-    let restored = await restoreDb(testDb, pathToBackup);
+    //let restored = await restoreDb(testDb, pathToBackup);
+    let restored = await dropAndRestoreDb();
     console.log(restored);
   } catch (err) {
     console.log(err);


### PR DESCRIPTION
Switch from useing childprocess.spawn to using childprocess.exec for the restoreAndDropDb script
No longer have to reference the path to the mongorestore command when using .exec

Remove various console.logs to declutter terminal

