### PR TITLE
Make assignmentType just type string, not enum

### DIFF
--- a/server/datasource/schemas/assignment.js
+++ b/server/datasource/schemas/assignment.js
@@ -25,7 +25,7 @@ var AssignmentSchema = new Schema({
   assignedDate: { type: Date },
   answers: [{ type: ObjectId, ref: 'Answer'}],
   dueDate: { type: Date },
-  assignmentType: {type: String, enum: ['problem', 'workspace'], default: 'problem' },
+  assignmentType: { type: String },
   linkedWorkspace: { type: ObjectId, ref: 'Workspace' }, // for auto updatingtype problem assignments
 }, { versionKey: false });
 


### PR DESCRIPTION
Could change this back once workspace assignments are implemented