### PR TITLE
Share Your Ideas button in assignment-info-student

### DIFF
--- a/app/templates/components/assignment-info-student.hbs
+++ b/app/templates/components/assignment-info-student.hbs
@@ -63,14 +63,14 @@
   <button class="primary-button revise" {{action 'reviseAssignmentResponse'}}>Revise</button>
 {{/if}}
 {{#if showRespondButton}}
-  <button class="primary-button respond" {{action 'beginAssignmentResponse'}}>Respond</button>
+  <button class="primary-button respond" {{action 'beginAssignmentResponse'}}>Share Your Ideas</button>
 {{/if}}
 
   <div class="info-msg-container">
     {{#if sortedList.length}}
       <p class="info">You have made a total of {{sortedList.length}} submissions to this assignment. You can view the details of each submission by clicking on one of the Past Submissions items below. If you would like to revise your most recently submitted revision, cick Revise.</p>
     {{else}}
-      <p class="info">It looks like you have not made any submissions to this assignment. Click 'Respond' to begin making a submission.</p>
+      <p class="info">It looks like you have not made any submissions to this assignment. Click 'Share Your Ideas' to begin making a submission.</p>
     {{/if}}
   </div>
 


### PR DESCRIPTION
FIxes #453 

Under assignments info under students section the button now says 
`Share Your Ideas`

<img width="1246" alt="Screen Shot 2020-10-19 at 7 07 51 PM" src="https://user-images.githubusercontent.com/47477912/96521126-87c46700-123e-11eb-8dd0-14877076dddb.png">
