### PR TITLE
Update hardcoded URLS in mixin to include prod1 domains

### DIFF
--- a/app/mixins/mt_auth_mixin.js
+++ b/app/mixins/mt_auth_mixin.js
@@ -5,6 +5,9 @@ getRedirectUrl() {
 
 getMtSsoUrl() {
   let { host }  = window.location;
+  if (host === 'prod1encompass.mathematicalthinking.org') {
+    return `https://prod1sso.mathematicalthinking.org`;
+  }
   if (host === 'encompass.mathematicalthinking.org') {
     return `https://sso.mathematicalthinking.org`;
   }


### PR DESCRIPTION
Update mixins/mt_auth_mixin.js#getMtSsoUrl to handle the case where the window location is the new prod1encompass, and return the URL for prod1sso. 

To Do: figure out how to get this value from an ENV variable (currently breaks the "Sign in with Google" button to use process.env variables in the getMtSsoUrl function, and completely breaks the login page to `require('dotenv').config()` at the top of the file).