### PR TITLE
Refactor/ws new criteria build

### DIFF
--- a/scss/_workspace.scss
+++ b/scss/_workspace.scss
@@ -176,6 +176,9 @@
   i {
     margin: 2px;
   }
+  p.error-box {
+    max-width: 500px;
+  }
   .action_button {
     margin: 20px 0 50px 28px;
   }

--- a/server/datasource/api/answerApi.js
+++ b/server/datasource/api/answerApi.js
@@ -51,6 +51,9 @@ const getAnswers = async function(req, res, next) {
   } else {
     criteria = await access.get.answers(user);
   }
+  if (!criteria) {
+    return utils.sendResponse(res, null);
+  }
 
   models.Answer.find(criteria)
   .exec((err, answers) => {

--- a/server/middleware/access/answers.js
+++ b/server/middleware/access/answers.js
@@ -37,14 +37,23 @@ const accessibleAnswersQuery = async function(user, ids) {
     const ownSections = await utils.getTeacherSections(user);
 
     const ownAssignmentIds = await utils.getModelIds('Assignment', {createdBy: user._id});
-    filter.$or = [
-      { assignment : { $in: ownAssignmentIds } },
-      { section: { $in: ownSections} }
-    ];
 
-    // filter.assignment = { $in: ownAssignmentIds };
+    let areValidSections = _.isArray(ownSections) && !_.isEmpty(ownSections);
+    let areValidAssignments = _.isArray(ownAssignmentIds) && !_.isEmpty(ownAssignmentIds);
 
-    // filter.section = { $in: ownSections };
+    if (areValidAssignments || areValidSections) {
+      filter.$or = [];
+      if (areValidAssignments) {
+        filter.$or.push({ assignment : { $in: ownAssignmentIds } });
+      }
+      if (areValidSections) {
+        filter.$or.push({ section: { $in: ownSections} });
+      }
+    }
+    else {
+      // teacher has no sections or assignments
+      return null;
+    }
     return filter;
   }
   }catch(err) {

--- a/server/middleware/access/utils.js
+++ b/server/middleware/access/utils.js
@@ -56,12 +56,12 @@ async function getTeacherAssignments(userId) {
 
 function getTeacherSections(user) {
   if (!user) {
-    return;
+    return [];
   }
   let sections = user.sections;
 
   if (!Array.isArray(sections)) {
-    return;
+    return [];
   }
 
   return sections.map((section) => {


### PR DESCRIPTION
Modified building of criteria for finding answers to speed up workspace creation time (from 20s -> 5s locally when filtering by a problem with a large number of answers(~2500))
  -- No longer performing separate query/map to get the ids of the allowed answers

Fixed criteria for when a teacher filter is applied 
   -- should only allow answers that are related to their sections or answers
   -- this may need to be updated in future to account for old pows data?