### PR TITLE
Filter comment list and various bug fixes

### DIFF
--- a/app/components/comment-list.js
+++ b/app/components/comment-list.js
@@ -49,29 +49,36 @@ Encompass.CommentListComponent = Ember.Component.extend(Encompass.CurrentUserMix
     }
 
     if (this.thisSubmissionOnly) {
-      // let newComments = [];
-      // filtered.forEach((comment) => {
-      //   let commentSubId = comment.get('submission').get('id');
-      //   let currentSubmissionId = this.get('currentSubmission').get('id');
-      //   if (commentSubId === currentSubmissionId) {
-      //     newComments.push(comment);
-      //   }
-      // });
-      // console.log('new comments are', newComments);
-      // return newComments;
       filtered = filtered.filterBy('submission.id', this.get('currentSubmission.id'));
     }
 
-    if(this.filterComments){
-      //change this to query the comments vs filter what is viewable?
-      var regexp = new RegExp(this.commentFilterText, "i");
-      filtered = filtered.filter( function(comment){
-        //item.get('url').match(regExp);
-        return regexp.test( comment.get('text') );
-      });
-    }
     return filtered.sortBy('createDate').reverse();
   }.property('comments.@each.isTrashed', 'thisSubmissionOnly', 'myCommentsOnly', 'filterComments', 'commentFilterText', 'currentSubmission.id'),
+
+  commentSearchResults: function() {
+    if (!this.get('isSearching')) {
+      return;
+    }
+    let searchText = this.get('commentFilterText');
+    if (searchText.length < 1) {
+      return [];
+    }
+    this.set('isLoadingSearchResults', true);
+    return this.get('store').query('comment', {
+      text: searchText
+    }).then((comments) => {
+      this.set('searchResults', comments);
+      this.set('isLoadingSearchResults', false);
+    });
+  }.observes('commentFilterText'),
+
+  displayList: function() {
+    if (this.get('isSearching')) {
+      return this.get('searchResults');
+    }
+
+    return this.get('filteredComments');
+  }.property('isSearching', 'searchResults.[]', 'filteredComments.[]'),
 
   clearCommentParent: function() {
     if(this.get('newCommentParent')) {

--- a/app/components/comment-list.js
+++ b/app/components/comment-list.js
@@ -49,16 +49,17 @@ Encompass.CommentListComponent = Ember.Component.extend(Encompass.CurrentUserMix
     }
 
     if (this.thisSubmissionOnly) {
-      let newComments = [];
-      filtered.forEach((comment) => {
-        let commentSubId = comment.get('submission').get('id');
-        let currentSubmissionId = this.get('currentSubmission').get('id');
-        if (commentSubId === currentSubmissionId) {
-          newComments.push(comment);
-        }
-      });
-      console.log('new comments are', newComments);
-      return newComments;
+      // let newComments = [];
+      // filtered.forEach((comment) => {
+      //   let commentSubId = comment.get('submission').get('id');
+      //   let currentSubmissionId = this.get('currentSubmission').get('id');
+      //   if (commentSubId === currentSubmissionId) {
+      //     newComments.push(comment);
+      //   }
+      // });
+      // console.log('new comments are', newComments);
+      // return newComments;
+      filtered = filtered.filterBy('submission.id', this.get('currentSubmission.id'));
     }
 
     if(this.filterComments){
@@ -70,7 +71,7 @@ Encompass.CommentListComponent = Ember.Component.extend(Encompass.CurrentUserMix
       });
     }
     return filtered.sortBy('createDate').reverse();
-  }.property('comments.[]', 'comments.@each.isTrashed', 'thisSubmissionOnly', 'myCommentsOnly', 'filterComments', 'commentFilterText'),
+  }.property('comments.@each.isTrashed', 'thisSubmissionOnly', 'myCommentsOnly', 'filterComments', 'commentFilterText', 'currentSubmission.id'),
 
   clearCommentParent: function() {
     if(this.get('newCommentParent')) {

--- a/app/components/comment-list.js
+++ b/app/components/comment-list.js
@@ -33,6 +33,17 @@ Encompass.CommentListComponent = Ember.Component.extend(Encompass.CurrentUserMix
     }
   },
 
+  init: function() {
+    this._super(...arguments);
+    const htmlFormat = 'YYYY-MM-DD';
+
+    let oneYearAgo = moment().subtract(365, 'days').calendar();
+    let oneYearAgoDate = new Date(oneYearAgo);
+    let htmlDate = moment(oneYearAgoDate).format(htmlFormat);
+
+    this.set('sinceDate', htmlDate);
+  },
+
   newCommentPlaceholder: function() {
     var placeholder = this.labels[this.get('newCommentLabel')].placeholder;
     if(_.isArray(placeholder)) {
@@ -60,17 +71,19 @@ Encompass.CommentListComponent = Ember.Component.extend(Encompass.CurrentUserMix
       return;
     }
     let searchText = this.get('commentFilterText');
-    if (searchText.length < 1) {
+    if (searchText.length < 5) {
       return [];
     }
     this.set('isLoadingSearchResults', true);
     return this.get('store').query('comment', {
-      text: searchText
+      text: searchText,
+      myCommentsOnly: this.get('myCommentsOnly'),
+      since: this.get('sinceDate')
     }).then((comments) => {
       this.set('searchResults', comments);
       this.set('isLoadingSearchResults', false);
     });
-  }.observes('commentFilterText'),
+  }.observes('commentFilterText', 'myCommentsOnly', 'sinceDate'),
 
   displayList: function() {
     if (this.get('isSearching')) {
@@ -206,6 +219,17 @@ Encompass.CommentListComponent = Ember.Component.extend(Encompass.CurrentUserMix
 
     toggleFilter: function() {
       this.toggleProperty('showFilter');
+      if (this.get('showFilter') && this.get('isSearching')) {
+        this.set('isSearching', false);
+      }
+    },
+
+    toggleSearch: function() {
+      this.toggleProperty('isSearching');
+
+      if (this.get('isSearching') && this.get('showFilter')) {
+        this.set('showFilter', false);
+      }
     }
   }
 });

--- a/app/components/folder-elem.js
+++ b/app/components/folder-elem.js
@@ -22,8 +22,12 @@ Encompass.FolderElemComponent = Ember.Component.extend(Encompass.DragNDrop.Dropp
   //editFolderMode: true, // (from folder controller)
 
   containsCurrentSubmission: function(){
-    return this.model.get('submissions').includes(this.get('currentSubmission'));
-  }.property('submissions.[].id', 'currentSubmission'),
+    const submissions = this.model.get('submissions');
+    const currentSubmission = this.get('currentSubmission');
+
+    const filtered = submissions.filterBy('id', currentSubmission.id);
+    return !Ember.isEmpty(filtered);
+  }.property('model.submissions.[]', 'currentSubmission.id'),
 
   /* Drag and drop stuff */
   supportedTypes: {

--- a/app/components/folder-elem.js
+++ b/app/components/folder-elem.js
@@ -23,24 +23,28 @@ Encompass.FolderElemComponent = Ember.Component.extend(Encompass.DragNDrop.Dropp
 
   containsCurrentSubmission: function(){
     const submissions = this.model.get('submissions');
-    if (Ember.isEmpty(submissions)) {
-      return false;
-    }
     const currentSubmission = this.get('currentSubmission');
 
+    if (Ember.isEmpty(submissions) || Ember.isEmpty(currentSubmission)) {
+      return false;
+    }
+
     const filtered = submissions.filterBy('id', currentSubmission.id);
+
     return !Ember.isEmpty(filtered);
   }.property('model.submissions.[]', 'currentSubmission.id'),
 
   containsCurrentSelection: function() {
     const selections = this.model.get('taggings').mapBy('selection');
-    if (Ember.isEmpty(selections)) {
+    const currentSelection = this.get('currentSelection');
+
+    if (Ember.isEmpty(selections) || Ember.isEmpty(currentSelection)) {
       return false;
     }
-    const currentSelection = this.get('currentSelection');
-    const filtered = selections.filterBy('id', currentSelection.id);
-    return !Ember.isEmpty(filtered);
 
+    const filtered = selections.filterBy('id', currentSelection.id);
+
+    return !Ember.isEmpty(filtered);
   }.property('currentSelection.id', 'model.selections.@each.isTrashed'),
 
   /* Drag and drop stuff */

--- a/app/components/folder-elem.js
+++ b/app/components/folder-elem.js
@@ -23,11 +23,25 @@ Encompass.FolderElemComponent = Ember.Component.extend(Encompass.DragNDrop.Dropp
 
   containsCurrentSubmission: function(){
     const submissions = this.model.get('submissions');
+    if (Ember.isEmpty(submissions)) {
+      return false;
+    }
     const currentSubmission = this.get('currentSubmission');
 
     const filtered = submissions.filterBy('id', currentSubmission.id);
     return !Ember.isEmpty(filtered);
   }.property('model.submissions.[]', 'currentSubmission.id'),
+
+  containsCurrentSelection: function() {
+    const selections = this.model.get('taggings').mapBy('selection');
+    if (Ember.isEmpty(selections)) {
+      return false;
+    }
+    const currentSelection = this.get('currentSelection');
+    const filtered = selections.filterBy('id', currentSelection.id);
+    return !Ember.isEmpty(filtered);
+
+  }.property('currentSelection.id', 'model.selections.@each.isTrashed'),
 
   /* Drag and drop stuff */
   supportedTypes: {

--- a/app/components/image-upload.js
+++ b/app/components/image-upload.js
@@ -75,15 +75,22 @@ Encompass.ImageUploadComponent = Ember.Component.extend(Encompass.CurrentUserMix
           if (pdfCount > 0) {
             return this.uploadPdf(currentUser, pdfFormData).then((res) => {
               console.log('res pdf', res);
-              let results = this.get('uploadedPdfs').concat(this.get('uploadedImages'));
-              this.set('uploadResults', results);
+              let results;
+              if (this.get('uploadedPdfs') && this.get('uploadedImages')) {
+                results = this.get('uploadedPdfs').concat(this.get('uploadedImages'));
+                this.set('uploadResults', results);
+              }
+
             })
             .catch(console.log);
+          } else {
+            this.set('uploadResults', this.get('uploadedImages'));
           }
         });
       } else if (pdfCount > 0) {
         return this.uploadPdf(currentUser, pdfFormData).then((res) => {
           console.log('res', res);
+          this.set('uploadResults', this.get('uploadedPdfs'));
         })
         .catch(console.log);
       }

--- a/app/components/workspace-comment.js
+++ b/app/components/workspace-comment.js
@@ -9,7 +9,7 @@ Encompass.WorkspaceCommentComponent = Ember.Component.extend(Encompass.CurrentUs
 
   isForCurrentWorkspace: function() {
     return Ember.isEqual(this.get('currentWorkspace.id'), this.comment.get('workspace.id'));
-  }.property('currentWorkspace', 'comment.workspace'),
+  }.property('currentWorkspace.id', 'comment.workspace.id'),
 
   relevanceClass: function(){
     return 'relevance-' + this.get('comment.relevance');

--- a/app/templates/components/comment-list.hbs
+++ b/app/templates/components/comment-list.hbs
@@ -50,8 +50,8 @@
 {{#if showFilter}}
   <div class="filter">
     <p>
-    <label>{{input type="checkbox" checked=filterComments}} filter comments</label>
-    {{#if filterComments}}
+    <label>{{input type="checkbox" checked=isSearching}} Search all comments</label>
+    {{#if isSearching}}
       {{input type="text" value=commentFilterText placeholder="keyword/phrase" classNames="noborder nopadding"}}
     {{/if}}
     </p>
@@ -66,12 +66,18 @@
 <div>
 	<form>
 		<div id="al_feedback_display" class="al_vertical_stretch">
-			<ul>
-				{{#each this.filteredComments as |comment|}}
+			{{#if isLoadingSearchResults}}
+        Searching for comments. Thank you for your patience.
+      {{else}}
+      <ul>
+				{{#each displayList as |comment|}}
           {{workspace-comment comment=comment currentWorkspace=currentWorkspace reuseComment=(action "reuseComment") deleteComment=(action "deleteComment")}}
           {{!partial "../comments/comment"}}
+          {{else}}
+          <p>No comments made yet.</p>
 				{{/each}}
 			</ul>
+      {{/if}}
 		</div>
 	</form>
 	<!--div class="al_general" title="Enable to add feedback unassociated with a selection">

--- a/app/templates/components/comment-list.hbs
+++ b/app/templates/components/comment-list.hbs
@@ -68,7 +68,7 @@
 		<div id="al_feedback_display" class="al_vertical_stretch">
 			<ul>
 				{{#each this.filteredComments as |comment|}}
-          {{workspace-comment comment=comment currentWorspace=currentWorkspace reuseComment=(action "reuseComment") deleteComment=(action "deleteComment")}}
+          {{workspace-comment comment=comment currentWorkspace=currentWorkspace reuseComment=(action "reuseComment") deleteComment=(action "deleteComment")}}
           {{!partial "../comments/comment"}}
 				{{/each}}
 			</ul>

--- a/app/templates/components/comment-list.hbs
+++ b/app/templates/components/comment-list.hbs
@@ -18,6 +18,9 @@
       <a {{action 'toggleFilter'}}>
         <i class="fas fa-filter"></i> filter
       </a>
+      <a {{action 'toggleSearch'}}>
+        <i class="fas fa-search"></i> search
+      </a>
     </div>
 		<div class="al_controller">
       {{#if canComment}}
@@ -49,16 +52,37 @@
 
 {{#if showFilter}}
   <div class="filter">
-    <p>
+    {{!-- <p>
     <label>{{input type="checkbox" checked=isSearching}} Search all comments</label>
     {{#if isSearching}}
       {{input type="text" value=commentFilterText placeholder="keyword/phrase" classNames="noborder nopadding"}}
     {{/if}}
-    </p>
+    </p> --}}
     <p>
     {{!-- <label>{{input type="checkbox" checked=thisWorkspaceOnly}} this workspace only</label> --}}
     <label>{{input type="checkbox" checked=thisSubmissionOnly}} this submission only</label>
     <label>{{input type="checkbox" checked=myCommentsOnly}} my comments only</label>
+    </p>
+  </div>
+{{/if}}
+
+{{#if isSearching}}
+  <div class="search">
+    <p>
+      <label>Search comments</label>
+      {{input type="text" value=commentFilterText placeholder="keyword/phrase" classNames="noborder nopadding"}}
+
+
+    </p>
+    <p>
+    {{!-- <label>{{input type="checkbox" checked=thisWorkspaceOnly}} this workspace only</label> --}}
+    {{!-- <label>{{input type="checkbox" checked=thisSubmissionOnly}} this submission only</label> --}}
+    <label>{{input type="checkbox" checked=myCommentsOnly}} my comments only</label>
+
+    </p>
+    <p>
+      <label>Since</label>
+    {{input type="date" id="sinceDate" value=sinceDate classNames ="noborder no padding"}}
     </p>
   </div>
 {{/if}}

--- a/app/templates/components/folder-list.hbs
+++ b/app/templates/components/folder-list.hbs
@@ -4,7 +4,7 @@
   <div class="dropZone" style="height:10px;"></div>
   <ul id="al_folders">
     {{#each this.sortedFolders as |folder|}}
-      {{folder-elem model=folder currentWorkspace=workspace folderList=this editFolderMode=editFolderMode dropped=(action "fileSelectionInFolder") confirm="askToDelete" currentSubmission=currentSubmission }}
+      {{folder-elem model=folder currentWorkspace=workspace folderList=this editFolderMode=editFolderMode dropped=(action "fileSelectionInFolder") confirm="askToDelete" currentSubmission=currentSubmission currentSelection=currentSelection }}
     {{/each}}
   </ul>
   <div class="dropZone" style="height:10px;"></div>

--- a/app/templates/components/folder-list.hbs
+++ b/app/templates/components/folder-list.hbs
@@ -4,7 +4,7 @@
   <div class="dropZone" style="height:10px;"></div>
   <ul id="al_folders">
     {{#each this.sortedFolders as |folder|}}
-      {{folder-elem model=folder currentWorkspace=workspace folderList=this editFolderMode=editFolderMode dropped=(action "fileSelectionInFolder") confirm="askToDelete" }}
+      {{folder-elem model=folder currentWorkspace=workspace folderList=this editFolderMode=editFolderMode dropped=(action "fileSelectionInFolder") confirm="askToDelete" currentSubmission=currentSubmission }}
     {{/each}}
   </ul>
   <div class="dropZone" style="height:10px;"></div>

--- a/app/templates/components/workspace-comment.hbs
+++ b/app/templates/components/workspace-comment.hbs
@@ -1,7 +1,7 @@
     {{#if permittedToComment}}
-      <a 
-          {{! action (action reuseComment comment)}} 
-          {{action reuseComment comment}} 
+      <a
+          {{! action (action reuseComment comment)}}
+          {{action reuseComment comment}}
           title="reuse ths comment">
         {{#if comment.children.length}}
           {{comment.children.length}}
@@ -15,11 +15,11 @@
     {{/if}}
   	<p>
       {{#if isForCurrentWorkspace}}
-        {{#link-to 'workspace.submission.selection' selection.submission selection classNames="comment"}}
+        {{#link-to 'workspace.submission.selection' comment.selection.submission comment.selection classNames="comment"}}
           {{comment.text}}
         {{/link-to}}
       {{else}}
-      <a class="newWindow" target="_blank" href="{{selection.link}}">{{comment.text}}</a>
+      <a class="newWindow" target="_blank" href="{{comment.selection.link}}">{{comment.text}}</a>
       {{/if}}
     </p>
       <p class="meta">

--- a/app/templates/workspace/submission.hbs
+++ b/app/templates/workspace/submission.hbs
@@ -15,7 +15,7 @@
 
 <div id="al_left">
   {{! outlet folders}}
-  {{folder-list folders=currentWorkspace.folders workspace=currentWorkspace currentUser=currentUser fileSelection="fileSelectionInFolder" currentSubmission=currentSubmission store=store }}
+  {{folder-list folders=currentWorkspace.folders workspace=currentWorkspace currentUser=currentUser fileSelection="fileSelectionInFolder" currentSubmission=currentSubmission currentSelection=currentSelection store=store }}
 </div>
 
 <!--section class="submissions"-->

--- a/app/templates/workspace/submission.hbs
+++ b/app/templates/workspace/submission.hbs
@@ -15,7 +15,7 @@
 
 <div id="al_left">
   {{! outlet folders}}
-  {{folder-list folders=currentWorkspace.folders workspace=currentWorkspace currentUser=currentUser fileSelection="fileSelectionInFolder" store=store }}
+  {{folder-list folders=currentWorkspace.folders workspace=currentWorkspace currentUser=currentUser fileSelection="fileSelectionInFolder" currentSubmission=currentSubmission store=store }}
 </div>
 
 <!--section class="submissions"-->

--- a/dependencies/image-tagging.js
+++ b/dependencies/image-tagging.js
@@ -107,7 +107,7 @@ NoteInput = function() {
     charCode = parseInt(charCode, 10);
 
     if (charCode === ENTER) {
-      _stopEditing();
+      _stopEditing(event);
     }
 
     return false;
@@ -849,7 +849,9 @@ NoteInput = function() {
     var tmpId = _currentlyEditing,
       tagListItem,
       note;
-    event = event || window.event;
+      // window.event tends to be undefined in firefox
+      // is this line necessary if we are always passing in event?
+      event = event || window.event;
 
     if (event.target.id !== _tagIdPrefix + tmpId) {
       if (_currentlyResizingOrPlacing) {

--- a/server/datasource/api/commentApi.js
+++ b/server/datasource/api/commentApi.js
@@ -38,13 +38,13 @@ async function getComments(req, res, next) {
 
   var textSearch = req.query.text;
 
-  // for now only letting users search within comments they created
-  // since admins can technically access any comment, they would be
-  // getting way too many comments back if we just used the accessible comments
+  // Determine what comments can be searched
   if(textSearch) {
+    console.log('textSearch', textSearch);
     var regExp = new RegExp(textSearch, 'i');
+    console.log('regExp', regExp);
     criteria.text = regExp;
-    criteria.createdBy = user._id
+    //criteria.createdBy = user._id
   }
 
   // Are these ever being used?

--- a/server/datasource/api/commentApi.js
+++ b/server/datasource/api/commentApi.js
@@ -40,17 +40,19 @@ async function getComments(req, res, next) {
 
   // Determine what comments can be searched
   if(textSearch) {
-    console.log('textSearch', textSearch);
     var regExp = new RegExp(textSearch, 'i');
-    console.log('regExp', regExp);
     criteria.text = regExp;
-    //criteria.createdBy = user._id
   }
 
-  // Are these ever being used?
   var myCommentsOnly = (req.query.myCommentsOnly === 'true');
   if(myCommentsOnly) {
-    criteria.$and.push({createdBy: user});
+    criteria.createdBy = user._id;
+  }
+
+  var sinceDate = req.query.since;
+  if (sinceDate) {
+    let isoDate = new Date(sinceDate);
+    criteria.createDate = {$gte: isoDate};
   }
 
   var workspaces = req.query.workspaces;

--- a/server/datasource/api/folderApi.js
+++ b/server/datasource/api/folderApi.js
@@ -118,7 +118,7 @@ function postFolder(req, res, next) {
 function putFolder(req, res, next) {
 
   var user = userAuth.requireUser(req);
-  models.Workspace.findOne({owner: user._id, folders: req.params.id}).lean().populate('owner').populate('editors').exec(function(err, ws){
+  models.Workspace.findOne({folders: req.params.id}).lean().populate('owner').populate('editors').exec(function(err, ws){
     logger.warn("PUTTING FOLDER: " + JSON.stringify(req.body.folder) );
     if(wsAccess.canModify(user, ws)) {
       models.Folder.findById(req.params.id,

--- a/server/datasource/api/workspaceApi.js
+++ b/server/datasource/api/workspaceApi.js
@@ -4,6 +4,8 @@
   * @authors Damola Mabogunje <damola@mathforum.org>, Amir Tahvildaran <amir@mathforum.org>
   * @since 1.0.0
   */
+
+  /*jshint ignore:start*/
 //REQUIRE MODULES
 const mongoose = require('mongoose');
 const logger = require('log4js').getLogger('server');
@@ -826,12 +828,13 @@ function newWorkspaceRequest(req, res, next) {
   * @returns {Object} A 'named' array of workspace objects by creator
   * @throws {RestError} Something? went wrong
   */
- function getWorkspaces(req, res, next) {
+ async function getWorkspaces(req, res, next) {
   var user = userAuth.requireUser(req);
   logger.info('in getWorkspaces');
   logger.debug('looking for workspaces for user id' + user._id);
-  let criteria = utils.buildCriteria(req);
-    models.Workspace.find(userAuth.accessibleWorkspacesQuery(user)).exec(function(err, workspaces) {
+  let criteria = await access.get.workspaces(user);
+  console.log('criteria for get wses', criteria);
+    models.Workspace.find(criteria).exec(function(err, workspaces) {
       var response = {
         workspaces: workspaces,
         meta: { sinceToken: new Date() }
@@ -846,7 +849,6 @@ function newWorkspaceRequest(req, res, next) {
     });
 
 }
-/*jshint ignore:start*/
 
 function pruneObj(obj) {
 
@@ -1077,7 +1079,7 @@ return utils.sendResponse(res,  data );
 }
 
 module.exports.post.workspaceEnc = postWorkspaceEnc;
-/*jshint ignore:end*/
+
 module.exports.get.workspace = sendWorkspace;
 module.exports.get.workspaces = getWorkspaces;
 module.exports.put.workspace = putWorkspace;
@@ -1085,3 +1087,4 @@ module.exports.post.workspace = postWorkspace;
 module.exports.post.newWorkspaceRequest = newWorkspaceRequest;
 module.exports.packageSubmissions = packageSubmissions;
 module.exports.nameWorkspace = nameWorkspace;
+/*jshint ignore:end*/

--- a/server/middleware/access/comments.js
+++ b/server/middleware/access/comments.js
@@ -1,0 +1,73 @@
+const utils = require('./utils');
+const wsAccess = require('./workspaces');
+
+module.exports.get = {};
+
+const accessibleCommentsQuery = async function(user, ids) {
+  try {
+    const accountType = user.accountType;
+    const actingRole = user.actingRole;
+
+    let filter = {
+      isTrashed: false,
+    };
+
+    if (ids) {
+      filter._id = {$in : ids};
+    }
+
+
+    // should students ever be getting comments?
+    if (actingRole === 'student' || accountType === 'S') {
+      filter.createdBy = user._id;
+      return filter;
+    }
+    // will only reach here if admins/pdadmins are in actingRole teacher
+
+    if (accountType === 'A') {
+      return filter;
+    }
+
+    const accessibleWorkspaceIds = await utils.getAccessibleWorkspaceIds(user);
+    console.log('accessible ws ids in get comments', accessibleWorkspaceIds);
+
+
+    // everyone should have access to all comments that belong to a workspace that they have access to
+    filter.$or = [];
+    filter.$or.push({workspace : { $in: accessibleWorkspaceIds} });
+
+    //should have access to all comments that you created
+    // in case they are not in a workspace
+
+    if (accountType === 'P') {
+      // PDamins can get any comments created by someone from their organization
+      const userOrg = user.organization;
+
+      //const userIds = await getOrgUsers(userOrg);
+      const userIds = await utils.getModelIds('User', {organization: userOrg});
+
+      userIds.push(user_.id);
+
+      filter.$or.push({createdBy : {$in : userIds}});
+      return filter;
+    }
+
+    if (accountType === 'T') {
+    // teachers can get any comments where they are the primary teacher or in the teachers array
+    // should teachers be able to get all comments from organization?
+
+
+      filter.$or.push({ createdBy : user._id });
+      // filter.$or.push({ 'teacher.id': user.id });
+      // filter.$or.push({ teachers : user.id });
+
+      return filter;
+    }
+
+  }catch(err) {
+    console.trace();
+    console.error(`error building accessible comments critera: ${err}`);
+  }
+};
+
+module.exports.get.comments = accessibleCommentsQuery;

--- a/server/middleware/access/submissions.js
+++ b/server/middleware/access/submissions.js
@@ -9,7 +9,7 @@ const accessibleSubmissionsQuery = async function(user, ids) {
     const actingRole = user.actingRole;
 
     let filter = {
-      isTrashed: false
+      isTrashed: { $ne: true }
     };
 
     if (ids) {
@@ -28,10 +28,12 @@ const accessibleSubmissionsQuery = async function(user, ids) {
     // will only reach here if admins/pdadmins are in actingRole teacher
 
     if (accountType === 'A') {
+      console.log('admin filter get subs', filter);
       return filter;
     }
 
     const accessibleWorkspaceIds = await utils.getAccessibleWorkspaceIds(user);
+    console.log('accessible ws ids in get subs', accessibleWorkspaceIds);
 
 
     // everyone should have access to all submissions that belong to a workspace that they have access to

--- a/server/middleware/access/workspaces.js
+++ b/server/middleware/access/workspaces.js
@@ -108,7 +108,7 @@ function canModify(user, ws) {
     return false;
   }
   var isAdmin = user.accountType === 'A';
-  var isOwner = user.id === ws._id.toString();
+  var isOwner = user.id === ws.owner._id.toString();
   var editorIds = ws.editors.map(obj => obj._id.toString());
 
   var isEditor = _.includes(editorIds, user.id);

--- a/server/middleware/passport.js
+++ b/server/middleware/passport.js
@@ -179,6 +179,7 @@ module.exports = (passport) => {
                     createdBy,
                     authorizedBy,
                     isEmailConfirmed,
+                    actingRole: 'teacher'
                   });
                   console.log('newUSer', newUser);
 

--- a/test/selenium/comments.js
+++ b/test/selenium/comments.js
@@ -60,7 +60,7 @@ describe('Comments', function() {
       let text;
       let newComment;
       try{
-        let paragraphs = await helpers.getWebElements(driver, 'li.notice>p>a.newWindow');
+        let paragraphs = await helpers.getWebElements(driver, 'li.notice>p>a');
         if (!_.isEmpty(paragraphs)) {
           newComment = paragraphs[paragraphs.length - 1];
           text = await newComment.getText();


### PR DESCRIPTION
Separate search comments feature from filter comments feature
Searching comments defaults to only your comments within the last year, but these options can be modified.

Fix containsCurrentSubmission calculation for folders (folder now is highlighted), and add containsCurrentSelection property(folder is highlighted) 

Fix bug in image upload when importing only pdfs or only images

Fix firefox bug when saving imageTag with enter key

Workspace api now uses accessibleWorkspaces instead of the old buildCriteria - admins are now receiving a huge amount of workspaces. We might want to change this.