### PR TITLE
Bug/edit collabs

### DIFF
--- a/app/components/add-create-student.js
+++ b/app/components/add-create-student.js
@@ -68,6 +68,8 @@ Encompass.AddCreateStudentComponent = Ember.Component.extend(Encompass.ErrorHand
 
     if (organization) {
       createUserData.organization = organization.id;
+    } else {
+      createUserData.organization = this.get('currentUser.organization.id');
     }
 
     return Ember.$.post({

--- a/app/components/workspace-info.js
+++ b/app/components/workspace-info.js
@@ -72,10 +72,15 @@ Encompass.WorkspaceInfoComponent = Ember.Component.extend(Encompass.CurrentUserM
       if (utils.isNonEmptyArray(permissions)) {
         const objToRemove = permissions.findBy('user', user.id);
         if (objToRemove) {
-          permissions.removeObject(objToRemove);
-          const collaborators = this.get('originalCollaborators');
-          collaborators.removeObject(user);
-          this.get('alert').showToast('success', `${user.get('username')} removed`, 'bottom-end', 3000, null, false);
+          this.get('alert').showModal('warning', `Are you sure you want to remove ${user.get('username')} as a collaborator?`, `This may affect their ability to access ${this.get('workspace.name')} `, 'Yes, remove.')
+        .then((result) => {
+          if (result.value) {
+            permissions.removeObject(objToRemove);
+            const collaborators = this.get('originalCollaborators');
+            collaborators.removeObject(user);
+            this.get('alert').showToast('success', `${user.get('username')} removed`, 'bottom-end', 3000, null, false);
+          }
+        });
         }
       }
     },
@@ -123,6 +128,9 @@ Encompass.WorkspaceInfoComponent = Ember.Component.extend(Encompass.CurrentUserM
     },
 
     changeOwner: function (owner) {
+      if (!this.get('utils').isNonEmptyObject(owner)) {
+        return;
+      }
       let workspace = this.get('workspace');
       let username = owner.get('username');
       workspace.set('owner', owner);

--- a/app/components/workspace-info.js
+++ b/app/components/workspace-info.js
@@ -53,13 +53,13 @@ Encompass.WorkspaceInfoComponent = Ember.Component.extend(Encompass.CurrentUserM
   modes: function () {
     const basic = ['private', 'org', 'public'];
 
-    if (!this.get('currentUser.isAdmin')) {
+    if (this.get('currentUser.isStudent') || !this.get('currentUser.isAdmin')) {
       return basic;
     }
 
     return ['private', 'org', 'public', 'internet'];
 
-  }.property('currentUser.isAdmin'),
+  }.property('currentUser.isAdmin', 'currentUser.isStudent'),
 
   actions: {
     removeCollab(user) {

--- a/app/components/workspace-list-container.js
+++ b/app/components/workspace-list-container.js
@@ -414,7 +414,7 @@ buildCollabFilter() {
   let filter = {};
 
   if (utils.isNonEmptyArray(collabWorkspaces)) {
-    ids = collabWorkspaces.mapBy('id');
+    ids = collabWorkspaces;
   }
   // user is not a collaborator for any workspaces
   if (!this.get('utils').isNonEmptyArray(ids)) {

--- a/app/components/workspace-new-copy.js
+++ b/app/components/workspace-new-copy.js
@@ -262,6 +262,23 @@ Encompass.WorkspaceNewCopyComponent = Ember.Component.extend(Encompass.CurrentUs
       });
     }
   },
+  handleSubmissionsLoadingMessage: function() {
+    const that = this;
+    if (!this.get('loadingSubmissions')) {
+      this.set('showLoadingSubmissions', false);
+      return;
+    }
+    Ember.run.later(function() {
+      if (that.isDestroyed || that.isDestroying) {
+        return;
+      }
+      if (!that.get('loadingSubmissions')) {
+        return;
+      }
+      that.set('showLoadingSubmissions', true);
+    }, 500);
+
+  }.observes('loadingSubmissions'),
 
   actions: {
     goToStep(stepValue) {

--- a/app/components/workspace-new-copy.js
+++ b/app/components/workspace-new-copy.js
@@ -394,7 +394,7 @@ Encompass.WorkspaceNewCopyComponent = Ember.Component.extend(Encompass.CurrentUs
       }
 
       let baseOptions = {
-        answerOptions : { all: true },
+        submissionOptions : { all: true },
         folderOptions : {
           includeStructureOnly: true,
           folderSetOptions: this.get('newFolderSetOptions'),

--- a/app/components/workspace-new-copy.js
+++ b/app/components/workspace-new-copy.js
@@ -39,28 +39,37 @@ Encompass.WorkspaceNewCopyComponent = Ember.Component.extend(Encompass.CurrentUs
         }
       ]
     },
-  modeInputs: {
-    groupName: 'mode',
-    required: true,
-    inputs: [
-      {
-        value: 'private',
-        label: 'Private',
-      },
-      {
-        value: 'org',
-        label: 'My Org',
-      },
-      {
-        value: 'public',
-        label: 'Public',
-      },
-      {
-        value: 'internet',
-        label: 'Internet',
-      }
-    ]
-  },
+
+  modeInputs: function() {
+    let res = {
+      groupName: 'mode',
+      required: true,
+      inputs: [
+        {
+          value: 'private',
+          label: 'Private',
+        },
+        {
+          value: 'org',
+          label: 'My Org',
+        },
+        {
+          value: 'public',
+          label: 'Public',
+        },
+      ]
+    };
+
+    if (this.get('currentUser.isStudent') || !this.get('currentUser.isAdmin') ) {
+      return res;
+    }
+
+    res.inputs.push({
+      value: 'internet',
+      label: 'Internet',
+    });
+    return res;
+  }.property('currentUser.isStudent', 'currentUser.isAdmin'),
 
   showSelectWorkspace: Ember.computed.equal('currentStep.value', 1),
   showSelectConfig: Ember.computed.equal('currentStep.value', 2),

--- a/app/components/ws-copy-custom-config.js
+++ b/app/components/ws-copy-custom-config.js
@@ -1,32 +1,32 @@
 /*global _:false */
 Encompass.WsCopyCustomConfigComponent = Ember.Component.extend({
   elementId: 'ws-copy-custom-config',
-  answerStudents: [],
+  submissionStudents: [],
   utils: Ember.inject.service('utility-methods'),
 
-  answerIds: Ember.computed.alias('customConfig.answerIds'),
-  answerOptions: Ember.computed.alias('customConfig.answerOptions'),
+  SubmissionIds: Ember.computed.alias('customConfig.SubmissionIds'),
+  submissionOptions: Ember.computed.alias('customConfig.submissionOptions'),
   selectionOptions: Ember.computed.alias('customConfig.selectionOptions'),
   commentOptions: Ember.computed.alias('customConfig.commentOptions'),
   responseOptions: Ember.computed.alias('customConfig.responseOptions'),
   folderOptions: Ember.computed.alias('customConfig.folderOptions'),
-  showStudentAnswerInput: Ember.computed.equal('answerOptions.byStudent', true),
+  showStudentSubmissionInput: Ember.computed.equal('submissionOptions.byStudent', true),
 
-  formattedAnswerOptions: function() {
-    let answerOptions = {
+  formattedSubmissionOptions: function() {
+    let submissionOptions = {
       all: true,
     };
 
-    if (this.get('answerOptions.all')) {
-      return answerOptions;
+    if (this.get('submissionOptions.all')) {
+      return submissionOptions;
     }
-    delete answerOptions.all;
+    delete submissionOptions.all;
 
-    answerOptions.answerIds = this.get('answerIdsFromStudents');
+    submissionOptions.submissionIds = this.get('submissionsFromStudents').mapBy('id');
 
-    return answerOptions;
+    return submissionOptions;
 
-  }.property('answerOptions.all', 'submissionsFromStudents.[]'),
+  }.property('submissionOptions.all', 'submissionsFromStudents.[]'),
 
   formattedFolderOptions: function() {
     let folderOptions = {
@@ -116,19 +116,19 @@ Encompass.WsCopyCustomConfigComponent = Ember.Component.extend({
   formattedConfig: function() {
 
     return {
-      answerOptions: this.get('formattedAnswerOptions'),
+      submissionOptions: this.get('formattedSubmissionOptions'),
       folderOptions: this.get('formattedFolderOptions'),
       selectionOptions: this.get('formattedSelectionOptions'),
       commentOptions: this.get('formattedCommentOptions'),
       responseOptions: this.get('formattedResponseOptions')
     };
-  }.property('formattedAnswerOptions.@each{all,none,custom}', 'formattedSelectionOptions.@each{all,none,custom}', 'formattedCommentOptions.@each{all,none,custom}', 'formattedResponseOptions.@each{all,none,custom}', 'formattedFolderOptions.@each{all,none,includeStructureOnly}'),
+  }.property('formattedSubmissionOptions.@each{all,none,custom}', 'formattedSelectionOptions.@each{all,none,custom}', 'formattedCommentOptions.@each{all,none,custom}', 'formattedResponseOptions.@each{all,none,custom}', 'formattedFolderOptions.@each{all,none,includeStructureOnly}'),
 
   customConfig: {
-    answerOptions: {
+    submissionOptions: {
       all: true,
       byStudent: false,
-      answerIds: []
+      submissionIds: []
     },
     folderOptions: {
       includeStructureOnly: true,
@@ -173,11 +173,11 @@ Encompass.WsCopyCustomConfigComponent = Ember.Component.extend({
   }.property('submissionThreads'),
 
   submissionsFromStudents: function() {
-    if (this.get('answerOptions.all')) {
+    if (this.get('submissionOptions.all')) {
       return this.get('workspace.submissions');
     }
     const threads = this.get('submissionThreads');
-    const students = this.get('answerStudents');
+    const students = this.get('submissionStudents');
     if (!threads || !this.get('utils').isNonEmptyArray(students) ) {
       return [];
     }
@@ -185,7 +185,7 @@ Encompass.WsCopyCustomConfigComponent = Ember.Component.extend({
       .map(student => threads.get(student))
       .flatten()
       .value();
-  }.property('answerStudents.[]', 'answerOptions.all', 'workspace.id', 'submissionThreads'),
+  }.property('submissionStudents.[]', 'submissionOptions.all', 'workspace.id', 'submissionThreads'),
 
   selectionsFromSubmissions: function() {
     return this.get('workspace.selections').filter((selection) => {
@@ -209,10 +209,10 @@ Encompass.WsCopyCustomConfigComponent = Ember.Component.extend({
     });
   }.property('submissionsFromStudents.[]'),
 
-  answerIdsFromStudents: function() {
+  submissionIdsFromStudents: function() {
     const subs = this.get('submissionsFromStudents');
 
-    return subs.mapBy('answer.content.id');
+    return subs.mapBy('id');
   }.property('submissionsFromStudents.[]'),
 
   actions: {
@@ -228,15 +228,15 @@ Encompass.WsCopyCustomConfigComponent = Ember.Component.extend({
       this.get(propToUpdate).pushObject(val);
     },
 
-    setAnswers() {
-      if (this.get('showStudentAnswerInput')) {
-        const answerIds = this.get('answerIdsFromStudents');
-        if (this.get('utils').isNonEmptyArray(answerIds)) {
-          this.set('answerIds', [...answerIds]);
+    setSubmissions() {
+      if (this.get('showStudentSubmissionInput')) {
+        const submissionIds = this.get('submissionIdsFromStudents');
+        if (this.get('utils').isNonEmptyArray(submissionIds)) {
+          this.set('submissionIds', [...submissionIds]);
           this.set('showSelectionInputs', true);
           return;
         }
-        this.set('noAnswersToCopy', true);
+        this.set('noSubmissionssToCopy', true);
         return;
       }
       this.set('showSelectionInputs', true);
@@ -246,7 +246,7 @@ Encompass.WsCopyCustomConfigComponent = Ember.Component.extend({
     updateCollectionOptions(val, propName) {
       let keys = ['all', 'none', 'custom'];
 
-      if (propName === 'answerOptions') {
+      if (propName === 'submissionOptions') {
         keys = ['all', 'byStudent'];
       }
 
@@ -267,6 +267,9 @@ Encompass.WsCopyCustomConfigComponent = Ember.Component.extend({
         }
       });
 
+    },
+    toggleIncludeStructureOnly() {
+      this.toggleProperty('folderOptions.includeStructureOnly');
     },
     next(){
       this.get('onProceed')(this.get('formattedConfig'));

--- a/app/components/ws-copy-review.js
+++ b/app/components/ws-copy-review.js
@@ -4,6 +4,9 @@ Encompass.WsCopyReviewComponent = Ember.Component.extend({
   actions: {
     next() {
       this.get('onProceed')();
+    },
+    back() {
+      this.get('onBack')(-1);
     }
   }
 

--- a/app/components/ws-copy-workspace.js
+++ b/app/components/ws-copy-workspace.js
@@ -65,6 +65,7 @@ Encompass.WsCopyWorkspaceComponent = Ember.Component.extend({
         // only allowing workspaces with > 0 submissions
         if (submissionsLength > 0) {
           this.get('onProceed')();
+          return;
         }
         this.set('tooFewSubmissions', true);
         return;

--- a/app/components/ws-permissions-new.js
+++ b/app/components/ws-permissions-new.js
@@ -113,6 +113,11 @@ Encompass.WsPermissionsNewComponent = Ember.Component.extend({
    }
   },
 
+  willDestroyElement() {
+    this.set('selectedUser', null);
+    this._super(...arguments);
+  },
+
   buildCustomSubmissionIds(submissionsValue) {
     if (submissionsValue === 'custom') {
       let ids = this.get('customSubmissionIds');

--- a/app/components/ws-permissions-new.js
+++ b/app/components/ws-permissions-new.js
@@ -88,7 +88,14 @@ Encompass.WsPermissionsNewComponent = Ember.Component.extend({
     const utils = this.get('utils');
 
    if (!utils.isNullOrUndefined(selectedUserId) && utils.isNonEmptyArray(permissions)) {
-     const userPermissions = permissions.findBy('user', selectedUserId);
+     const userPermissions = permissions.find((obj) => {
+      let user = obj.user;
+      if (utils.isNonEmptyObject(user)) {
+        return user.get('id') === selectedUserId;
+      }
+      return user === selectedUserId;
+     });
+
      if (utils.isNonEmptyObject(userPermissions)) {
       //prefill for editing
       _.each(['folders', 'comments', 'selections', 'feedback', 'global'], (prop) => {
@@ -106,7 +113,7 @@ Encompass.WsPermissionsNewComponent = Ember.Component.extend({
           this.set('submissions', 'userOnly');
         } else if (_.isArray(submissions.submissionIds)) {
           this.set('submissions', 'custom');
-          this.set('customSubmissionIds', submissions.submissionIds);
+          this.set('customSubmissionIds', [...submissions.submissionIds]);
         }
       }
      }
@@ -197,7 +204,12 @@ Encompass.WsPermissionsNewComponent = Ember.Component.extend({
       this.set('saveError', true);
     },
     updateCustomSubs(id) {
+      if (!this.get('utils').isNonEmptyArray(this.get('customSubmissionIds'))) {
+        this.set('customSubmissionIds', []);
+      }
+
       const customSubmissionIds = this.get('customSubmissionIds');
+
       const isIn = customSubmissionIds.includes(id);
       if (isIn) {
         // remove

--- a/app/models/copy_workspace_request.js
+++ b/app/models/copy_workspace_request.js
@@ -3,7 +3,7 @@ Encompass.CopyWorkspaceRequest = DS.Model.extend(Encompass.Auditable, {
   owner: DS.belongsTo('user', { inverse: null }),
   mode: DS.attr('string'),
   originalWsId: DS.belongsTo('workspace', {inverse: null}),
-  answerOptions: DS.attr(),
+  submissionOptions: DS.attr(),
   folderOptions: DS.attr(),
   selectionOptions: DS.attr(),
   commentOptions: DS.attr(),

--- a/app/templates/components/new-folderset-form.hbs
+++ b/app/templates/components/new-folderset-form.hbs
@@ -1,8 +1,14 @@
 <div class="new-folderset name">
   <p>Name</p>
   {{input id="folderset-name" type="text" value=name placeholder="Name for new folder set"}}
+  {{#each nameErrors as |error|}}
+    {{error-box error=error showDismiss=true resetError=(action (mut nameErrors) null)}}
+  {{/each}}
 </div>
 <div class="new-folderset privacy">
   <p>Privacy Setting</p>
   {{radio-group options=privacyInputs selectedValue=privacySetting}}
+  {{#each privacyErrors as |error|}}
+    {{error-box error=error showDismiss=true resetError=(action (mut privacyErrors) null)}}
+  {{/each}}
 </div>

--- a/app/templates/components/workspace-info.hbs
+++ b/app/templates/components/workspace-info.hbs
@@ -37,6 +37,7 @@
       {{#if canEdit}}
         {{#if isEditing}}
           <button class="action_button" {{action 'saveWorkspace'}}>Save</button>
+          <button class="action_button" {{action (mut isEditing) null}}>Cancel</button>
         {{else}}
           <button class="action_button" {{action 'editWorkspace'}}>Edit</button>
         {{/if}}

--- a/app/templates/components/workspace-new-copy.hbs
+++ b/app/templates/components/workspace-new-copy.hbs
@@ -21,7 +21,7 @@
 </div>
 
 {{#if showSelectWorkspace}}
-  {{ws-copy-workspace store=store workspaceToCopy=workspaceToCopy selectedWorkspace=selectedWorkspace onProceed=(action "setOriginalWorkspace")}}
+  {{ws-copy-workspace loadingSubmissions=loadingSubmissions loadSubmissionErrors=loadSubmissionErrors store=store workspaceToCopy=workspaceToCopy selectedWorkspace=selectedWorkspace onProceed=(action "setOriginalWorkspace")}}
 {{/if}}
 
 {{#if showSelectConfig}}

--- a/app/templates/components/workspace-new-copy.hbs
+++ b/app/templates/components/workspace-new-copy.hbs
@@ -21,7 +21,7 @@
 </div>
 
 {{#if showSelectWorkspace}}
-  {{ws-copy-workspace loadingSubmissions=loadingSubmissions loadSubmissionErrors=loadSubmissionErrors store=store workspaceToCopy=workspaceToCopy selectedWorkspace=selectedWorkspace onProceed=(action "setOriginalWorkspace")}}
+  {{ws-copy-workspace showLoadingSubmissions=showLoadingSubmissions loadSubmissionErrors=loadSubmissionErrors store=store workspaceToCopy=workspaceToCopy selectedWorkspace=selectedWorkspace onProceed=(action "setOriginalWorkspace")}}
 {{/if}}
 
 {{#if showSelectConfig}}

--- a/app/templates/components/workspace-new-copy.hbs
+++ b/app/templates/components/workspace-new-copy.hbs
@@ -37,7 +37,7 @@
 {{/if}}
 
 {{#if showReview}}
-  {{ws-copy-review onProceed=(action "createCopyRequest")}}
+  {{ws-copy-review onProceed=(action "createCopyRequest") onBack=(action "changeStep")}}
 {{/if}}
 
 

--- a/app/templates/components/ws-copy-custom-config.hbs
+++ b/app/templates/components/ws-copy-custom-config.hbs
@@ -1,14 +1,13 @@
 <h5>Submissions</h5>
 
-<input type="radio" checked={{answerOptions.all}} required="true" name="answerOptions" value="all" onclick={{action "updateCollectionOptions" "all" "answerOptions"}}>
+<input type="radio" checked={{submissionOptions.all}} required="true" name="submissionOptions" value="all" onclick={{action "updateCollectionOptions" "all" "submissionOptions"}}>
 <label>All</label>
 
-<input type="radio" checked={{answerOptions.byStudent}} required="true" name="answerOptions" value="byStudent" onclick={{action "updateCollectionOptions" "byStudent" "answerOptions"}}>
+<input type="radio" checked={{submissionOptions.byStudent}} required="true" name="submissionOptions" value="byStudent" onclick={{action "updateCollectionOptions" "byStudent" "submissionOptions"}}>
 <label>By Student</label>
-{{log 'show student answer input' showStudentAnswerInput}}
-{{#if showStudentAnswerInput}}
+{{#if showStudentSubmissionInput}}
   {{selectize-input
-  inputId="answers-by-student"
+  inputId="submissions-by-student"
   initialOptions=studentSelectOptions
   maxItems=studentSelectOptions.length
   onItemAdd=(action "updateMultiSelect")
@@ -16,14 +15,14 @@
   labelField="label"
   valueField="value"
   searchField="label"
-  propToUpdate="answerStudents"
+  propToUpdate="submissionStudents"
   placeholder="Add students"}}
 
-  {{#each answerStudents as |student|}}
+  {{#each submissionStudents as |student|}}
   <p>{{student}}</p>
   {{/each}}
 {{/if}}
-{{#if noAnswersToCopy}}
+{{#if noSubmissionsToCopy}}
   <p class="error-message">Your current configuration would result in 0 submissions. Please modify your criteria.</p>
 {{/if}}
 
@@ -50,8 +49,8 @@ onclick={{action "updateCollectionOptions" "all" "folderOptions"}}>
 <label>None</label>
 
 {{#if folderOptions.all}}
+  <input type="checkbox" checked={{folderOptions.includeStructureOnly}} name="includeStructureOnly" onclick={{action "toggleIncludeStructureOnly"}}>
   <label>Include Structure Only</label>
-  <input type="checkbox" checked={{folderOptions.includeStructureOnly}} name="includeStructureOnly">
 {{/if}}
 
 <h5>Comments</h5>

--- a/app/templates/components/ws-copy-owner-settings.hbs
+++ b/app/templates/components/ws-copy-owner-settings.hbs
@@ -51,7 +51,7 @@ placeholder="Search users to choose as owner"}}
       <label>No</label>
 
       {{#if doCreateFolderSet}}
-        {{new-folderset-form name=folderSetName privacySetting=folderSetPrivacy}}
+        {{new-folderset-form nameErrors=folderSetNameErrors privacyErrors=folderSetPrivacySettingErrors name=folderSetName privacySetting=folderSetPrivacy}}
       {{/if}}
 
     {{else}}

--- a/app/templates/components/ws-copy-permissions.hbs
+++ b/app/templates/components/ws-copy-permissions.hbs
@@ -16,7 +16,7 @@ isAsync=true
 placeholder="Search for collaborators to add"}}
 
 {{#if selectedCollaborator}}
-  {{ws-permissions-new workspace=workspace onSave=(action "savePermissions") selectedUser=selectedCollaborator}}
+  {{ws-permissions-new workspace=workspace onSave=(action "savePermissions") permissions=permissions selectedUser=selectedCollaborator}}
 {{/if}}
 
 

--- a/app/templates/components/ws-copy-review.hbs
+++ b/app/templates/components/ws-copy-review.hbs
@@ -1,3 +1,6 @@
 <p class="info">Review the details of your request located above. If everything looks correct, hit 'Submit' to create your new copied workspace.</p>
 
-<button class="ws-copy submit" {{action "next"}}>Submit</button>
+<div class="nav-btn-container">
+  <button {{action "back"}}>Prev</button>
+  <button class="ws-copy submit" {{action "next"}}>Submit</button>
+</div>

--- a/app/templates/components/ws-copy-workspace.hbs
+++ b/app/templates/components/ws-copy-workspace.hbs
@@ -30,7 +30,12 @@
 {{#if tooFewSubmissions}}
   {{error-box error="Please select a workspace with at least 1 submission." resetError=(action (mut tooFewSubmissions) null) showDismiss=true }}
 {{/if}}
-
+{{#if loadingSubmissions}}
+  <p class="loading-message">Loading submissions... Thank you for your patience.</p>
+{{/if}}
+{{#each loadSubmissionErrors as |error|}}
+  <p class="error-message">{{error}}</p>
+{{/each}}
 <div class="nav-btn-container">
   <button class="btn-next" {{action "next"}}>Next</button>
 </div>

--- a/app/templates/components/ws-copy-workspace.hbs
+++ b/app/templates/components/ws-copy-workspace.hbs
@@ -30,7 +30,7 @@
 {{#if tooFewSubmissions}}
   {{error-box error="Please select a workspace with at least 1 submission." resetError=(action (mut tooFewSubmissions) null) showDismiss=true }}
 {{/if}}
-{{#if loadingSubmissions}}
+{{#if showLoadingSubmissions}}
   <p class="loading-message">Loading submissions... Thank you for your patience.</p>
 {{/if}}
 {{#each loadSubmissionErrors as |error|}}

--- a/app/templates/components/ws-info-permissions.hbs
+++ b/app/templates/components/ws-info-permissions.hbs
@@ -15,6 +15,6 @@
 }}
 
 {{#if selectedCollaborator}}
-  {{ws-permissions-new workspace=workspace onSave=(action "savePermissions") selectedUser=selectedCollaborator}}
+  {{ws-permissions-new workspace=workspace permissions=permissions onSave=(action "savePermissions") selectedUser=selectedCollaborator}}
 {{/if}}
 

--- a/app/templates/components/ws-permissions-new.hbs
+++ b/app/templates/components/ws-permissions-new.hbs
@@ -13,7 +13,6 @@
     </li>
   {{/each}}
   </ul>
-  <p>Use submission viewer component here</p>
 {{/if}}
 {{radio-group options=globalItems selectedValue=global}}
 

--- a/app/templates/components/ws-permissions-new.hbs
+++ b/app/templates/components/ws-permissions-new.hbs
@@ -3,6 +3,16 @@
 
 {{radio-group options=submissionItems selectedValue=submissions}}
 {{#if showCustomSubmissions}}
+<ul>
+
+
+  {{#each workspace.submissions.content as |submission|}}
+    <li>
+       <input type="checkbox" checked={{is-in customSubmissionIds submission.id}} name="customIds" value={{submission.id}} onclick={{action "updateCustomSubs" submission.id}}>
+      <span>{{submission.id}} by {{submission.student}}</span>
+    </li>
+  {{/each}}
+  </ul>
   <p>Use submission viewer component here</p>
 {{/if}}
 {{radio-group options=globalItems selectedValue=global}}
@@ -19,3 +29,4 @@
   <p class="error-message">Sorry, something went wrong. Please try again.</p>
 {{/if}}
 <button class="save-permissions" {{action "savePermissions"}}>Save User Permissions </button>
+<button {{action (mut selectedUser) null}}>Cancel</button>

--- a/server/datasource/schemas/copyWorkspaceRequest.js
+++ b/server/datasource/schemas/copyWorkspaceRequest.js
@@ -19,10 +19,10 @@ var CopyWorkspaceRequestSchema = new Schema({
   owner: { type: ObjectId, ref: 'User' },
   name: { type: String },
   mode: { type: String, enum: ['private', 'org', 'public', 'internet']},
-  answerOptions: {
+  submissionOptions: {
     all: { type: Boolean },
     none: { type: Boolean },
-    answerIds: [{ type: ObjectId, ref: 'Answer' }]
+    submissionIds: [{ type: ObjectId, ref: 'Answer' }]
   },
   folderOptions: {
     includeStructureOnly: { type: Boolean },

--- a/server/datasource/schemas/copyWorkspaceRequest.js
+++ b/server/datasource/schemas/copyWorkspaceRequest.js
@@ -57,7 +57,8 @@ var CopyWorkspaceRequestSchema = new Schema({
       global: {type: String, enum: ['viewOnly', 'editor', 'custom'] },
       submissions: {
         all: { type: Boolean },
-        submissionIds: [ {type: ObjectId, ref: 'Submission'} ]
+        submissionIds: [ {type: ObjectId, ref: 'Submission'} ],
+        userOnly: [ { type: Boolean }]
       },
       folders: { type: Number, enum: [0, 1, 2, 3, 4] },
       comments: { type: Number, enum: [0, 1, 2, 3, 4] },

--- a/server/datasource/schemas/workspace.js
+++ b/server/datasource/schemas/workspace.js
@@ -55,7 +55,8 @@ var WorkspaceSchema = new Schema({
     global: {type: String, enum: ['viewOnly', 'editor', 'custom'] },
     submissions: {
       all: { type: Boolean },
-      submissionIds: [ {type: ObjectId, ref: 'Submission'} ]
+      submissionIds: [ {type: ObjectId, ref: 'Submission'} ],
+      userOnly: { type: Boolean }
     },
     folders: { type: Number, enum: [0, 1, 2, 3, 4] },
     comments: { type: Number, enum: [0, 1, 2, 3, 4] },

--- a/server/middleware/access/submissions.js
+++ b/server/middleware/access/submissions.js
@@ -15,7 +15,7 @@ const accessibleSubmissionsQuery = async function(user, ids) {
 
     let filter = {
       $and: [
-        { isTrashed: false }
+        { isTrashed: { $ne: true } }
       ]
     };
 

--- a/test/mocha/copyWorkspaceTest.js
+++ b/test/mocha/copyWorkspaceTest.js
@@ -63,23 +63,23 @@ describe(`Copy Workspace operations by account type`, function () {
       }
       */
       // return array [ copyWorkspaceRequest, hash of expected lengths]
-      function buildShallowRequest(settings, workspace, answerIds = null, doIncludeFolders = false) {
+      function buildShallowRequest(settings, workspace, submissionIds = null, doIncludeFolders = false) {
         let { newOwnerId, newWsName, newMode, permissions } = settings;
         if (!Array.isArray(permissions)) {
           permissions = [];
         }
 
-        let includeAllAnswers;
+        let includeAllSubmissions;
         let subsLength;
         let foldersLength;
 
-        if (Array.isArray(answerIds)) {
-          includeAllAnswers = false;
-          subsLength = answerIds.length;
+        if (Array.isArray(submissionIds)) {
+          includeAllSubmissions = false;
+          subsLength = submissionIds.length;
         } else {
-          includeAllAnswers = true;
+          includeAllSubmissions = true;
           subsLength = workspace.submissions.length;
-          answerIds = [];
+          submissionIds = [];
         }
 
         if (doIncludeFolders) {
@@ -105,9 +105,9 @@ describe(`Copy Workspace operations by account type`, function () {
               owner: newOwnerId,
               name: newWsName,
               mode: newMode,
-              answerOptions: {
-                all: includeAllAnswers,
-                answerIds: answerIds
+              submissionOptions: {
+                all: includeAllSubmissions,
+                submissionIds: submissionIds
               },
               folderOptions: {
                 includeStructureOnly: true,
@@ -137,25 +137,25 @@ describe(`Copy Workspace operations by account type`, function () {
         ];
       }
 
-      function buildDeepCloneRequest(settings, workspace, expectedLengths, answerIds = null, doIncludeFolders = true) {
+      function buildDeepCloneRequest(settings, workspace, expectedLengths, submissionIds = null, doIncludeFolders = true) {
         let { newOwnerId, newWsName, newMode, permissions } = settings;
         if (!Array.isArray(permissions)) {
           permissions = [];
         }
 
-        let includeAllAnswers;
+        let includeAllSubmissions;
         let subsLength;
         let foldersLength;
 
         let { taggings, selections, comments, responses } = expectedLengths;
 
-        if (Array.isArray(answerIds)) {
-          includeAllAnswers = false;
-          subsLength = answerIds.length;
+        if (Array.isArray(submissionIds)) {
+          includeAllSubmissions = false;
+          subsLength = submissionIds.length;
         } else {
-          includeAllAnswers = true;
+          includeAllSubmissions = true;
           subsLength = workspace.submissions.length;
-          answerIds = [];
+          submissionIds = [];
         }
 
         if (doIncludeFolders) {
@@ -181,9 +181,9 @@ describe(`Copy Workspace operations by account type`, function () {
               owner: newOwnerId,
               name: newWsName,
               mode: newMode,
-              answerOptions: {
-                all: includeAllAnswers,
-                answerIds: answerIds
+              submissionOptions: {
+                all: includeAllSubmissions,
+                submissionIds: submissionIds
               },
               folderOptions: {
                 includeStructureOnly: false,
@@ -212,6 +212,61 @@ describe(`Copy Workspace operations by account type`, function () {
 
         ];
       }
+
+      function buildCustomRequest(settings, workspace, customConfig, expectedLengths, existingFolderSetInfo) {
+        let { newOwnerId, newWsName, newMode, permissions } = settings;
+
+        if (!Array.isArray(permissions)) {
+          permissions = [];
+        }
+        let { submissionOptions, folderOptions } = customConfig;
+        let subsLength, foldersLength;
+
+        if (submissionOptions.all === true) {
+          subsLength = workspace.submissions.length;
+        } else {
+          subsLength = submissionOptions.submissionIds.length;
+        }
+        if (folderOptions.all === true) {
+          foldersLength = workspace.folders.length;
+        } else if (existingFolderSetInfo) {
+          foldersLength = existingFolderSetInfo.numFolders;
+        } else {
+          foldersLength = 0;
+        }
+
+        let { taggings, selections, comments, responses } = expectedLengths;
+
+        let lengths = {
+          submissions: subsLength,
+          taggings: taggings,
+          selections: selections,
+          comments: comments,
+          responses: responses,
+          folders: foldersLength,
+          permissions: permissions.length
+        };
+
+        let customRequest = {};
+
+        let target = {
+          originalWsId: workspace._id,
+          owner: newOwnerId,
+          name: newWsName,
+          mode: newMode,
+          permissionOptions: {
+            permissionObjects: permissions
+          }
+      };
+
+        let combined = Object.assign(target, customConfig);
+        customRequest.copyWorkspaceRequest = combined;
+        return [
+          customRequest,
+          lengths
+        ];
+      }
+
       function makeCopyRequestAsync(request, expectedCollectionLengths) {
         try {
           let newWs;
@@ -394,7 +449,7 @@ describe(`Copy Workspace operations by account type`, function () {
         describe('Copying Subset of Submissions', function () {
           describe('Not Including Folders', function () {
             describe('Current user as owner', function () {
-              let answerIds = ["5bec35898c73047613e2f34b"];
+              let submissionIds = ["5bec36958c73047613e2f34d"];
 
               let settings = {
                 newOwnerId: _id,
@@ -402,11 +457,11 @@ describe(`Copy Workspace operations by account type`, function () {
                 newMode: originalWs.mode,
                 permissions: []
               };
-              let [request, lengths] = buildShallowRequest(settings, originalWs, answerIds);
+              let [request, lengths] = buildShallowRequest(settings, originalWs, submissionIds);
               makeCopyRequestAsync(request, lengths);
             });
             describe('Student as owner', function () {
-              let answerIds = ["5bec35898c73047613e2f34b"];
+              let submissionIds = ["5bec36958c73047613e2f34d"];
 
               let settings = {
                 newOwnerId: studentOwner,
@@ -415,11 +470,11 @@ describe(`Copy Workspace operations by account type`, function () {
                 newMode: originalWs.mode,
                 permissions: []
               };
-              let [request, lengths] = buildShallowRequest(settings, originalWs, answerIds);
+              let [request, lengths] = buildShallowRequest(settings, originalWs, submissionIds);
               makeCopyRequestAsync(request, lengths);
             });
             describe('Student as editor', function () {
-              let answerIds = ["5bec35898c73047613e2f34b"];
+              let submissionIds = ["5bec36958c73047613e2f34d"];
 
               let settings = {
                 newOwnerId: _id,
@@ -432,11 +487,11 @@ describe(`Copy Workspace operations by account type`, function () {
 
                 }]
               };
-              let [request, lengths] = buildShallowRequest(settings, originalWs, answerIds);
+              let [request, lengths] = buildShallowRequest(settings, originalWs, submissionIds);
               makeCopyRequestAsync(request, lengths);
             });
             describe('Student as view only collaborator', function () {
-              let answerIds = ["5bec35898c73047613e2f34b"];
+              let submissionIds = ["5bec36958c73047613e2f34d"];
 
               let settings = {
                 newOwnerId: _id,
@@ -449,14 +504,14 @@ describe(`Copy Workspace operations by account type`, function () {
 
                 }]
               };
-              let [request, lengths] = buildShallowRequest(settings, originalWs, answerIds);
+              let [request, lengths] = buildShallowRequest(settings, originalWs, submissionIds);
               makeCopyRequestAsync(request, lengths);
             });
           });
 
           describe('Including Folders', function () {
             describe('Current user as owner', function () {
-              let answerIds = ["5bec35898c73047613e2f34b"];
+              let submissionIds = ["5bec36958c73047613e2f34d"];
 
               let settings = {
                 newOwnerId: _id,
@@ -464,11 +519,11 @@ describe(`Copy Workspace operations by account type`, function () {
                 newMode: originalWs.mode,
                 permissions: []
               };
-              let [request, lengths] = buildShallowRequest(settings, originalWs, answerIds, true);
+              let [request, lengths] = buildShallowRequest(settings, originalWs, submissionIds, true);
               makeCopyRequestAsync(request, lengths);
             });
             describe('Student as owner', function () {
-              let answerIds = ["5bec35898c73047613e2f34b"];
+              let submissionIds = ["5bec36958c73047613e2f34d"];
 
               let settings = {
                 newOwnerId: studentOwner,
@@ -477,11 +532,11 @@ describe(`Copy Workspace operations by account type`, function () {
                 newMode: originalWs.mode,
                 permissions: []
               };
-              let [request, lengths] = buildShallowRequest(settings, originalWs, answerIds, true);
+              let [request, lengths] = buildShallowRequest(settings, originalWs, submissionIds, true);
               makeCopyRequestAsync(request, lengths);
             });
             describe('Student as editor', function () {
-              let answerIds = ["5bec35898c73047613e2f34b"];
+              let submissionIds = ["5bec36958c73047613e2f34d"];
 
               let settings = {
                 newOwnerId: _id,
@@ -494,11 +549,11 @@ describe(`Copy Workspace operations by account type`, function () {
 
                 }]
               };
-              let [request, lengths] = buildShallowRequest(settings, originalWs, answerIds, true);
+              let [request, lengths] = buildShallowRequest(settings, originalWs, submissionIds, true);
               makeCopyRequestAsync(request, lengths);
             });
             describe('Student as view only collaborator', function () {
-              let answerIds = ["5bec35898c73047613e2f34b"];
+              let submissionIds = ["5bec36958c73047613e2f34d"];
 
               let settings = {
                 newOwnerId: _id,
@@ -511,7 +566,7 @@ describe(`Copy Workspace operations by account type`, function () {
 
                 }]
               };
-              let [request, lengths] = buildShallowRequest(settings, originalWs, answerIds, true);
+              let [request, lengths] = buildShallowRequest(settings, originalWs, submissionIds, true);
               makeCopyRequestAsync(request, lengths);
             });
           });
@@ -535,8 +590,6 @@ describe(`Copy Workspace operations by account type`, function () {
                 newMode: originalWs.mode,
                 permissions: []
               };
-              //         let { taggings, selections, comments, responses } = expectedLengths;
-
 
               let [request, lengths] = buildDeepCloneRequest(settings, originalWs, expectedLengths);
               makeCopyRequestAsync(request, lengths);
@@ -598,8 +651,6 @@ describe(`Copy Workspace operations by account type`, function () {
                 newMode: originalWs.mode,
                 permissions: []
               };
-              //         let { taggings, selections, comments, responses } = expectedLengths;
-
 
               let [request, lengths] = buildDeepCloneRequest(settings, originalWs, expectedLengths, null, false);
               makeCopyRequestAsync(request, lengths);
@@ -645,7 +696,7 @@ describe(`Copy Workspace operations by account type`, function () {
           });
         });
         describe('Copying Subset of Submissions', function () {
-          let answerIds = ["5bb813fc9885323f6d894972"];
+          let submissionIds = ["5bec36958c73047613e2f34c"];
           describe('Including Folders', function () {
             let expectedLengths = {
               taggings: 2,
@@ -663,7 +714,7 @@ describe(`Copy Workspace operations by account type`, function () {
               //         let { taggings, selections, comments, responses } = expectedLengths;
 
 
-              let [request, lengths] = buildDeepCloneRequest(settings, originalWs, expectedLengths, answerIds);
+              let [request, lengths] = buildDeepCloneRequest(settings, originalWs, expectedLengths, submissionIds);
               makeCopyRequestAsync(request, lengths);
             });
 
@@ -674,7 +725,7 @@ describe(`Copy Workspace operations by account type`, function () {
                 newMode: originalWs.mode,
                 permissions: []
               };
-              let [request, lengths] = buildDeepCloneRequest(settings, originalWs, expectedLengths, answerIds);
+              let [request, lengths] = buildDeepCloneRequest(settings, originalWs, expectedLengths, submissionIds);
               makeCopyRequestAsync(request, lengths);
             });
 
@@ -690,7 +741,7 @@ describe(`Copy Workspace operations by account type`, function () {
 
                 }]
               };
-              let [request, lengths] = buildDeepCloneRequest(settings, originalWs, expectedLengths, answerIds);
+              let [request, lengths] = buildDeepCloneRequest(settings, originalWs, expectedLengths, submissionIds);
               makeCopyRequestAsync(request, lengths);
 
 
@@ -707,7 +758,7 @@ describe(`Copy Workspace operations by account type`, function () {
 
                 }]
               };
-              let [request, lengths] = buildDeepCloneRequest(settings, originalWs, expectedLengths, answerIds);
+              let [request, lengths] = buildDeepCloneRequest(settings, originalWs, expectedLengths, submissionIds);
               makeCopyRequestAsync(request, lengths);
 
 
@@ -728,7 +779,7 @@ describe(`Copy Workspace operations by account type`, function () {
                 permissions: []
               };
 
-              let [request, lengths] = buildDeepCloneRequest(settings, originalWs, expectedLengths, answerIds, false);
+              let [request, lengths] = buildDeepCloneRequest(settings, originalWs, expectedLengths, submissionIds, false);
               makeCopyRequestAsync(request, lengths);
             });
 
@@ -739,7 +790,7 @@ describe(`Copy Workspace operations by account type`, function () {
                 newMode: originalWs.mode,
                 permissions: []
               };
-              let [request, lengths] = buildDeepCloneRequest(settings, originalWs, expectedLengths, answerIds, false);
+              let [request, lengths] = buildDeepCloneRequest(settings, originalWs, expectedLengths, submissionIds, false);
               makeCopyRequestAsync(request, lengths);
             });
 
@@ -753,7 +804,7 @@ describe(`Copy Workspace operations by account type`, function () {
                   global: 'editor'
                 }]
               };
-              let [request, lengths] = buildDeepCloneRequest(settings, originalWs, expectedLengths, answerIds, false);
+              let [request, lengths] = buildDeepCloneRequest(settings, originalWs, expectedLengths, submissionIds, false);
               makeCopyRequestAsync(request, lengths);
             });
             describe('Student as view only collaborator', function () {
@@ -766,9 +817,3475 @@ describe(`Copy Workspace operations by account type`, function () {
                   global: 'viewOnly'
                 }]
               };
-              let [request, lengths] = buildDeepCloneRequest(settings, originalWs, expectedLengths, answerIds, false);
+              let [request, lengths] = buildDeepCloneRequest(settings, originalWs, expectedLengths, submissionIds, false);
               makeCopyRequestAsync(request, lengths);
             });
+          });
+        });
+      });
+
+      describe('Custom Requests', function() {
+        describe('Copying All Submissions', function () {
+          describe('Including Folders', function () {
+            describe('Including structure only', function() {
+              describe('All Selections, Comments, and Responses', function() {
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: originalWs.selections.length,
+                  comments: originalWs.comments.length,
+                  responses: originalWs.responses.length
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    all: true,
+                },
+                folderOptions: {
+                  includeStructureOnly: true,
+                  folderSetOptions: {
+                    doCreateFolderSet: false,
+                  },
+                  all: true,
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  all: true,
+
+                },
+                responseOptions: {
+                  all: true
+                }
+              };
+                describe('Current user as owner', function () {
+                  let settings = {
+                    newOwnerId: _id,
+                    newWsName: newWsName,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as owner', function () {
+                  let settings = {
+                    newOwnerId: studentOwner,
+                    newWsName: `Tracy's copy`,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as editor', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'editor'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+                describe('Student as view only collaborator', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'viewOnly'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+              });
+              describe('All Selections and Comments with No Responses', function() {
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: originalWs.selections.length,
+                  comments: originalWs.comments.length,
+                  responses: 0
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    all: true,
+                },
+                folderOptions: {
+                  includeStructureOnly: true,
+                  folderSetOptions: {
+                    doCreateFolderSet: false,
+                  },
+                  all: true,
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  all: true,
+
+                },
+                responseOptions: {
+                  none: true
+                }
+              };
+                describe('Current user as owner', function () {
+                  let settings = {
+                    newOwnerId: _id,
+                    newWsName: newWsName,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as owner', function () {
+                  let settings = {
+                    newOwnerId: studentOwner,
+                    newWsName: `Tracy's copy`,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as editor', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'editor'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+                describe('Student as view only collaborator', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'viewOnly'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+              });
+              describe('All Selections with No Comments and No Responses', function() {
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: originalWs.selections.length,
+                  comments: 0,
+                  responses: 0
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    all: true,
+                },
+                folderOptions: {
+                  includeStructureOnly: true,
+                  folderSetOptions: {
+                    doCreateFolderSet: false,
+                  },
+                  all: true,
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  none: true
+                },
+                responseOptions: {
+                  none: true
+                }
+              };
+                describe('Current user as owner', function () {
+                  let settings = {
+                    newOwnerId: _id,
+                    newWsName: newWsName,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as owner', function () {
+                  let settings = {
+                    newOwnerId: studentOwner,
+                    newWsName: `Tracy's copy`,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as editor', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'editor'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+                describe('Student as view only collaborator', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'viewOnly'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+              });
+              describe('Subset of selections with all comments/responses', function() {
+                const selectionIds = ["5bec373d8c73047613e2f35c", "5bec37a78c73047613e2f365"];
+                const associatedCommentIds = ["5bec375d8c73047613e2f35e","5bec37e38c73047613e2f366"];
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: selectionIds.length,
+                  comments: associatedCommentIds.length,
+                  responses: originalWs.responses.length
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    all: true,
+                },
+                folderOptions: {
+                  includeStructureOnly: true,
+                  folderSetOptions: {
+                    doCreateFolderSet: false,
+                  },
+                  all: true,
+                },
+                selectionOptions: {
+                  all: false,
+                  selectionIds
+                },
+                commentOptions: {
+                  all: true,
+
+                },
+                responseOptions: {
+                  all: true
+                }
+              };
+              describe('Current user as owner', function () {
+                let settings = {
+                  newOwnerId: _id,
+                  newWsName: newWsName,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+                //         let { taggings, selections, comments, responses } = expectedLengths;
+
+
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as owner', function () {
+                let settings = {
+                  newOwnerId: studentOwner,
+                  newWsName: `Tracy's copy`,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as editor', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'editor'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+              describe('Student as view only collaborator', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'viewOnly'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+              });
+              describe('Subset of comments with all selections/responses', function() {
+                // const selectionIds = ["5bec373d8c73047613e2f35c", "5bec37a78c73047613e2f365"];
+                const commentIds = ["5bec37708c73047613e2f35f","5bec37a08c73047613e2f364"];
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: originalWs.selections.length,
+                  comments: commentIds.length,
+                  responses: originalWs.responses.length
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    all: true,
+                },
+                folderOptions: {
+                  includeStructureOnly: true,
+                  folderSetOptions: {
+                    doCreateFolderSet: false,
+                  },
+                  all: true,
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  all: false,
+                  commentIds
+                },
+                responseOptions: {
+                  all: true
+                }
+              };
+              describe('Current user as owner', function () {
+                let settings = {
+                  newOwnerId: _id,
+                  newWsName: newWsName,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+                //         let { taggings, selections, comments, responses } = expectedLengths;
+
+
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as owner', function () {
+                let settings = {
+                  newOwnerId: studentOwner,
+                  newWsName: `Tracy's copy`,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as editor', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'editor'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+              describe('Student as view only collaborator', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'viewOnly'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+              });
+            });
+            describe('Including Folder Contents', function() {
+              describe('All Selections, Comments, and Responses', function() {
+                let expectedLengths = {
+                  taggings: originalWs.taggings.length,
+                  selections: originalWs.selections.length,
+                  comments: originalWs.comments.length,
+                  responses: originalWs.responses.length
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    all: true,
+                },
+                folderOptions: {
+                  includeStructureOnly: false,
+                  folderSetOptions: {
+                    doCreateFolderSet: false,
+                  },
+                  all: true,
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  all: true,
+
+                },
+                responseOptions: {
+                  all: true
+                }
+              };
+                describe('Current user as owner', function () {
+                  let settings = {
+                    newOwnerId: _id,
+                    newWsName: newWsName,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as owner', function () {
+                  let settings = {
+                    newOwnerId: studentOwner,
+                    newWsName: `Tracy's copy`,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as editor', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'editor'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+                describe('Student as view only collaborator', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'viewOnly'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+              });
+              describe('All Selections and Comments with No Responses', function() {
+                let expectedLengths = {
+                  taggings: originalWs.taggings.length,
+                  selections: originalWs.selections.length,
+                  comments: originalWs.comments.length,
+                  responses: 0
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    all: true,
+                },
+                folderOptions: {
+                  includeStructureOnly: false,
+                  folderSetOptions: {
+                    doCreateFolderSet: false,
+                  },
+                  all: true,
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  all: true,
+
+                },
+                responseOptions: {
+                  none: true
+                }
+              };
+                describe('Current user as owner', function () {
+                  let settings = {
+                    newOwnerId: _id,
+                    newWsName: newWsName,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as owner', function () {
+                  let settings = {
+                    newOwnerId: studentOwner,
+                    newWsName: `Tracy's copy`,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as editor', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'editor'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+                describe('Student as view only collaborator', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'viewOnly'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+              });
+              describe('All Selections with No Comments and No Responses', function() {
+                let expectedLengths = {
+                  taggings: originalWs.taggings.length,
+                  selections: originalWs.selections.length,
+                  comments: 0,
+                  responses: 0
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    all: true,
+                },
+                folderOptions: {
+                  includeStructureOnly: false,
+                  folderSetOptions: {
+                    doCreateFolderSet: false,
+                  },
+                  all: true,
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  none: true
+                },
+                responseOptions: {
+                  none: true
+                }
+              };
+                describe('Current user as owner', function () {
+                  let settings = {
+                    newOwnerId: _id,
+                    newWsName: newWsName,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as owner', function () {
+                  let settings = {
+                    newOwnerId: studentOwner,
+                    newWsName: `Tracy's copy`,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as editor', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'editor'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+                describe('Student as view only collaborator', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'viewOnly'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+              });
+              describe('Subset of selections with all comments/responses', function() {
+                const selectionIds = ["5bec373d8c73047613e2f35c", "5bec37a78c73047613e2f365"];
+                const associatedCommentIds = ["5bec375d8c73047613e2f35e","5bec37e38c73047613e2f366"];
+                const associatedTaggingIds = ["5bec37f48c73047613e2f367", "5bec38338c73047613e2f36b"];
+                let expectedLengths = {
+                  taggings: associatedTaggingIds.length,
+                  selections: selectionIds.length,
+                  comments: associatedCommentIds.length,
+                  responses: originalWs.responses.length
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    all: true,
+                },
+                folderOptions: {
+                  includeStructureOnly: false,
+                  folderSetOptions: {
+                    doCreateFolderSet: false,
+                  },
+                  all: true,
+                },
+                selectionOptions: {
+                  all: false,
+                  selectionIds
+                },
+                commentOptions: {
+                  all: true,
+                },
+                responseOptions: {
+                  all: true
+                }
+              };
+              describe('Current user as owner', function () {
+                let settings = {
+                  newOwnerId: _id,
+                  newWsName: newWsName,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+                //         let { taggings, selections, comments, responses } = expectedLengths;
+
+
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as owner', function () {
+                let settings = {
+                  newOwnerId: studentOwner,
+                  newWsName: `Tracy's copy`,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as editor', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'editor'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+              describe('Student as view only collaborator', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'viewOnly'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+              });
+              describe('Subset of comments with all selections/responses', function() {
+                // const selectionIds = ["5bec373d8c73047613e2f35c", "5bec37a78c73047613e2f365"];
+                const commentIds = ["5bec37708c73047613e2f35f","5bec37a08c73047613e2f364"];
+                let expectedLengths = {
+                  taggings: originalWs.taggings.length,
+                  selections: originalWs.selections.length,
+                  comments: commentIds.length,
+                  responses: originalWs.responses.length
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    all: true,
+                },
+                folderOptions: {
+                  includeStructureOnly: false,
+                  folderSetOptions: {
+                    doCreateFolderSet: false,
+                  },
+                  all: true,
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  all: false,
+                  commentIds
+                },
+                responseOptions: {
+                  all: true
+                }
+              };
+              describe('Current user as owner', function () {
+                let settings = {
+                  newOwnerId: _id,
+                  newWsName: newWsName,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+                //         let { taggings, selections, comments, responses } = expectedLengths;
+
+
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as owner', function () {
+                let settings = {
+                  newOwnerId: studentOwner,
+                  newWsName: `Tracy's copy`,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as editor', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'editor'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+              describe('Student as view only collaborator', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'viewOnly'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+              });
+            });
+
+          });
+
+          describe('Not Including Folders', function() {
+            describe('Using Existing Folder Set', function() {
+              const folderSetInfo = {
+                folderSetId: "5bec409176124a776f2ff00e",
+                numFolders: 9
+              };
+
+              describe('All Selections, Comments, and Responses', function() {
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: originalWs.selections.length,
+                  comments: originalWs.comments.length,
+                  responses: originalWs.responses.length,
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    all: true,
+                },
+                folderOptions: {
+                  folderSetOptions: {
+                    existingFolderSetToUse: folderSetInfo.folderSetId,
+                  },
+                  all: false,
+                  none: true
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  all: true,
+
+                },
+                responseOptions: {
+                  all: true
+                }
+              };
+                describe('Current user as owner', function () {
+                  let settings = {
+                    newOwnerId: _id,
+                    newWsName: newWsName,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as owner', function () {
+                  let settings = {
+                    newOwnerId: studentOwner,
+                    newWsName: `Tracy's copy`,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as editor', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'editor'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                  makeCopyRequestAsync(request, lengths);
+                });
+                describe('Student as view only collaborator', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'viewOnly'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                  makeCopyRequestAsync(request, lengths);
+                });
+              });
+              describe('All Selections and Comments with No Responses', function() {
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: originalWs.selections.length,
+                  comments: originalWs.comments.length,
+                  responses: 0
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    all: true,
+                },
+                folderOptions: {
+                  folderSetOptions: {
+                    existingFolderSetToUse: folderSetInfo.folderSetId,
+                  },
+                  all: false,
+                  none: true
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  all: true,
+
+                },
+                responseOptions: {
+                  none: true
+                }
+              };
+                describe('Current user as owner', function () {
+                  let settings = {
+                    newOwnerId: _id,
+                    newWsName: newWsName,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as owner', function () {
+                  let settings = {
+                    newOwnerId: studentOwner,
+                    newWsName: `Tracy's copy`,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as editor', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'editor'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                  makeCopyRequestAsync(request, lengths);
+                });
+                describe('Student as view only collaborator', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'viewOnly'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                  makeCopyRequestAsync(request, lengths);
+                });
+              });
+              describe('All Selections with No Comments and No Responses', function() {
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: originalWs.selections.length,
+                  comments: 0,
+                  responses: 0
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    all: true,
+                },
+                folderOptions: {
+                  folderSetOptions: {
+                    existingFolderSetToUse: folderSetInfo.folderSetId,
+                  },
+                  all: false,
+                  none: true
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  none: true
+                },
+                responseOptions: {
+                  none: true
+                }
+              };
+                describe('Current user as owner', function () {
+                  let settings = {
+                    newOwnerId: _id,
+                    newWsName: newWsName,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as owner', function () {
+                  let settings = {
+                    newOwnerId: studentOwner,
+                    newWsName: `Tracy's copy`,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as editor', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'editor'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                  makeCopyRequestAsync(request, lengths);
+                });
+                describe('Student as view only collaborator', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'viewOnly'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                  makeCopyRequestAsync(request, lengths);
+                });
+              });
+              describe('Subset of selections with all comments/responses', function() {
+                const selectionIds = ["5bec373d8c73047613e2f35c", "5bec37a78c73047613e2f365"];
+                const associatedCommentIds = ["5bec375d8c73047613e2f35e","5bec37e38c73047613e2f366"];
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: selectionIds.length,
+                  comments: associatedCommentIds.length,
+                  responses: originalWs.responses.length
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    all: true,
+                },
+                folderOptions: {
+                  folderSetOptions: {
+                    existingFolderSetToUse: folderSetInfo.folderSetId,
+                  },
+                  all: false,
+                  none: true
+                },
+                selectionOptions: {
+                  all: false,
+                  selectionIds
+                },
+                commentOptions: {
+                  all: true,
+
+                },
+                responseOptions: {
+                  all: true
+                }
+              };
+              describe('Current user as owner', function () {
+                let settings = {
+                  newOwnerId: _id,
+                  newWsName: newWsName,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as owner', function () {
+                let settings = {
+                  newOwnerId: studentOwner,
+                  newWsName: `Tracy's copy`,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as editor', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'editor'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                makeCopyRequestAsync(request, lengths);
+              });
+              describe('Student as view only collaborator', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'viewOnly'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                makeCopyRequestAsync(request, lengths);
+              });
+              });
+              describe('Subset of comments with all selections/responses', function() {
+                // const selectionIds = ["5bec373d8c73047613e2f35c", "5bec37a78c73047613e2f365"];
+                const commentIds = ["5bec37708c73047613e2f35f","5bec37a08c73047613e2f364"];
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: originalWs.selections.length,
+                  comments: commentIds.length,
+                  responses: originalWs.responses.length
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    all: true,
+                },
+                folderOptions: {
+                  folderSetOptions: {
+                    existingFolderSetToUse: folderSetInfo.folderSetId,
+                  },
+                  all: false,
+                  none: true
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  all: false,
+                  commentIds
+                },
+                responseOptions: {
+                  all: true
+                }
+              };
+              describe('Current user as owner', function () {
+                let settings = {
+                  newOwnerId: _id,
+                  newWsName: newWsName,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as owner', function () {
+                let settings = {
+                  newOwnerId: studentOwner,
+                  newWsName: `Tracy's copy`,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as editor', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'editor'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                makeCopyRequestAsync(request, lengths);
+              });
+              describe('Student as view only collaborator', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'viewOnly'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                makeCopyRequestAsync(request, lengths);
+              });
+              });
+            });
+            describe('Not Using Existing Folder Set', function() {
+              describe('All Selections, Comments, and Responses', function() {
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: originalWs.selections.length,
+                  comments: originalWs.comments.length,
+                  responses: originalWs.responses.length,
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    all: true,
+                },
+                folderOptions: {
+                  folderSetOptions: {
+                    existingFolderSetToUse: null,
+                  },
+                  all: false,
+                  none: true
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  all: true,
+
+                },
+                responseOptions: {
+                  all: true
+                }
+              };
+                describe('Current user as owner', function () {
+                  let settings = {
+                    newOwnerId: _id,
+                    newWsName: newWsName,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as owner', function () {
+                  let settings = {
+                    newOwnerId: studentOwner,
+                    newWsName: `Tracy's copy`,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as editor', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'editor'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+                describe('Student as view only collaborator', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'viewOnly'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+              });
+              describe('All Selections and Comments with No Responses', function() {
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: originalWs.selections.length,
+                  comments: originalWs.comments.length,
+                  responses: 0
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    all: true,
+                },
+                folderOptions: {
+                  folderSetOptions: {
+                    existingFolderSetToUse: null,
+                  },
+                  all: false,
+                  none: true
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  all: true,
+
+                },
+                responseOptions: {
+                  none: true
+                }
+              };
+                describe('Current user as owner', function () {
+                  let settings = {
+                    newOwnerId: _id,
+                    newWsName: newWsName,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as owner', function () {
+                  let settings = {
+                    newOwnerId: studentOwner,
+                    newWsName: `Tracy's copy`,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as editor', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'editor'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+                describe('Student as view only collaborator', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'viewOnly'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+              });
+              describe('All Selections with No Comments and No Responses', function() {
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: originalWs.selections.length,
+                  comments: 0,
+                  responses: 0
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    all: true,
+                },
+                folderOptions: {
+                  folderSetOptions: {
+                    existingFolderSetToUse: null,
+                  },
+                  all: false,
+                  none: true
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  none: true
+                },
+                responseOptions: {
+                  none: true
+                }
+              };
+                describe('Current user as owner', function () {
+                  let settings = {
+                    newOwnerId: _id,
+                    newWsName: newWsName,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as owner', function () {
+                  let settings = {
+                    newOwnerId: studentOwner,
+                    newWsName: `Tracy's copy`,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as editor', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'editor'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+                describe('Student as view only collaborator', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'viewOnly'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+              });
+              describe('Subset of selections with all comments/responses', function() {
+                const selectionIds = ["5bec373d8c73047613e2f35c", "5bec37a78c73047613e2f365"];
+                const associatedCommentIds = ["5bec375d8c73047613e2f35e","5bec37e38c73047613e2f366"];
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: selectionIds.length,
+                  comments: associatedCommentIds.length,
+                  responses: originalWs.responses.length
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    all: true,
+                },
+                folderOptions: {
+                  folderSetOptions: {
+                    existingFolderSetToUse: null,
+                  },
+                  all: false,
+                  none: true
+                },
+                selectionOptions: {
+                  all: false,
+                  selectionIds
+                },
+                commentOptions: {
+                  all: true,
+
+                },
+                responseOptions: {
+                  all: true
+                }
+              };
+              describe('Current user as owner', function () {
+                let settings = {
+                  newOwnerId: _id,
+                  newWsName: newWsName,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+                //         let { taggings, selections, comments, responses } = expectedLengths;
+
+
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as owner', function () {
+                let settings = {
+                  newOwnerId: studentOwner,
+                  newWsName: `Tracy's copy`,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as editor', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'editor'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+              describe('Student as view only collaborator', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'viewOnly'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+              });
+              describe('Subset of comments with all selections/responses', function() {
+                // const selectionIds = ["5bec373d8c73047613e2f35c", "5bec37a78c73047613e2f365"];
+                const commentIds = ["5bec37708c73047613e2f35f","5bec37a08c73047613e2f364"];
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: originalWs.selections.length,
+                  comments: commentIds.length,
+                  responses: originalWs.responses.length
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    all: true,
+                },
+                folderOptions: {
+                  folderSetOptions: {
+                    existingFolderSetToUse: null,
+                  },
+                  all: false,
+                  none: true
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  all: false,
+                  commentIds
+                },
+                responseOptions: {
+                  all: true
+                }
+              };
+              describe('Current user as owner', function () {
+                let settings = {
+                  newOwnerId: _id,
+                  newWsName: newWsName,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+                //         let { taggings, selections, comments, responses } = expectedLengths;
+
+
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as owner', function () {
+                let settings = {
+                  newOwnerId: studentOwner,
+                  newWsName: `Tracy's copy`,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as editor', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'editor'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+              describe('Student as view only collaborator', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'viewOnly'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+              });
+            });
+
+          });
+        });
+        describe('Copying Subset of Submissions', function() {
+          let submissionIds = [ "5bec36958c73047613e2f34d"];
+          let allSelectionIds = ["5bec37838c73047613e2f361", "5bec37a78c73047613e2f365"];
+          let allResponseIds = ["5bec6497aa4a927d50cd5b9b"];
+          let allCommentIds = ["5bec37a08c73047613e2f364", "5bec37e38c73047613e2f366"];
+          let allTaggingIds = ["5bec37f48c73047613e2f367","5bec38018c73047613e2f368"];
+          describe('Including Folders', function () {
+            describe('Including structure only', function() {
+              describe('All Selections, Comments, and Responses', function() {
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: allSelectionIds.length,
+                  comments: allCommentIds.length,
+                  responses: allResponseIds.length
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    submissionIds,
+                },
+                folderOptions: {
+                  includeStructureOnly: true,
+                  folderSetOptions: {
+                    doCreateFolderSet: false,
+                  },
+                  all: true,
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  all: true,
+
+                },
+                responseOptions: {
+                  all: true
+                }
+              };
+                describe('Current user as owner', function () {
+                  let settings = {
+                    newOwnerId: _id,
+                    newWsName: newWsName,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as owner', function () {
+                  let settings = {
+                    newOwnerId: studentOwner,
+                    newWsName: `Tracy's copy`,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as editor', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'editor'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+                describe('Student as view only collaborator', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'viewOnly'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+              });
+              describe('All Selections and Comments with No Responses', function() {
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: allSelectionIds.length,
+                  comments: allCommentIds.length,
+                  responses: 0
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    submissionIds
+                },
+                folderOptions: {
+                  includeStructureOnly: true,
+                  folderSetOptions: {
+                    doCreateFolderSet: false,
+                  },
+                  all: true,
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  all: true,
+
+                },
+                responseOptions: {
+                  none: true
+                }
+              };
+                describe('Current user as owner', function () {
+                  let settings = {
+                    newOwnerId: _id,
+                    newWsName: newWsName,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as owner', function () {
+                  let settings = {
+                    newOwnerId: studentOwner,
+                    newWsName: `Tracy's copy`,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as editor', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'editor'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+                describe('Student as view only collaborator', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'viewOnly'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+              });
+              describe('All Selections with No Comments and No Responses', function() {
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: allSelectionIds.length,
+                  comments: 0,
+                  responses: 0
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    submissionIds
+                },
+                folderOptions: {
+                  includeStructureOnly: true,
+                  folderSetOptions: {
+                    doCreateFolderSet: false,
+                  },
+                  all: true,
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  none: true
+                },
+                responseOptions: {
+                  none: true
+                }
+              };
+                describe('Current user as owner', function () {
+                  let settings = {
+                    newOwnerId: _id,
+                    newWsName: newWsName,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as owner', function () {
+                  let settings = {
+                    newOwnerId: studentOwner,
+                    newWsName: `Tracy's copy`,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as editor', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'editor'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+                describe('Student as view only collaborator', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'viewOnly'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+              });
+              describe('Subset of selections with all comments/responses', function() {
+                const selectionIds = ["5bec37838c73047613e2f361"];
+                const associatedCommentIds = ["5bec37a08c73047613e2f364"];
+                const associatedResponseIds = ["5bec36958c73047613e2f34d"];
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: selectionIds.length,
+                  comments: associatedCommentIds.length,
+                  responses: associatedResponseIds.length
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    submissionIds
+                },
+                folderOptions: {
+                  includeStructureOnly: true,
+                  folderSetOptions: {
+                    doCreateFolderSet: false,
+                  },
+                  all: true,
+                },
+                selectionOptions: {
+                  all: false,
+                  selectionIds
+                },
+                commentOptions: {
+                  all: true,
+
+                },
+                responseOptions: {
+                  all: true
+                }
+              };
+              describe('Current user as owner', function () {
+                let settings = {
+                  newOwnerId: _id,
+                  newWsName: newWsName,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+                //         let { taggings, selections, comments, responses } = expectedLengths;
+
+
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as owner', function () {
+                let settings = {
+                  newOwnerId: studentOwner,
+                  newWsName: `Tracy's copy`,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as editor', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'editor'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+              describe('Student as view only collaborator', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'viewOnly'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+              });
+              describe('Subset of comments with all selections/responses', function() {
+                // const selectionIds = ["5bec373d8c73047613e2f35c", "5bec37a78c73047613e2f365"];
+                const commentIds = ["5bec37a08c73047613e2f364"];
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: allSelectionIds.length,
+                  comments: commentIds.length,
+                  responses: allResponseIds.length
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    submissionIds
+                },
+                folderOptions: {
+                  includeStructureOnly: true,
+                  folderSetOptions: {
+                    doCreateFolderSet: false,
+                  },
+                  all: true,
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  all: false,
+                  commentIds
+                },
+                responseOptions: {
+                  all: true
+                }
+              };
+              describe('Current user as owner', function () {
+                let settings = {
+                  newOwnerId: _id,
+                  newWsName: newWsName,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+                //         let { taggings, selections, comments, responses } = expectedLengths;
+
+
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as owner', function () {
+                let settings = {
+                  newOwnerId: studentOwner,
+                  newWsName: `Tracy's copy`,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as editor', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'editor'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+              describe('Student as view only collaborator', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'viewOnly'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+              });
+            });
+            describe('Including Folder Contents', function() {
+              describe('All Selections, Comments, and Responses', function() {
+                let expectedLengths = {
+                  taggings: allTaggingIds.length,
+                  selections: allSelectionIds.length,
+                  comments: allCommentIds.length,
+                  responses: allResponseIds.length
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    submissionIds
+                },
+                folderOptions: {
+                  includeStructureOnly: false,
+                  folderSetOptions: {
+                    doCreateFolderSet: false,
+                  },
+                  all: true,
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  all: true,
+
+                },
+                responseOptions: {
+                  all: true
+                }
+              };
+                describe('Current user as owner', function () {
+                  let settings = {
+                    newOwnerId: _id,
+                    newWsName: newWsName,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as owner', function () {
+                  let settings = {
+                    newOwnerId: studentOwner,
+                    newWsName: `Tracy's copy`,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as editor', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'editor'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+                describe('Student as view only collaborator', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'viewOnly'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+              });
+              describe('All Selections and Comments with No Responses', function() {
+                let expectedLengths = {
+                  taggings: allTaggingIds.length,
+                  selections: allSelectionIds.length,
+                  comments: allCommentIds.length,
+                  responses: 0
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    submissionIds,
+                },
+                folderOptions: {
+                  includeStructureOnly: false,
+                  folderSetOptions: {
+                    doCreateFolderSet: false,
+                  },
+                  all: true,
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  all: true,
+
+                },
+                responseOptions: {
+                  none: true
+                }
+              };
+                describe('Current user as owner', function () {
+                  let settings = {
+                    newOwnerId: _id,
+                    newWsName: newWsName,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as owner', function () {
+                  let settings = {
+                    newOwnerId: studentOwner,
+                    newWsName: `Tracy's copy`,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as editor', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'editor'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+                describe('Student as view only collaborator', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'viewOnly'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+              });
+              describe('All Selections with No Comments and No Responses', function() {
+                let expectedLengths = {
+                  taggings: allTaggingIds.length,
+                  selections: allSelectionIds.length,
+                  comments: 0,
+                  responses: 0
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    submissionIds,
+                },
+                folderOptions: {
+                  includeStructureOnly: false,
+                  folderSetOptions: {
+                    doCreateFolderSet: false,
+                  },
+                  all: true,
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  none: true
+                },
+                responseOptions: {
+                  none: true
+                }
+              };
+                describe('Current user as owner', function () {
+                  let settings = {
+                    newOwnerId: _id,
+                    newWsName: newWsName,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as owner', function () {
+                  let settings = {
+                    newOwnerId: studentOwner,
+                    newWsName: `Tracy's copy`,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as editor', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'editor'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+                describe('Student as view only collaborator', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'viewOnly'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+              });
+              describe('Subset of selections with all comments/responses', function() {
+                const selectionIds = ["5bec37838c73047613e2f361"];
+                const associatedCommentIds = ["5bec37a08c73047613e2f364"];
+                const associatedResponseIds = ["5bec36958c73047613e2f34d"];
+                const associatedTaggingIds = ["5bec38018c73047613e2f368"];
+                let expectedLengths = {
+                  taggings: associatedTaggingIds.length,
+                  selections: selectionIds.length,
+                  comments: associatedCommentIds.length,
+                  responses: associatedResponseIds.length
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    submissionIds,
+                },
+                folderOptions: {
+                  includeStructureOnly: false,
+                  folderSetOptions: {
+                    doCreateFolderSet: false,
+                  },
+                  all: true,
+                },
+                selectionOptions: {
+                  all: false,
+                  selectionIds
+                },
+                commentOptions: {
+                  all: true,
+                },
+                responseOptions: {
+                  all: true
+                }
+              };
+              describe('Current user as owner', function () {
+                let settings = {
+                  newOwnerId: _id,
+                  newWsName: newWsName,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as owner', function () {
+                let settings = {
+                  newOwnerId: studentOwner,
+                  newWsName: `Tracy's copy`,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as editor', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'editor'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+              describe('Student as view only collaborator', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'viewOnly'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+              });
+              describe('Subset of comments with all selections/responses', function() {
+                // const selectionIds = ["5bec373d8c73047613e2f35c", "5bec37a78c73047613e2f365"];
+                const commentIds = ["5bec37a08c73047613e2f364"];
+                let expectedLengths = {
+                  taggings: allTaggingIds.length,
+                  selections: allSelectionIds.length,
+                  comments: commentIds.length,
+                  responses: allResponseIds.length
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    submissionIds
+                },
+                folderOptions: {
+                  includeStructureOnly: false,
+                  folderSetOptions: {
+                    doCreateFolderSet: false,
+                  },
+                  all: true,
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  all: false,
+                  commentIds
+                },
+                responseOptions: {
+                  all: true
+                }
+              };
+              describe('Current user as owner', function () {
+                let settings = {
+                  newOwnerId: _id,
+                  newWsName: newWsName,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as owner', function () {
+                let settings = {
+                  newOwnerId: studentOwner,
+                  newWsName: `Tracy's copy`,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as editor', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'editor'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+              describe('Student as view only collaborator', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'viewOnly'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+              });
+            });
+
+          });
+
+          describe('Not Including Folders', function() {
+            describe('Using Existing Folder Set', function() {
+              const folderSetInfo = {
+                folderSetId: "5bec409176124a776f2ff00e",
+                numFolders: 9
+              };
+
+              describe('All Selections, Comments, and Responses', function() {
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: allSelectionIds.length,
+                  comments: allCommentIds.length,
+                  responses: allResponseIds.length,
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    submissionIds
+                },
+                folderOptions: {
+                  folderSetOptions: {
+                    existingFolderSetToUse: folderSetInfo.folderSetId,
+                  },
+                  all: false,
+                  none: true
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  all: true,
+
+                },
+                responseOptions: {
+                  all: true
+                }
+              };
+                describe('Current user as owner', function () {
+                  let settings = {
+                    newOwnerId: _id,
+                    newWsName: newWsName,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as owner', function () {
+                  let settings = {
+                    newOwnerId: studentOwner,
+                    newWsName: `Tracy's copy`,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as editor', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'editor'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                  makeCopyRequestAsync(request, lengths);
+                });
+                describe('Student as view only collaborator', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'viewOnly'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                  makeCopyRequestAsync(request, lengths);
+                });
+              });
+              describe('All Selections and Comments with No Responses', function() {
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: allSelectionIds.length,
+                  comments: allCommentIds.length,
+                  responses: 0
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    submissionIds
+                },
+                folderOptions: {
+                  folderSetOptions: {
+                    existingFolderSetToUse: folderSetInfo.folderSetId,
+                  },
+                  all: false,
+                  none: true
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  all: true,
+
+                },
+                responseOptions: {
+                  none: true
+                }
+              };
+                describe('Current user as owner', function () {
+                  let settings = {
+                    newOwnerId: _id,
+                    newWsName: newWsName,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as owner', function () {
+                  let settings = {
+                    newOwnerId: studentOwner,
+                    newWsName: `Tracy's copy`,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as editor', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'editor'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                  makeCopyRequestAsync(request, lengths);
+                });
+                describe('Student as view only collaborator', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'viewOnly'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                  makeCopyRequestAsync(request, lengths);
+                });
+              });
+              describe('All Selections with No Comments and No Responses', function() {
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: allSelectionIds.length,
+                  comments: 0,
+                  responses: 0
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    submissionIds
+                },
+                folderOptions: {
+                  folderSetOptions: {
+                    existingFolderSetToUse: folderSetInfo.folderSetId,
+                  },
+                  all: false,
+                  none: true
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  none: true
+                },
+                responseOptions: {
+                  none: true
+                }
+              };
+                describe('Current user as owner', function () {
+                  let settings = {
+                    newOwnerId: _id,
+                    newWsName: newWsName,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as owner', function () {
+                  let settings = {
+                    newOwnerId: studentOwner,
+                    newWsName: `Tracy's copy`,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as editor', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'editor'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                  makeCopyRequestAsync(request, lengths);
+                });
+                describe('Student as view only collaborator', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'viewOnly'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                  makeCopyRequestAsync(request, lengths);
+                });
+              });
+              describe('Subset of selections with all comments/responses', function() {
+                const selectionIds = ["5bec37838c73047613e2f361"];
+                const associatedCommentIds = ["5bec37a08c73047613e2f364"];
+                const associatedResponseIds = ["5bec36958c73047613e2f34d"];
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: selectionIds.length,
+                  comments: associatedCommentIds.length,
+                  responses: associatedResponseIds.length
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    submissionIds
+                },
+                folderOptions: {
+                  folderSetOptions: {
+                    existingFolderSetToUse: folderSetInfo.folderSetId,
+                  },
+                  all: false,
+                  none: true
+                },
+                selectionOptions: {
+                  all: false,
+                  selectionIds
+                },
+                commentOptions: {
+                  all: true,
+
+                },
+                responseOptions: {
+                  all: true
+                }
+              };
+              describe('Current user as owner', function () {
+                let settings = {
+                  newOwnerId: _id,
+                  newWsName: newWsName,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as owner', function () {
+                let settings = {
+                  newOwnerId: studentOwner,
+                  newWsName: `Tracy's copy`,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as editor', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'editor'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                makeCopyRequestAsync(request, lengths);
+              });
+              describe('Student as view only collaborator', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'viewOnly'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                makeCopyRequestAsync(request, lengths);
+              });
+              });
+              describe('Subset of comments with all selections/responses', function() {
+                // const selectionIds = ["5bec373d8c73047613e2f35c", "5bec37a78c73047613e2f365"];
+                const commentIds = ["5bec37a08c73047613e2f364"];
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: allSelectionIds.length,
+                  comments: commentIds.length,
+                  responses: allResponseIds.length
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    submissionIds
+                },
+                folderOptions: {
+                  folderSetOptions: {
+                    existingFolderSetToUse: folderSetInfo.folderSetId,
+                  },
+                  all: false,
+                  none: true
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  all: false,
+                  commentIds
+                },
+                responseOptions: {
+                  all: true
+                }
+              };
+              describe('Current user as owner', function () {
+                let settings = {
+                  newOwnerId: _id,
+                  newWsName: newWsName,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as owner', function () {
+                let settings = {
+                  newOwnerId: studentOwner,
+                  newWsName: `Tracy's copy`,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as editor', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'editor'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                makeCopyRequestAsync(request, lengths);
+              });
+              describe('Student as view only collaborator', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'viewOnly'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths, folderSetInfo);
+                makeCopyRequestAsync(request, lengths);
+              });
+              });
+            });
+            describe('Not Using Existing Folder Set', function() {
+              describe('All Selections, Comments, and Responses', function() {
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: allSelectionIds.length,
+                  comments: allCommentIds.length,
+                  responses: allResponseIds.length,
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    submissionIds
+                },
+                folderOptions: {
+                  folderSetOptions: {
+                    existingFolderSetToUse: null,
+                  },
+                  all: false,
+                  none: true
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  all: true,
+
+                },
+                responseOptions: {
+                  all: true
+                }
+              };
+                describe('Current user as owner', function () {
+                  let settings = {
+                    newOwnerId: _id,
+                    newWsName: newWsName,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as owner', function () {
+                  let settings = {
+                    newOwnerId: studentOwner,
+                    newWsName: `Tracy's copy`,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as editor', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'editor'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+                describe('Student as view only collaborator', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'viewOnly'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+              });
+              describe('All Selections and Comments with No Responses', function() {
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: allSelectionIds.length,
+                  comments: allCommentIds.length,
+                  responses: 0
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    submissionIds,
+                },
+                folderOptions: {
+                  folderSetOptions: {
+                    existingFolderSetToUse: null,
+                  },
+                  all: false,
+                  none: true
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  all: true,
+
+                },
+                responseOptions: {
+                  none: true
+                }
+              };
+                describe('Current user as owner', function () {
+                  let settings = {
+                    newOwnerId: _id,
+                    newWsName: newWsName,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as owner', function () {
+                  let settings = {
+                    newOwnerId: studentOwner,
+                    newWsName: `Tracy's copy`,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as editor', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'editor'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+                describe('Student as view only collaborator', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'viewOnly'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+              });
+              describe('All Selections with No Comments and No Responses', function() {
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: allSelectionIds.length,
+                  comments: 0,
+                  responses: 0
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    submissionIds
+                },
+                folderOptions: {
+                  folderSetOptions: {
+                    existingFolderSetToUse: null,
+                  },
+                  all: false,
+                  none: true
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  none: true
+                },
+                responseOptions: {
+                  none: true
+                }
+              };
+                describe('Current user as owner', function () {
+                  let settings = {
+                    newOwnerId: _id,
+                    newWsName: newWsName,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as owner', function () {
+                  let settings = {
+                    newOwnerId: studentOwner,
+                    newWsName: `Tracy's copy`,
+                    newMode: originalWs.mode,
+                    permissions: []
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+
+                describe('Student as editor', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'editor'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+                describe('Student as view only collaborator', function () {
+                  let settings = {
+                    newOwnerId: _id,
+
+                    newWsName: `Tracy as Editor`,
+                    newMode: originalWs.mode,
+                    permissions: [{
+                      user: studentOwner,
+                      global: 'viewOnly'
+
+                    }]
+                  };
+                  let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                  makeCopyRequestAsync(request, lengths);
+                });
+              });
+              describe('Subset of selections with all comments/responses', function() {
+                const selectionIds = ["5bec37838c73047613e2f361"];
+                const associatedCommentIds = ["5bec37a08c73047613e2f364"];
+                const associatedResponseIds = ["5bec36958c73047613e2f34d"];
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: selectionIds.length,
+                  comments: associatedCommentIds.length,
+                  responses: associatedResponseIds.length
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    submissionIds,
+                },
+                folderOptions: {
+                  folderSetOptions: {
+                    existingFolderSetToUse: null,
+                  },
+                  all: false,
+                  none: true
+                },
+                selectionOptions: {
+                  all: false,
+                  selectionIds
+                },
+                commentOptions: {
+                  all: true,
+
+                },
+                responseOptions: {
+                  all: true
+                }
+              };
+              describe('Current user as owner', function () {
+                let settings = {
+                  newOwnerId: _id,
+                  newWsName: newWsName,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as owner', function () {
+                let settings = {
+                  newOwnerId: studentOwner,
+                  newWsName: `Tracy's copy`,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as editor', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'editor'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+              describe('Student as view only collaborator', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'viewOnly'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+              });
+              describe('Subset of comments with all selections/responses', function() {
+                // const selectionIds = ["5bec373d8c73047613e2f35c", "5bec37a78c73047613e2f365"];
+                const commentIds = ["5bec37a08c73047613e2f364"];
+                let expectedLengths = {
+                  taggings: 0,
+                  selections: allSelectionIds.length,
+                  comments: commentIds.length,
+                  responses: allResponseIds.length
+                };
+
+                let customConfig = {
+                  submissionOptions: {
+                    submissionIds,
+                },
+                folderOptions: {
+                  folderSetOptions: {
+                    existingFolderSetToUse: null,
+                  },
+                  all: false,
+                  none: true
+                },
+                selectionOptions: {
+                  all: true
+                },
+                commentOptions: {
+                  all: false,
+                  commentIds
+                },
+                responseOptions: {
+                  all: true
+                }
+              };
+              describe('Current user as owner', function () {
+                let settings = {
+                  newOwnerId: _id,
+                  newWsName: newWsName,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+                //         let { taggings, selections, comments, responses } = expectedLengths;
+
+
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as owner', function () {
+                let settings = {
+                  newOwnerId: studentOwner,
+                  newWsName: `Tracy's copy`,
+                  newMode: originalWs.mode,
+                  permissions: []
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+
+              describe('Student as editor', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'editor'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+              describe('Student as view only collaborator', function () {
+                let settings = {
+                  newOwnerId: _id,
+
+                  newWsName: `Tracy as Editor`,
+                  newMode: originalWs.mode,
+                  permissions: [{
+                    user: studentOwner,
+                    global: 'viewOnly'
+
+                  }]
+                };
+                let [request, lengths] = buildCustomRequest(settings, originalWs, customConfig, expectedLengths);
+                makeCopyRequestAsync(request, lengths);
+              });
+              });
+            });
+
           });
         });
       });


### PR DESCRIPTION
Refactored copyWorkspaceRequest to use array of submissionIds instead of answerIds 
Added api tests for copyWorkspaceRequests

Minor tweaks/cleanup to copy-workspace process

Added validation of mongoose objectIds when using mongoose.Types.ObjectId(value) in sortWorkspaces api function

Improved the editing of collaborators from workspace-info page 

