### PR TITLE
Do not show nonselectable view while selecting

### DIFF
--- a/app/templates/components/workspace-submission.hbs
+++ b/app/templates/components/workspace-submission.hbs
@@ -98,8 +98,8 @@
         </div>
       </div>
     {{/selectable-area}}
-    {{/if}}
-    <div class="non-selectable-sub">
+    {{else}}
+        <div class="non-selectable-sub">
       <h5 class="submission-header summary">Brief Summary</h5>
       <div class="submission short {{if isVmt "vmt-summary"}}">
         {{#if isVmt}}
@@ -146,6 +146,8 @@
         {{/if}}
       </div>
     </div>
+
+    {{/if}}
 
   {{#if currentSubmission.uploadedFile.savedFileName}}
   <div id="submission_images">


### PR DESCRIPTION
Fix side effect of trying to keep vmt replayer in dom always 
  -- showing /hiding selections was displaying duplicate brief summary / explanations
  -- need to find better way to prevent vmt room from reloading when selectable view is toggled