### PR TITLE
Bug/privacy radio buttons

### DIFF
--- a/app/helpers/is-equal.js
+++ b/app/helpers/is-equal.js
@@ -1,6 +1,7 @@
 // is-equal helper is necessary to determine which option is currently selected.
 // app/helpers/is-equal.js
 
-Encompass.IsEqualHelper = Ember.Helper.helper( function(leftSide, rightSide){
+Encompass.IsEqualHelper = Ember.Helper.helper( function(args){
+  let [leftSide, rightSide] = args;
   return leftSide === rightSide;
 });

--- a/app/templates/components/problem-info.hbs
+++ b/app/templates/components/problem-info.hbs
@@ -20,19 +20,14 @@
               <label>Privacy Settings
                 <span class="required-star">*</span>
               </label>
-              {{!-- <input type="radio"  required="true" name="privacy" value="M" {{action "radioSelect"}}>
+              <input type="radio" checked={{is-equal privacySetting "M"}} required="true" name="privacy" value="M" onclick={{action "radioSelect" "M"}}>
               <label class="radio-label">Just Me</label>
-              <input type="radio"  required="true" name="privacy" value="O" {{action "radioSelect"}}>
+              <input type="radio" checked={{is-equal privacySetting "O"}} required="true" name="privacy" value="O" onclick={{action "radioSelect" "O"}}>
               <label class="radio-label">My Organization</label>
-              <input type="radio"  required="true" name="privacy" value="E" {{action "radioSelect"}}>
-              <label class="radio-label">Everyone</label> --}}
-
-              {{input type="radio" value=justMe required="true" name="privacy" click=(action "radioSelect" 'M')}}
-              <label class="radio-label">Just Me</label>
-              {{input type="radio" value=myOrg required="true" name="privacy" click=(action "radioSelect" 'O')}}
-              <label class="radio-label">My Organization</label>
-              {{input type="radio" value=everyone required="true" name="privacy" click=(action "radioSelect" 'E')}}
+              <input type="radio" checked={{is-equal privacySetting "E"}} required="true" name="privacy" value="E" onclick={{action "radioSelect" "E"}}>
               <label class="radio-label">Everyone</label>
+
+
             </li>
           </ol>
         </fieldset>

--- a/test/selenium/sections.js
+++ b/test/selenium/sections.js
@@ -1,5 +1,5 @@
 // REQUIRE MODULES
-const {Builder} = require('selenium-webdriver');
+const {Builder, until} = require('selenium-webdriver');
 const expect = require('chai').expect;
 const _ = require('underscore');
 

--- a/test/selenium/sections.js
+++ b/test/selenium/sections.js
@@ -69,10 +69,15 @@ describe('Sections', function () {
     }
 
     before(async function() {
-      await helpers.findAndClickElement(driver, css.topBar.sections);
-      await helpers.findAndClickElement(driver, '#newsection');
-      //await helpers.waitForSelector(driver, css.newSection.form);
-     });
+      try {
+        await helpers.findAndClickElement(driver, css.topBar.sections);
+        await helpers.findAndClickElement(driver, '#newsection');
+        await driver.wait(until.urlIs(`${host}/#/sections/new`), 5000);
+        await helpers.waitForSelector(driver, css.newSection.form);
+      }catch(err) {
+        console.log(err);
+      }
+    });
 
     describe('Verify form inputs', async function () {
       await verifyForm();

--- a/test/selenium/workspaces_new.js
+++ b/test/selenium/workspaces_new.js
@@ -17,11 +17,17 @@ describe('Visiting Workspace Creation', function() {
     driver = new Builder()
       .forBrowser('chrome')
       .build();
-      await dbSetup.prepTestDb();
-      await helpers.login(driver, host);
-      await helpers.findAndClickElement(driver, css.topBar.workspaces);
-      await helpers.findAndClickElement(driver, '#new-workspace-link');
-      await helpers.waitForSelector(driver,'#create-workspace-btn');
+      try {
+        await dbSetup.prepTestDb();
+        await helpers.login(driver, host);
+        await helpers.findAndClickElement(driver, css.topBar.workspaces);
+        await helpers.findAndClickElement(driver, '#new-workspace-link');
+        await driver.wait(until.urlIs(`${host}/#/workspaces/new`), 5000);
+        await helpers.waitForSelector(driver,'#create-workspace-btn');
+      }catch(err) {
+        console.log(err);
+      }
+
     });
 
   after(() => {


### PR DESCRIPTION
Fix is-equal helper (helpers pass in args as a single array argument)

Use is-equal helper to have the correct privacy setting radio button be checked when edit problem form initially loads.

Implement a potential fix for the flakiness of selenium tests with travis - wait for the current url to be workspaces/new and sections/new before verifying the forms. May have to update other tests to follow the same protocol.