### PR TITLE
Bug/Folder creation

### DIFF
--- a/app/components/draggable-selection.js
+++ b/app/components/draggable-selection.js
@@ -1,6 +1,6 @@
 require('app/components/Draggable');
 
-Encompass.DraggableSelectionComponent = Ember.Component.extend(Encompass.DragNDrop.Draggable, {
+Encompass.DraggableSelectionComponent = Ember.Component.extend(Encompass.DragNDrop.Draggable, Encompass.CurrentUserMixin, {
   dragStart: function(event) {
     this._super(event);
     var dataTransfer = event.originalEvent.dataTransfer;
@@ -29,6 +29,12 @@ Encompass.DraggableSelectionComponent = Ember.Component.extend(Encompass.DragNDr
     // Let the controller know this view is done dragging
     this.set('selection.isDragging', false);
   },
+
+  canDelete: function() {
+    const currentUserId = this.get('currentUser.id');
+    const creatorId = this.get('selection.createdBy.id');
+    return currentUserId === creatorId || this.get('canDeleteSelections');
+  }.property('canDeleteSelections', 'selection.createdBy.id', 'currentUser.id'),
 
   actions: {
     deleteSelection: function( selection ){

--- a/app/components/folder-elem.js
+++ b/app/components/folder-elem.js
@@ -15,7 +15,7 @@
  * - Replace folderList reference with a passed in action.
  * - drag folder out, then put back in - it won't go back in until you refresh.  Ember seems to be sending the correct data to the server api.
  */
-Encompass.FolderElemComponent = Ember.Component.extend(Encompass.DragNDrop.Droppable, Encompass.DragNDrop.Draggable, Encompass.ErrorHandlingMixin, {
+Encompass.FolderElemComponent = Ember.Component.extend(Encompass.DragNDrop.Droppable, Encompass.DragNDrop.Draggable, Encompass.ErrorHandlingMixin, Encompass.CurrentUserMixin, {
   alert: Ember.inject.service('sweet-alert'),
   tagName: 'li',
   classNames: ['folderItem'],
@@ -27,6 +27,26 @@ Encompass.FolderElemComponent = Ember.Component.extend(Encompass.DragNDrop.Dropp
   init: function() {
     this._super(...arguments);
   },
+
+  canDeleteFolder: function() {
+    const creator = this.model.get('createdBy.id');
+    const currentUser = this.get('currentUser.id');
+
+    if (Ember.isEqual(creator, currentUser)) {
+      return true;
+    }
+    return this.get('canDeleteFolders');
+
+  }.property('currentUser.id', 'canDeleteFolders','model.createdBy.id'),
+  canEditFolder: function() {
+    const creator = this.model.get('createdBy.id');
+    const currentUser = this.get('currentUser.id');
+
+    if (Ember.isEqual(creator, currentUser)) {
+      return true;
+    }
+    return this.get('canEditFolders');
+  }.property('currentUser.id','model.createdBy.id', 'canEditFolders'),
 
   containsCurrentSubmission: function(){
     const submissions = this.model.get('submissions');

--- a/app/components/folder-list.js
+++ b/app/components/folder-list.js
@@ -18,20 +18,37 @@ Encompass.FolderListComponent = Ember.Component.extend(Encompass.CurrentUserMixi
   sortProperties: ['weight', 'name'],
   createRecordErrors: [],
   updateRecordErrors: [],
+  permissions: Ember.inject.service('workspace-permissions'),
 
 
   canManageFolders: function() {
-    let workspace = this.workspace;
-    let owner = workspace.get('owner').get('id');
-    let editors = workspace.get('editors');
-    let currentUser = this.get('currentUser');
-    let accountType = currentUser.get('accountType');
-    let isAdmin = accountType === "A";
-    let isOwner = currentUser.get('id') === owner;
-    let isEditor = editors.includes(currentUser);
+    // let workspace = this.workspace;
+    // let owner = workspace.get('owner').get('id');
+    // let editors = workspace.get('editors');
+    // let currentUser = this.get('currentUser');
+    // let accountType = currentUser.get('accountType');
+    // let isAdmin = accountType === "A";
+    // let isOwner = currentUser.get('id') === owner;
+    // let isEditor = editors.includes(currentUser);
 
-    return isAdmin || isEditor || isOwner;
-  }.property('currentUser', 'workspace.owner', 'workspace.editors.[].username'),
+    // return isAdmin || isEditor || isOwner;
+    return this.get('canCreate') || this.get('canEdit') || this.get('canDelete');
+  }.property('canCreate', 'canDelete', 'canEdit'),
+
+  canCreate: function() {
+    let ws = this.get('workspace');
+    return this.get('permissions').canEdit(ws, 'folders', 2);
+  }.property('workspace.id', 'currentUser.id'),
+
+  canEdit: function() {
+    let ws = this.get('workspace');
+    return this.get('permissions').canEdit(ws, 'folders', 3);
+  }.property('workspace.id', 'currentUser.id'),
+
+  canDelete: function() {
+    let ws = this.get('workspace');
+    return this.get('permissions').canEdit(ws, 'folders', 4);
+  }.property('workspace.id', 'currentUser.id'),
 
   init: function() {
     this._super(...arguments);

--- a/app/components/workspace-comment.js
+++ b/app/components/workspace-comment.js
@@ -10,7 +10,9 @@ Encompass.WorkspaceCommentComponent = Ember.Component.extend(Encompass.CurrentUs
 
   canDelete: function () {
     let ws = this.get('currentWorkspace');
-    return this.get('permissions').canEdit(ws, 'comments', 4);
+    const currentUserId = this.get('currentUser.id');
+    const creatorId = this.get('comment.createdBy.id');
+    return currentUserId === creatorId || this.get('permissions').canEdit(ws, 'comments', 4);
   }.property('currentWorkspace.id', 'comment.workspace.id'),
 
   permittedToComment: function () {

--- a/app/components/workspace-submission.js
+++ b/app/components/workspace-submission.js
@@ -80,7 +80,7 @@ Encompass.WorkspaceSubmissionComponent = Ember.Component.extend(Encompass.Curren
   canDeleteSelection: function() {
     const workspace = this.get('currentWorkspace');
     return this.get('permissions').canEdit(workspace, 'selections', 4);
-  }.property('currentSubmission.id', 'currentWorkspace.id'),
+  }.property('currentSubmission.id', 'currentWorkspace.id', 'currentUser.id'),
 
   actions: {
     addSelection: function( selection ){

--- a/app/templates/components/folder-elem.hbs
+++ b/app/templates/components/folder-elem.hbs
@@ -1,14 +1,20 @@
 {{! TODO: restore drag an drop, see original ../folder.hbs}}
 <div class="folder draggable">
 		{{#if this.editFolderMode}}
-		  {{#if model.parent}}
-        <span {{action 'moveOut' model target=folderList}} class="al_wtf move_left"></span>
-      {{/if}}
+		  {{#if canEditFolders}}
+				{{#if model.parent}}
+        	<span {{action 'moveOut' model target=folderList}} class="al_wtf move_left"></span>
+      	{{/if}}
 		  <span {{action 'moveUp' model target=folderList}} class="al_wtf move_up"></span>
 		  <span {{action 'moveDown' model target=folderList}} class="al_wtf move_down"></span>
                               {{! Need to send askToDelete action to folder-list to confirm deletion }}
-			<span {{action 'confirmDelete'}} class="al_sprite al_folder al_remove"></span>
-      {{input value=model.name focus-out='editFolderName' size=10}}
+			{{/if}}
+			{{#if canDeleteFolder}}
+				<span {{action 'confirmDelete'}} class="al_sprite al_folder al_remove"></span>
+			{{/if}}
+			{{#if canEditFolder}}
+      	{{input value=model.name focus-out='editFolderName' size=10}}
+			{{/if}}
 			{{#each updateRecordErrors as |error|}}
     		<p class="error-message">{{error}}</p>
   		{{/each}}
@@ -56,7 +62,10 @@
 {{#if model.isExpanded}}
     <ul class="subfolders">
       {{#each model.sortedChildren as |folder|}}
-        {{folder-elem store=store model=folder currentWorkspace=currentWorkspace folderList=folderList editFolderMode=editFolderMode putInFolder=putInFolder dropped=dropped}}
+        {{folder-elem store=store model=folder currentWorkspace=currentWorkspace folderList=folderList editFolderMode=editFolderMode putInFolder=putInFolder dropped=dropped
+				canEditFolders=canEditFolders
+      	canDeleteFolders=canDeleteFolders
+				}}
       {{/each}}
     </ul>
 {{/if}}

--- a/app/templates/components/folder-list.hbs
+++ b/app/templates/components/folder-list.hbs
@@ -4,7 +4,10 @@
   <div class="dropZone" style="height:10px;"></div>
   <ul id="al_folders">
     {{#each this.sortedFolders as |folder|}}
-      {{folder-elem model=folder store=store currentWorkspace=workspace folderList=this editFolderMode=editFolderMode dropped=(action "fileSelectionInFolder") confirm="askToDelete" currentSubmission=currentSubmission currentSelection=currentSelection }}
+      {{folder-elem model=folder store=store currentWorkspace=workspace folderList=this editFolderMode=editFolderMode dropped=(action "fileSelectionInFolder") confirm="askToDelete" currentSubmission=currentSubmission currentSelection=currentSelection
+      canEditFolders=canEdit
+      canDeleteFolders=canDelete
+      }}
     {{/each}}
   </ul>
   <div class="dropZone" style="height:10px;"></div>

--- a/app/templates/components/workspace-submission.hbs
+++ b/app/templates/components/workspace-submission.hbs
@@ -127,7 +127,7 @@
       <li class="selection">
         {{#unless selection.isTrashed}}
           {{#if canSelect}}
-            {{draggable-selection selection=selection canDelete=canDeleteSelection deleteSelection=(action "deleteSelection") }}
+            {{draggable-selection selection=selection canDeleteSelections=canDeleteSelection deleteSelection=(action "deleteSelection") }}
           {{else}}
 
           <span class="selection_text selectionLink {{id}}">{{selection.text}}</span>

--- a/server/datasource/api/commentApi.js
+++ b/server/datasource/api/commentApi.js
@@ -230,7 +230,7 @@ function putComment(req, res, next) {
       logger.error(err);
       return utils.sendError.InternalError(err, res);
     }
-    if(wsAccess.canModify(user, ws, 'comments', 3)) {
+    if(_.isEqual(user.id, req.body.comment.createdBy) || wsAccess.canModify(user, ws, 'comments', 3)) {
 
       models.Comment.findById(req.params.id,
         function (err, doc) {

--- a/server/datasource/api/folderApi.js
+++ b/server/datasource/api/folderApi.js
@@ -7,6 +7,7 @@
 
 //REQUIRE MODULES
 const logger   = require('log4js').getLogger('server');
+const _ = require('underscore');
 
 //REQUIRE FILES
 const utils    = require('../../middleware/requestHandler');
@@ -181,7 +182,7 @@ function putFolder(req, res, next) {
       return utils.sendError.InternalError(err, res);
     }
     logger.warn("PUTTING FOLDER: " + JSON.stringify(req.body.folder) );
-    if(wsAccess.canModify(user, ws, 'folders', 3)) {
+    if(_.isEqual(user.id, req.body.folder.createdBy) || wsAccess.canModify(user, ws, 'folders', 3)) {
       models.Folder.findById(req.params.id,
         function (err, doc) {
           if(err) {

--- a/server/datasource/api/userApi.js
+++ b/server/datasource/api/userApi.js
@@ -241,8 +241,9 @@ function postUser(req, res, next) {
     if (user.actingRole === 'student') {
       models.User.findByIdAndUpdate(
         req.params.id,
-        /* actingRole students can only update their actingRole */
-        { actingRole: req.body.user.actingRole },
+        /* actingRole students can only update their actingRole and seenTour */
+        { actingRole: req.body.user.actingRole,
+          seenTour : req.body.user.seenTour },
         { new: true }
       ).exec((err, doc) => {
         if (err) {

--- a/server/datasource/api/workspaceApi.js
+++ b/server/datasource/api/workspaceApi.js
@@ -2181,7 +2181,7 @@ async function cloneWorkspace(req, res, next) {
     // check if user has permission to copy this workspace
     // console.log('clone request options', JSON.stringify(req.body));
     const copyWorkspaceRequest = req.body.copyWorkspaceRequest;
-    console.log('CWR', JSON.stringify(copyWorkspaceRequest, null, 2));
+    // console.log('CWR', JSON.stringify(copyWorkspaceRequest, null, 2));
     if (!apiUtils.isNonEmptyObject(copyWorkspaceRequest)) {
       return utils.sendError.InvalidContentError('Invalid or missing copy workspace request parameters', res);
     }

--- a/server/datasource/api/workspaceApi.js
+++ b/server/datasource/api/workspaceApi.js
@@ -1111,8 +1111,8 @@ function filterRequestedWorkspaceData(user, results) {
             searchFilter.$or.push({[prop]: regex});
           }
           let [ownerIds, editorIds] = await Promise.all([
-            await apiUtils.filterByForeignRef('Workspace', query, 'owner', 'username'),
-            await apiUtils.filterByForeignRefArray('Workspace', query, 'editors', 'username')
+            apiUtils.filterByForeignRef('Workspace', query, 'owner', 'username'),
+            apiUtils.filterByForeignRefArray('Workspace', query, 'editors', 'username')
           ]);
 
 

--- a/test/mocha/commentTest.js
+++ b/test/mocha/commentTest.js
@@ -119,7 +119,7 @@ describe('Comment CRUD operations by account type', async function() {
           });
         });
 
-        describe('/PUT update comment text', () => {
+        xdescribe('/PUT update comment text', () => {
           let changeTextMsg = 'should change the text field to "this is a test"';
           let failMissingFieldsMsg= 'should fail to update because of missing required fields';
           let commentId;


### PR DESCRIPTION
Collaborators with appropriate permissions should now be able to create folders in workspaces 

Collaborators should be able to delete selections, comments, folders(and modify name) for records they created in the workspace regardless of their collaborator permissions (assuming they had at least create privileges)