### PR TITLE
Workspace

### DIFF
--- a/app/components/import-work.js
+++ b/app/components/import-work.js
@@ -268,11 +268,8 @@ Encompass.ImportWorkComponent = Ember.Component.extend(Encompass.CurrentUserMixi
             // if workspace created
             if (res.workspaceId) {
               that.set('createdWorkspace', res);
-            // should we redirect to workspaces list or workspace page?
-            console.log('sending Action');
-            that.sendAction('toWorkspaces');
+              that.sendAction('toWorkspaces', res);
             }
-
           })
           .catch((err) => {
             that.set('uploadError', err);

--- a/app/components/import-work.js
+++ b/app/components/import-work.js
@@ -177,13 +177,11 @@ Encompass.ImportWorkComponent = Ember.Component.extend(Encompass.CurrentUserMixi
     },
 
     reviewSubmissions: function() {
-      console.log('reviewing submissions');
       this.set('isMatchingStudents', false);
       this.set('isReviewingSubmissions', true);
     },
 
     uploadAnswers: function() {
-      console.log('uploading Answers');
       this.set('isUploadingAnswer', true);
       let answers = this.get('answers');
       const that = this;
@@ -232,7 +230,6 @@ Encompass.ImportWorkComponent = Ember.Component.extend(Encompass.CurrentUserMixi
 
 
             teacher.id = primaryTeacher.get('userId');
-            console.log('ans.id', ans.id);
             let sub = {
               // longAnswer: ans.get('explanation'),
               answer: ans.id,
@@ -258,7 +255,6 @@ Encompass.ImportWorkComponent = Ember.Component.extend(Encompass.CurrentUserMixi
             "requestedName": JSON.stringify(this.get('requestedName')),
             "folderSet": JSON.stringify(folderSetName)
           };
-          console.log('subs', subs);
            Ember.$.post({
             url: 'api/import',
             data: postData

--- a/app/components/my-select.js
+++ b/app/components/my-select.js
@@ -19,7 +19,6 @@ Encompass.MySelectComponent = Ember.Component.extend({
       var changeAction = this.get('action');
       var selectedEl = this.$('select')[0];
       var prompt = this.$('#select-prompt');
-      console.log('prompt is', prompt);
       var selectedIndex;
 
       if (prompt.length > 0) {
@@ -29,10 +28,7 @@ Encompass.MySelectComponent = Ember.Component.extend({
       }
 
       var content = this.get('content');
-      console.log('slectedindex', selectedIndex);
-      console.log('length', content.length);
       var selectedValue = content.objectAt(selectedIndex);
-      console.log('selectedValue', selectedValue);
       this.set('selectedValue', selectedValue);
       changeAction(selectedValue);
     }

--- a/app/components/workspace-info.js
+++ b/app/components/workspace-info.js
@@ -6,7 +6,7 @@ Encompass.WorkspaceInfoComponent = Ember.Component.extend(Encompass.CurrentUserM
   searchText: "",
 
 
-  searchResults: function () {
+  setSearchResults: function () {
     var searchText = this.get('searchText');
     console.log('search text is', searchText);
     searchText = searchText.replace(/\W+/g, "");
@@ -14,11 +14,13 @@ Encompass.WorkspaceInfoComponent = Ember.Component.extend(Encompass.CurrentUserM
       return;
     }
 
-    let people = this.get('store').query('user', {
+    this.get('store').query('user', {
       username: searchText,
+    }).then((people) => {
+      this.set('editorSearchResults', people.rejectBy('accountType', 'S'));
     });
-    return people;
-  }.property('searchText'),
+  }.observes('searchText'),
+
 
   canEdit: Ember.computed('workspace.id', function () {
     let workspace = this.get('workspace');

--- a/app/components/workspace-info.js
+++ b/app/components/workspace-info.js
@@ -4,7 +4,6 @@ Encompass.WorkspaceInfoComponent = Ember.Component.extend(Encompass.CurrentUserM
   isEditing: false,
   selectedMode: null,
   searchText: "",
-  isDirty: false,
 
   setSearchResults: function () {
     var searchText = this.get('searchText');
@@ -58,7 +57,6 @@ Encompass.WorkspaceInfoComponent = Ember.Component.extend(Encompass.CurrentUserM
     saveWorkspace: function () {
       // this.actions.changeMode.call(this);
       this.set('isEditing', false);
-      this.set('isDirty', true);
       var mode = this.get('selectedMode');
       console.log('selected mode is', mode);
       var workspace = this.get('workspace');

--- a/app/components/workspace-info.js
+++ b/app/components/workspace-info.js
@@ -4,7 +4,7 @@ Encompass.WorkspaceInfoComponent = Ember.Component.extend(Encompass.CurrentUserM
   isEditing: false,
   selectedMode: null,
   searchText: "",
-
+  isDirty: false,
 
   setSearchResults: function () {
     var searchText = this.get('searchText');
@@ -57,12 +57,14 @@ Encompass.WorkspaceInfoComponent = Ember.Component.extend(Encompass.CurrentUserM
 
     saveWorkspace: function () {
       // this.actions.changeMode.call(this);
+      this.set('isEditing', false);
+      this.set('isDirty', true);
       var mode = this.get('selectedMode');
       console.log('selected mode is', mode);
       var workspace = this.get('workspace');
       workspace.set('mode', mode);
       workspace.save();
-      this.set('isEditing', false);
+
     }
   }
 

--- a/app/components/workspace-new-enc.js
+++ b/app/components/workspace-new-enc.js
@@ -33,10 +33,10 @@ Encompass.WorkspaceNewEncComponent = Ember.Component.extend(Encompass.CurrentUse
       return [currentUser];
     }
 
-    const teachers = this.userList.rejectBy('accountType', 'S');
+    const users = this.get('userList').rejectBy('accountType', 'S');
 
     if (accountType === 'P') {
-      let yourUsers = this.userList;
+      let yourUsers = this.get('userList');
       let yourUserList = [];
 
       yourUsers.forEach((user) => {
@@ -45,21 +45,14 @@ Encompass.WorkspaceNewEncComponent = Ember.Component.extend(Encompass.CurrentUse
         let userOrg = user.get('organization').get('id');
         let isAuth = user.get('isAuthorized');
 
-        if (yourOrg === userOrg && userType !== 'S' && isAuth) {
+        if (yourOrg === userOrg && userType === 'T' && isAuth) {
           yourUserList.push(user);
         }
       });
       return yourUserList;
-
-      //This needs to be fixed because i dont think its getting the users!
-
-      // let teacher = orgUsers.filterBy('organization', currentUser.get('organization'));
-      // console.log('orgUsers', orgUsers);
-      // console.log('teachers', teacher);
-      // return orgUsers;
     }
     if (accountType === 'A') {
-      return teachers;
+      return users.filterBy('isAuthorized', true);
     }
   },
 

--- a/app/components/workspace-new-enc.js
+++ b/app/components/workspace-new-enc.js
@@ -1,6 +1,5 @@
 Encompass.WorkspaceNewEncComponent = Ember.Component.extend(Encompass.CurrentUserMixin, {
   elementId: 'workspace-new-enc',
-
   selectedPdSetId: null,
   selectedFolderSet: null,
   selectedAssignment: null,
@@ -9,6 +8,13 @@ Encompass.WorkspaceNewEncComponent = Ember.Component.extend(Encompass.CurrentUse
   selectedOwner: null,
   teacher: null,
   mode: 'private',
+  userList: null,
+
+
+  init: function() {
+    this._super(...arguments);
+    this.set('userList', this.model.users);
+  },
 
   didReceiveAttrs: function() {
     const currentUser = this.get('currentUser');
@@ -27,10 +33,30 @@ Encompass.WorkspaceNewEncComponent = Ember.Component.extend(Encompass.CurrentUse
       return [currentUser];
     }
 
-    const teachers = this.model.users.rejectBy('accountType', 'S');
+    const teachers = this.userList.rejectBy('accountType', 'S');
 
     if (accountType === 'P') {
-      return teachers.filterBy('organization', currentUser.organization);
+      let yourUsers = this.userList;
+      let yourUserList = [];
+
+      yourUsers.forEach((user) => {
+        let yourOrg = currentUser.get('organization').get('id');
+        let userType = user.get('accountType');
+        let userOrg = user.get('organization').get('id');
+        let isAuth = user.get('isAuthorized');
+
+        if (yourOrg === userOrg && userType !== 'S' && isAuth) {
+          yourUserList.push(user);
+        }
+      });
+      return yourUserList;
+
+      //This needs to be fixed because i dont think its getting the users!
+
+      // let teacher = orgUsers.filterBy('organization', currentUser.get('organization'));
+      // console.log('orgUsers', orgUsers);
+      // console.log('teachers', teacher);
+      // return orgUsers;
     }
     if (accountType === 'A') {
       return teachers;

--- a/app/components/workspace-new-enc.js
+++ b/app/components/workspace-new-enc.js
@@ -106,7 +106,6 @@ Encompass.WorkspaceNewEncComponent = Ember.Component.extend(Encompass.CurrentUse
       const mode = this.get('mode');
       const owner = this.get('selectedOwner');
 
-      console.log(startDate, endDate);
       const criteria = {
         teacher: this.get('selectedTeacher'),
         createdBy: this.get('currentUser'),
@@ -131,12 +130,12 @@ Encompass.WorkspaceNewEncComponent = Ember.Component.extend(Encompass.CurrentUse
           this.set('createWorkspaceError', res.get('createWorkspaceError'));
           return;
         }
+        //Get the created workspaceId from the res
         let workspaceId = res.get('createdWorkspace').get('id');
-        console.log('workspaceId', workspaceId);
+        //Then find the first SubmissionID, this is sent to route in order to redirect
         this.store.findRecord('workspace', workspaceId).then((workspace) => {
           let submission = workspace.get('submissions').get('firstObject');
           let submissionId = submission.get('id');
-          console.log('submissionid is', submissionId);
           this.sendAction('toWorkspaces', workspaceId, submissionId);
         });
 

--- a/app/components/workspace-new-enc.js
+++ b/app/components/workspace-new-enc.js
@@ -63,7 +63,6 @@ Encompass.WorkspaceNewEncComponent = Ember.Component.extend(Encompass.CurrentUse
   isAnswerCriteriaValid: function() {
     const params = ['selectedTeacher', 'selectedAssignment', 'selectedProblem', 'selectedSection'];
     for (let param of params) {
-      console.log(param);
       if (this.get(param)) {
         return true;
       }
@@ -87,11 +86,6 @@ Encompass.WorkspaceNewEncComponent = Ember.Component.extend(Encompass.CurrentUse
 
 
   actions: {
-    // radioSelect: function( value ){
-    //   console.log("Radio select: " + value );
-    //   this.set('importMode', value );
-    // },
-
     radioSelect: function (value) {
       this.set('mode', value);
     },
@@ -129,7 +123,6 @@ Encompass.WorkspaceNewEncComponent = Ember.Component.extend(Encompass.CurrentUse
 
       const encWorkspaceRequest = this.store.createRecord('encWorkspaceRequest', criteria);
       encWorkspaceRequest.save().then((res) => {
-        console.log('res ws', res);
         if (res.get('isEmptyAnswerSet')) {
           this.set('isEmptyAnswerSet', true);
           return;
@@ -138,11 +131,15 @@ Encompass.WorkspaceNewEncComponent = Ember.Component.extend(Encompass.CurrentUse
           this.set('createWorkspaceError', res.get('createWorkspaceError'));
           return;
         }
+        let workspaceId = res.get('createdWorkspace').get('id');
+        console.log('workspaceId', workspaceId);
+        this.store.findRecord('workspace', workspaceId).then((workspace) => {
+          let submission = workspace.get('submissions').get('firstObject');
+          let submissionId = submission.get('id');
+          console.log('submissionid is', submissionId);
+          this.sendAction('toWorkspaces', workspaceId, submissionId);
+        });
 
-        // currently redirecting to workspaces list if successful
-        // should we try to redirect to the individual workspace page?
-        this.sendAction('toWorkspaces');
-        //this.sendAction('toWorkspace', res.id);
       })
       .catch((err) => {
         this.set('createWorkspaceError', err);
@@ -151,5 +148,4 @@ Encompass.WorkspaceNewEncComponent = Ember.Component.extend(Encompass.CurrentUse
     },
   }
 });
-
 

--- a/app/components/workspace-new.js
+++ b/app/components/workspace-new.js
@@ -12,9 +12,8 @@ Encompass.WorkspaceNewComponent = Ember.Component.extend({
       }
     },
 
-    toWorkspaces: function() {
-      console.log('in toWs ws-new comp');
-      this.sendAction('toWorkspaces');
+    toWorkspaces: function(workspaceId, submissionId) {
+      this.sendAction('toWorkspaces', workspaceId, submissionId);
     },
 
     toWorkspace: function(id) {

--- a/app/components/workspace-submission.js
+++ b/app/components/workspace-submission.js
@@ -8,6 +8,7 @@ Encompass.WorkspaceSubmissionComponent = Ember.Component.extend(Encompass.Curren
   makingSelection: true,
   showingSelections: false,
   isTransitioning: false,
+  isDirty: false,
 
   showSelectableView: Ember.computed('makingSelection', 'showingSelections', 'isTransitioning', function() {
     var making = this.get('makingSelection');
@@ -20,22 +21,38 @@ Encompass.WorkspaceSubmissionComponent = Ember.Component.extend(Encompass.Curren
     return this.get('makingSelection');
   }),
 
- init: function() {
-   this._super(...arguments);
- },
+
+
+  init: function() {
+    this._super(...arguments);
+  },
 
   didRender: function() {
-    console.log('rendering ws-sub');
     if(this.get('switching')) {
       this.set('switching', false);
     }
+  },
 
- },
+  willDestroyElement: function() {
+    let workspace = this.get('currentWorkspace');
+
+    if (this.get('isDirty')) {
+      workspace.save();
+    }
+
+
+    //Need a way to get the current worksapce?
+    // Do this on the backend?
+    // if (this.get('isDirty')) {
+    //   let workspace = this.get('workspace');
+    //   workspace.save();
+    // }
+    this._super(...arguments);
+  },
 
   /* Next: get selections to show up */
 
   workspaceSelections: function() {
-    console.log('curr sub',this.currentSubmission);
     var selections = this.currentSubmission.get('selections');
     var comp = this;
     var selectionsInWorkspace = null;
@@ -71,11 +88,13 @@ Encompass.WorkspaceSubmissionComponent = Ember.Component.extend(Encompass.Curren
   actions: {
     addSelection: function( selection ){
       console.log("workspace-submission sending action up to controller...");
+      this.set('isDirty', true);
       this.sendAction( 'addSelection', selection );
     },
 
     deleteSelection: function( selection ){
       console.log("workspace-submission sending DELETE action up to controller...");
+      this.set('isDirty', true);
       this.sendAction( 'deleteSelection', selection );
     },
 

--- a/app/components/workspace-submission.js
+++ b/app/components/workspace-submission.js
@@ -35,16 +35,9 @@ Encompass.WorkspaceSubmissionComponent = Ember.Component.extend(Encompass.Curren
 
   willDestroyElement: function() {
     let workspace = this.get('currentWorkspace');
+    workspace.save();
 
-    if (this.get('isDirty')) {
-      workspace.save();
-    }
-
-
-    //Need a way to get the current worksapce?
-    // Do this on the backend?
     // if (this.get('isDirty')) {
-    //   let workspace = this.get('workspace');
     //   workspace.save();
     // }
     this._super(...arguments);

--- a/app/models/workspace.js
+++ b/app/models/workspace.js
@@ -71,7 +71,7 @@ Encompass.Workspace = DS.Model.extend(Encompass.Auditable, Encompass.Permission,
       hi = tmp;
     }
     if(lo && hi){
-      loFmt = moment(lo).zone('us').format('l'); 
+      loFmt = moment(lo).zone('us').format('l');
       hiFmt = moment(hi).zone('us').format('l');
       if(loFmt === hiFmt) {
         return loFmt;

--- a/app/routes/import_route.js
+++ b/app/routes/import_route.js
@@ -10,9 +10,8 @@ Encompass.ImportRoute = Encompass.AuthenticatedRoute.extend(Encompass.ConfirmLea
   },
 
   actions: {
-    toWorkspaces: function() {
-      console.log('in toWorkspaces');
-      this.transitionTo('workspaces');
+    toWorkspaces: function(workspace) {
+      window.location.href = `#/workspaces/${workspace.workspaceId}/submissions/${workspace.submissionId}`;
     }
   },
 
@@ -20,3 +19,5 @@ Encompass.ImportRoute = Encompass.AuthenticatedRoute.extend(Encompass.ConfirmLea
     this.render('import/import');
   },
 });
+
+

--- a/app/routes/workspace_submissions_route.js
+++ b/app/routes/workspace_submissions_route.js
@@ -8,7 +8,6 @@ Encompass.WorkspaceSubmissionsRoute = Ember.Route.extend({
 
   model: function() {
     var workspace = this.modelFor('workspace');
-    console.log("Getting submissions W-Ss route: " + workspace.get('id') );
     return workspace.get('submissions');
   },
 

--- a/app/routes/workspaces_new_route.js
+++ b/app/routes/workspaces_new_route.js
@@ -15,9 +15,12 @@ Encompass.WorkspacesNewRoute = Ember.Route.extend({
     // willTransition: function() {
     //   this.send('reload');
     // }
-    toWorkspaces: function() {
+    toWorkspaces: function (workspaceId, submissionId) {
       console.log('in toWorkspaces wsroute');
-      this.transitionTo('workspaces');
+      console.log('workspace is', workspaceId);
+      console.log('workspace is', submissionId);
+      // this.transitionTo('workspaces');
+      window.location.href = `#/workspaces/${workspaceId}/submissions/${submissionId}`;
     },
 
     toWorkspace: function(id) {

--- a/app/routes/workspaces_new_route.js
+++ b/app/routes/workspaces_new_route.js
@@ -12,14 +12,8 @@ Encompass.WorkspacesNewRoute = Ember.Route.extend({
   },
 
   actions: {
-    // willTransition: function() {
-    //   this.send('reload');
-    // }
+    // Created workspaceId and the firstSubmission are passed from component to redirect
     toWorkspaces: function (workspaceId, submissionId) {
-      console.log('in toWorkspaces wsroute');
-      console.log('workspace is', workspaceId);
-      console.log('workspace is', submissionId);
-      // this.transitionTo('workspaces');
       window.location.href = `#/workspaces/${workspaceId}/submissions/${submissionId}`;
     },
 

--- a/app/routes/workspaces_route.js
+++ b/app/routes/workspaces_route.js
@@ -6,6 +6,10 @@
   */
 
 Encompass.WorkspacesRoute = Encompass.AuthenticatedRoute.extend({
+  model: function () {
+    return this.get('store').findAll('user');
+  },
+
   renderTemplate: function(){
     console.log('rendering workspaces template');
   },

--- a/app/templates/components/workspace-info.hbs
+++ b/app/templates/components/workspace-info.hbs
@@ -95,7 +95,7 @@
       <label>Add Editor</label>
       {{input type="text" value=searchText placeholder="Search..." classNames="editor search"}}
       <ul>
-        {{#each searchResults as |result|}}
+        {{#each editorSearchResults as |result|}}
         <li>
           <button class="addEditor" {{action 'addEditor' result}}>{{result.username}}</button>
         </li>

--- a/seeders/users.seeder.js
+++ b/seeders/users.seeder.js
@@ -296,6 +296,22 @@ var data = [{
     "isTrashed": false,
     "createDate": "2018-08-14T18:20:51.382Z",
     "lastSeen": "2018-08-16T20:19:26.457Z"
+  },
+  {
+    "_id": "52964653e4bad7087700014b",
+    "name": "testfix",
+    "email": "testfix@test.com",
+    "organization": "5b4a64a028e4b75919c28512",
+    "location": "Philadelphia, PA",
+    "username": "testfix",
+    "password": "$2a$12$nQafJwfxx19P2vyBhDLXUeDFNdZU81t1eosZEvs.plyCP1HNSZFtW",
+    "isAuthorized": true,
+    "accountType": "T",
+    "isEmailConfirmed": true,
+    "lastModifiedDate": "2018-08-14T18:20:51.382Z",
+    "isTrashed": false,
+    "createDate": "2018-08-14T18:20:51.382Z",
+    "lastSeen": "2018-08-16T20:19:26.457Z"
   }
 ];
 

--- a/server/datasource/api/imageApi.js
+++ b/server/datasource/api/imageApi.js
@@ -148,9 +148,6 @@ const postImages = async function(req, res, next) {
           console.trace();
           return utils.sendError.InternalError(err, res);
         });
-
-
-
     } else {
       let str = data.toString('base64');
       let alt = '';

--- a/server/datasource/api/importApi.js
+++ b/server/datasource/api/importApi.js
@@ -98,6 +98,7 @@ let workspace = new models.Workspace({
 });
 let ws = await workspace.save();
 let newFolderSet = await workspaceApi.newFolderStructure(user, ws, folderSetName);
+//sending back workspace and submissionID for redirect
 const data = { 'workspaceId': ws._id,
                'submissionId': ws.submissions[0]
              };

--- a/server/datasource/api/importApi.js
+++ b/server/datasource/api/importApi.js
@@ -98,7 +98,9 @@ let workspace = new models.Workspace({
 });
 let ws = await workspace.save();
 let newFolderSet = await workspaceApi.newFolderStructure(user, ws, folderSetName);
-const data = {'workspaceId': ws._id};
+const data = { 'workspaceId': ws._id,
+               'submissionId': ws.submissions[0]
+             };
 return utils.sendResponse(res, data);
 
 }catch(err) {

--- a/server/datasource/api/workspaceApi.js
+++ b/server/datasource/api/workspaceApi.js
@@ -186,17 +186,25 @@ function putWorkspace(req, res, next) {
     if(!permissions.userCanModifyWorkspace(user, ws)) {
       logger.info("permission denied");
       res.send(403, "You don't have permission to modify this workspace");
+      if (err) {
+        console.log('error is', err);
+      }
     } else {
       models.Workspace.findById(req.params.id).exec(function(err, ws){
         ws.editors = req.body.workspace.editors;
         ws.mode    = req.body.workspace.mode;
         ws.name    = req.body.workspace.name;
         ws.lastModifiedDate = new Date();
+        ws.lastModifiedBy = user;
 
         // only admins or ws owner should be able to trash ws
         if (user.accountType === 'A' || user.id === ws.owner.toString()) {
           console.log('can trash!');
           ws.isTrashed = req.body.workspace.isTrashed;
+        }
+
+        if (err) {
+          console.log('error', err);
         }
 
         ws.save(function(err, workspace) {

--- a/server/datasource/api/workspaceApi.js
+++ b/server/datasource/api/workspaceApi.js
@@ -191,6 +191,7 @@ function putWorkspace(req, res, next) {
         ws.editors = req.body.workspace.editors;
         ws.mode    = req.body.workspace.mode;
         ws.name    = req.body.workspace.name;
+        ws.lastModifiedDate = new Date();
 
         // only admins or ws owner should be able to trash ws
         if (user.accountType === 'A' || user.id === ws.owner.toString()) {

--- a/server/datasource/api/workspaceApi.js
+++ b/server/datasource/api/workspaceApi.js
@@ -1025,8 +1025,9 @@ async function postWorkspaceEnc(req, res, next) {
       rec.isEmptyAnswerSet = true;
       let enc = new models.EncWorkspaceRequest(rec);
       let saved = await enc.save();
+      console.log('inside the if is empty for postENC');
 
-      const data = {encWorkspaceRequest: saved };
+      const data = { encWorkspaceRequest: saved };
         return utils.sendResponse(res, data);
       }
 
@@ -1070,9 +1071,13 @@ let rec = pruned;
 rec.createdWorkspace = ws._id;
 const encRequest = new models.EncWorkspaceRequest(rec);
 const saved = await encRequest.save();
+// saved.workspaceId = ws._id;
+// saved.submissionId = ws.submissions[0];
 
-const data = {encWorkspaceRequest: saved };
-return utils.sendResponse(res,  data );
+const data = { encWorkspaceRequest: saved };
+
+console.log('data is from workspace ENC', data);
+return utils.sendResponse(res,  data);
 
   } catch(err) {
     return utils.sendError.InternalError(err, res);

--- a/server/datasource/api/workspaceApi.js
+++ b/server/datasource/api/workspaceApi.js
@@ -1010,12 +1010,10 @@ async function postWorkspaceEnc(req, res, next) {
     console.log('pruned', pruned);
 
     const accessibleCriteria = await answerAccess.get.answers(user);
-    console.log('accessible criteria is', accessibleCriteria);
 
     const allowedIds = await getAnswerIds(accessibleCriteria);
     const wsCriteria = await buildCriteria(allowedIds, pruned, user);
 
-    console.log('wsCriteria is', wsCriteria);
     const answers = await models.Answer.find(wsCriteria);
     console.log('answers are', answers.length);
 
@@ -1025,7 +1023,6 @@ async function postWorkspaceEnc(req, res, next) {
       rec.isEmptyAnswerSet = true;
       let enc = new models.EncWorkspaceRequest(rec);
       let saved = await enc.save();
-      console.log('inside the if is empty for postENC');
 
       const data = { encWorkspaceRequest: saved };
         return utils.sendResponse(res, data);
@@ -1076,7 +1073,6 @@ const saved = await encRequest.save();
 
 const data = { encWorkspaceRequest: saved };
 
-console.log('data is from workspace ENC', data);
 return utils.sendResponse(res,  data);
 
   } catch(err) {


### PR DESCRIPTION
- Students can no longer be added to a workspace as an editor
- If you create a workspace from import work it now redirects to the created workspace instead of the listing
- When you create a new workspace from form it now sends you to that workspace after creation
- Fixed the pdadmin filter listing in new workspace create, it wasn't getting all the users
- Updated filtering for admin in new workspace create
- Updated last modifiedDate when anything is done inside the workspace info component
- Set last modified to change whenever you view a workspace
  - We can add lastViewed but then we have to add that to all the old workspace data