### PR TITLE
Submission viewer

### DIFF
--- a/app/components/workspace-new-container.js
+++ b/app/components/workspace-new-container.js
@@ -10,7 +10,6 @@ Encompass.WorkspaceNewContainerComponent = Ember.Component.extend(Encompass.Curr
   answerToDelete: null,
   alert: Ember.inject.service('sweet-alert'),
   selectedAnswers: [],
-  doIncludeRevisions: false,
   currentStep: 1,
   showSubmissionViewer: Ember.computed.equal('currentStep', 1),
   showWorkspaceSettingsMenu: Ember.computed.equal('currentStep', 2),
@@ -21,9 +20,9 @@ Encompass.WorkspaceNewContainerComponent = Ember.Component.extend(Encompass.Curr
   selectedTeacher: null,
   selectedStudents: [],
   dateRange: '',
-
-  searchOptions: ['all'],
-  searchCriterion: 'all',
+  doIncludeRevisions: Ember.computed.equal('selectedRevisionOption', 'All Revisions'),
+  revisionsSelectOptions: ['All Revisions', 'Newest Only'],
+  selectedRevisionOption: 'All Revisions',
   sortCriterion: { name: 'A-Z', sortParam: { student: 1 }, doCollate: true, type: 'student' },
   sortOptions: {
     student: [

--- a/app/components/workspace-new-container.js
+++ b/app/components/workspace-new-container.js
@@ -129,6 +129,30 @@ Encompass.WorkspaceNewContainerComponent = Ember.Component.extend(Encompass.Curr
 
   }.property('criteriaTooExclusive', 'isDisplayingSearchResults', 'answers.@each.isTrashed', 'isFetchingAnswers', 'showLoadingMessage'),
 
+  getMostRecentAnswers: function(answers) {
+    if (!_.isArray(answers)) {
+      return [];
+    }
+    const threads = Ember.Map.create();
+
+    answers
+      .sortBy('student')
+      .getEach('student')
+      .uniq()
+      .forEach((student) => {
+        if(!threads.has(student)) {
+          const answers = this.studentWork(student);
+          threads.set(student, answers);
+        }
+      });
+
+      let results = [];
+      threads.forEach((answers) => {
+        results.addObject(answers.get('lastObject'));
+      });
+      return results;
+  },
+
 
   init: function() {
     this.getUserOrg()
@@ -579,7 +603,7 @@ Encompass.WorkspaceNewContainerComponent = Ember.Component.extend(Encompass.Curr
         return;
       }
 
-      const { requestedName, owner, mode, folderSet, permissionObjects } = settings;
+      const { requestedName, owner, mode, folderSet, permissionObjects, submissionSettings } = settings;
       if (utils.isNonEmptyArray(permissionObjects)) {
         permissionObjects.forEach((obj) => {
           if (obj.user && obj.user.get('id') ) {
@@ -589,6 +613,11 @@ Encompass.WorkspaceNewContainerComponent = Ember.Component.extend(Encompass.Curr
       }
       if (!utils.isNonEmptyArray(answers)) {
         return;
+      }
+
+      if (submissionSettings === 'mostRecent') {
+        // only include most recent submission
+        answers = this.getMostRecentAnswers(answers);
       }
       let criteria = {
         answers,

--- a/app/components/workspace-new-container.js
+++ b/app/components/workspace-new-container.js
@@ -516,11 +516,27 @@ Encompass.WorkspaceNewContainerComponent = Ember.Component.extend(Encompass.Curr
       if (!answer) {
         return;
       }
+      let isShowingRevisions = this.get('doIncludeRevisions');
+      // if showing revisions, only add or remove selected answer
+      // otherwise add or remove all revisions
       if (isChecked === true) {
-        this.get('selectedAnswers').removeObject(answer);
+        if (isShowingRevisions) {
+          this.get('selectedAnswers').removeObject(answer);
+          return;
+        }
+        let student = answer.get('student');
+        let revisions = this.get('submissionThreads').get(student);
+        this.get('selectedAnswers').removeObjects(revisions);
       }
       if (isChecked === false) {
-        this.get('selectedAnswers').addObject(answer);
+
+        if (isShowingRevisions) {
+          this.get('selectedAnswers').addObject(answer);
+          return;
+        }
+        let student = answer.get('student');
+        let revisions = this.get('submissionThreads').get(student);
+        this.get('selectedAnswers').addObjects(revisions);
       }
     },
     toggleIncludeRevisions() {

--- a/app/components/workspace-new-container.js
+++ b/app/components/workspace-new-container.js
@@ -22,7 +22,7 @@ Encompass.WorkspaceNewContainerComponent = Ember.Component.extend(Encompass.Curr
   dateRange: '',
   doIncludeRevisions: Ember.computed.equal('selectedRevisionOption', 'All Revisions'),
   revisionsSelectOptions: ['All Revisions', 'Newest Only'],
-  selectedRevisionOption: 'All Revisions',
+  selectedRevisionOption: 'Newest Only',
   sortCriterion: { name: 'A-Z', sortParam: { student: 1 }, doCollate: true, type: 'student' },
   sortOptions: {
     student: [

--- a/app/components/workspace-new-settings.js
+++ b/app/components/workspace-new-settings.js
@@ -7,6 +7,7 @@ Encompass.WorkspaceNewSettingsComponent = Ember.Component.extend(Encompass.Curre
   isEditingPermissions: false,
   unsavedCollaborator: null,
   selectedMode: 'private',
+  selectedSubmissionSettings: 'all',
 
   validModeValues: function() {
     const modeInputs = this.get('modeInputs.inputs');
@@ -39,6 +40,22 @@ Encompass.WorkspaceNewSettingsComponent = Ember.Component.extend(Encompass.Curre
     return res;
 
   }.property('validModeValues', 'doCreateFolderSet'),
+  submissionSettingsInputs: {
+    groupName: 'submissionSettings',
+    required: true,
+    inputs: [
+      {
+        value: 'all',
+        label: 'All Submissions',
+        moreInfo: 'Workspace will include all revisions',
+      },
+      {
+        value: 'mostRecent',
+        label: 'Most Recent Only',
+        moreInfo: 'Workspace will only include submissions of record',
+      },
+    ]
+  },
   modeInputs: function() {
     let res = {
       groupName: 'mode',
@@ -115,6 +132,7 @@ Encompass.WorkspaceNewSettingsComponent = Ember.Component.extend(Encompass.Curre
       const privacySetting = this.get('selectedMode');
       const folderSet = this.get('selectedFolderSet');
       const permissions = this.get('workspacePermissions');
+      const submissionSettings = this.get('selectedSubmissionSettings');
 
       errors = window.validate({workspaceName, owner, privacySetting}, this.get('constraints'));
 
@@ -132,7 +150,8 @@ Encompass.WorkspaceNewSettingsComponent = Ember.Component.extend(Encompass.Curre
         owner,
         mode: privacySetting,
         folderSet,
-        permissionObjects: permissions
+        permissionObjects: permissions,
+        submissionSettings
       };
 
       if (this.get('isEditingPermissions')) {

--- a/app/templates/components/workspace-new-container.hbs
+++ b/app/templates/components/workspace-new-container.hbs
@@ -25,7 +25,7 @@
     <div class="flex-item-full list-view">
       <div class="list-container">
         <h1>Submissions</h1>
-        <div class="searchbar">
+        {{!-- <div class="searchbar">
           {{search-bar
             onSearch=(action "searchAnswers")
             showFilter=true
@@ -36,7 +36,7 @@
             selectedCriterion=searchCriterion
             }}
 
-        </div>
+        </div> --}}
       </div>
       <div class="results-list">
         <div class="results-info">
@@ -61,10 +61,9 @@
             {{/if}}
           </div>
           <div class="side-icons">
-            <label class="show-revisions">
-              <input type="checkbox" checked={{doIncludeRevisions}} onclick={{action "toggleIncludeRevisions"}}>
-              Show All Revisions
-            </label>
+            <div class="select-bar">
+              {{my-select content=revisionsSelectOptions cannotBeNull=true selectedValue=selectedRevisionOption action=(action (mut selectedRevisionOption))}}
+            </div>
             <i class="fas fa-redo-alt refresh-icon" {{action 'refreshList'}} title="Refresh Submission list"></i>
           </div>
         </div>

--- a/app/templates/components/workspace-new-settings.hbs
+++ b/app/templates/components/workspace-new-settings.hbs
@@ -80,6 +80,15 @@
     {{/each}}
   </div>
 
+  <div class="ws-new submission-settings">
+    <p class="input-label">
+      Submission Settings
+      <span class="info-text-tip simptip-position-right simptip-multiline simptip-smooth" data-tooltip="Choose whether to include all revisions or just submissions of record">
+        <i class="fas fa-info-circle info-icon"></i>
+      </span>
+    </p>
+    {{radio-group options=submissionSettingsInputs selectedValue=selectedSubmissionSettings}}
+  </div>
   {{ws-new-settings-permissions permissions=workspacePermissions store=store users=users isEditing=isEditingPermissions selectedCollaborator = unsavedCollaborator}}
 
   <button class="primary-button" {{action "handleSettings"}}>Create Workspace</button>

--- a/scss/_submissions.scss
+++ b/scss/_submissions.scss
@@ -150,6 +150,34 @@
     background-color: white;
     border-radius: 50%;
   }
+  .select-bar {
+    @include flex-item(1, center, .3 0 auto);
+    margin-right: 15px;
+    #my-select {
+      width: 100%;
+      select {
+        height: 30px;
+        @include responsive-font-size(.6em, 1em, 350px, 1200px, .1em);
+        font-size: 1em;
+        border: none;
+        text-indent: 5px;
+        background: none;
+        width: 100%;
+        max-width: 100px;
+        text-align-last: left;
+        margin: 0 auto;
+        text-transform: capitalize;
+        color: black;
+        background: url(/images/caret-down.svg) no-repeat right;
+        background-size: 12px;
+        -webkit-appearance: none;
+        -moz-appearance: none;
+        &:focus {
+          outline: none;
+        }
+      }
+    }
+  }
   .loading-message-container {
     text-align: center;
     margin-top: 50px;


### PR DESCRIPTION

Will now add/remove all revisions when selecting submissions while only displaying newest revisions
Can choose to include all or just newest submissions on the workspace settings page
Removed search bar

Refactored doIncludeRevisions checkbox to my-select (TODO: needs to be styled properly) 
