### PR TITLE
Feat/group workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@
 /bower.json.ember-try
 /package.json.ember-try
 .DS_Store
+
+*.zip

--- a/app/components/assignment-info-teacher.hbs
+++ b/app/components/assignment-info-teacher.hbs
@@ -88,11 +88,7 @@
       </p>
     {{/if}}
       {{#if this.showLinkedWsForm}}
-        {{#if this.linkedByGroup}}
-          <LinkedWorkspacesNew @students={{this.groupsWithoutWorkspaces}} @assignment={{@assignment}} @section={{@section}} @problem={{@problem}} @onCancel={{action (mut showLinkedWsForm) false}} @store={{this.store}} @handleResults={{action "handleCreatedLinkedWs"}} />
-        {{else}}
-          <LinkedWorkspacesNew @students={{this.studentsWithoutWorkspaces}} @assignment={{@assignment}} @section={{@section}} @problem={{@problem}} @onCancel={{action (mut showLinkedWsForm) false}} @store={{this.store}} @handleResults={{action "handleCreatedLinkedWs"}} />
-        {{/if}}
+          <LinkedWorkspacesNew @students={{this.missingWorkspaces}} @assignment={{@assignment}} @section={{@section}} @problem={{@problem}} @onCancel={{action (mut showLinkedWsForm) false}} @store={{this.store}} @handleResults={{action "handleCreatedLinkedWs"}} />
       {{/if}}
       {{#if this.showAddLinkedWsBtn}}
         <button

--- a/app/components/assignment-info-teacher.js
+++ b/app/components/assignment-info-teacher.js
@@ -59,7 +59,7 @@ export default class AssignmentInfoTeacherComponent extends ErrorHandlingCompone
   }
 
   get showFullLinkedWsMsg() {
-    return this.linkedByGroup
+    return this.missingWorkspaces.length
       ? this.isEditing && this.allGroupsHaveWs
       : this.isEditing && this.allStudentsHaveWs;
   }
@@ -209,21 +209,12 @@ export default class AssignmentInfoTeacherComponent extends ErrorHandlingCompone
     );
   }
   get showAddLinkedWsBtn() {
-    if (this.linkedByGroup) {
-      return (
-        this.isEditing &&
-        this.hasBasicEditPrivileges &&
-        this.hideLinkedWsForm &&
-        !this.allGroupsHaveWs
-      );
-    } else {
-      return (
-        this.isEditing &&
-        this.hasBasicEditPrivileges &&
-        this.hideLinkedWsForm &&
-        !this.allStudentsHaveWs
-      );
-    }
+    return (
+      this.isEditing &&
+      this.hasBasicEditPrivileges &&
+      this.hideLinkedWsForm &&
+      this.missingWorkspaces.length
+    );
   }
 
   get showReport() {
@@ -279,6 +270,21 @@ export default class AssignmentInfoTeacherComponent extends ErrorHandlingCompone
 
   get linkedByGroup() {
     return this.args.assignment.linkedWorkspacesRequest.linkType === 'group';
+  }
+
+  get missingWorkspaces() {
+    if (this.args.assignment.linkedWorkspacesRequest.linkType === 'group') {
+      return this.groupsWithoutWorkspaces;
+    }
+    if (
+      this.args.assignment.linkedWorkspacesRequest.linkType === 'individual'
+    ) {
+      return this.studentsWithoutWorkspaces;
+    }
+    return [
+      ...this.groupsWithoutWorkspaces.toArray(),
+      ...this.studentsWithoutWorkspaces.toArray(),
+    ];
   }
 
   @action editAssignment() {

--- a/app/components/assignment-new.hbs
+++ b/app/components/assignment-new.hbs
@@ -132,7 +132,7 @@
             <div class="group-selection" {{on "click" this.updateSectionGroups}}>
               <RadioGroup @options={{this.groupWsOptions}} @selectedValue={{action "updateLinkedWorkspacesMode"}} @noWidth={{true}} />
             </div>
-              <LinkedWorkspacesNew @isDisplayOnly={{true}} @assignmentName={{this.assignmentNamePreview}} @sectionName={{this.selectedSection.name}} @students={{this.workspacesList}} />
+              <LinkedWorkspacesNew @isDisplayOnly={{true}} @assignmentName={{this.assignmentNamePreview}} @sectionName={{this.selectedSection.name}} @students={{this.workspacesList}} @updateLists={{this.updateLists}} />
           {{/if}}
         </li>
         {{#if this.doCreateLinkedWorkspaces}}

--- a/app/components/assignment-new.hbs
+++ b/app/components/assignment-new.hbs
@@ -148,6 +148,15 @@
           <RadioGroup @options={{this.parentWsOptions}} @selectedValue={{action "updateDoCreateParentWorkspace"}} />
 
           {{#if this.showParentWsForm}}
+            <label for="accessOptions">
+              <span
+                  class="label-text simptip-position-right simptip-multiline simptip-smooth"
+                  data-tooltip={{this.tooltips.parentWorkspace}}
+                >
+                Give access to students?
+                </span>
+            </label>
+            <RadioGroup @options={{this.parentWorkspaceAccessOptions}} @selectedValue={{action "updateParentWorkspaceAccess"}} @noWidth={{true}} />
             <ParentWorkspaceNew @isDisplayOnly={{true}} @assignmentName={{this.assignmentNamePreview}} />
           {{/if}}
         </li>

--- a/app/components/assignment-new.hbs
+++ b/app/components/assignment-new.hbs
@@ -132,7 +132,7 @@
             <div class="group-selection" {{on "click" this.updateSectionGroups}}>
               <RadioGroup @options={{this.groupWsOptions}} @selectedValue={{action "updateLinkedWorkspacesMode"}} @noWidth={{true}} />
             </div>
-              <LinkedWorkspacesNew @isDisplayOnly={{true}} @assignmentName={{this.assignmentNamePreview}} @sectionName={{this.selectedSection.name}} @mode={{this.linkedWorkspacesMode}} @students={{if this.linkedWorkspacesMode this.sectionGroups this.selectedSection.students.content}} />
+              <LinkedWorkspacesNew @isDisplayOnly={{true}} @assignmentName={{this.assignmentNamePreview}} @sectionName={{this.selectedSection.name}} @students={{this.workspacesList}} />
           {{/if}}
         </li>
         {{#if this.doCreateLinkedWorkspaces}}

--- a/app/components/assignment-new.js
+++ b/app/components/assignment-new.js
@@ -351,6 +351,9 @@ export default class AssignmentNewComponent extends ErrorHandlingComponent {
   }
   @action updateLinkedWorkspacesMode(val) {
     this.linkedWorkspacesMode = val;
+    //reset chosen linkedWorkspaces
+    this.groupWorkspacesToMake = [];
+    this.studentWorkspacesToMake = [];
   }
   @action updateDoCreateParentWorkspace(val) {
     this.doCreateParentWorkspace = val;

--- a/app/components/assignment-new.js
+++ b/app/components/assignment-new.js
@@ -111,6 +111,22 @@ export default class AssignmentNewComponent extends ErrorHandlingComponent {
   };
 
   @tracked sectionGroups = [];
+  @tracked groupWorkspacesToMake = [];
+  @tracked studentWorkspacesToMake = [];
+
+  @action updateLists(record) {
+    if (record.constructor.modelName === 'user') {
+      this.studentWorkspacesToMake.includes(record)
+        ? this.studentWorkspacesToMake.removeObject(record)
+        : this.studentWorkspacesToMake.addObject(record);
+    } else {
+      this.groupWorkspacesToMake.includes(record)
+        ? this.groupWorkspacesToMake.removeObject(record)
+        : this.groupWorkspacesToMake.addObject(record);
+    }
+    console.log(this.studentWorkspacesToMake);
+    console.log(this.groupWorkspacesToMake);
+  }
 
   @action updateSectionGroups() {
     if (this.selectedSection) {
@@ -256,6 +272,8 @@ export default class AssignmentNewComponent extends ErrorHandlingComponent {
       doCreate: doCreateLinkedWorkspaces,
       name: linkedNameFormat,
       linkType: this.linkedWorkspacesMode,
+      groups: this.groupWorkspacesToMake,
+      students: this.studentWorkspacesToMake,
     };
 
     createAssignmentData.parentWorkspaceRequest = {

--- a/app/components/assignment-new.js
+++ b/app/components/assignment-new.js
@@ -113,7 +113,7 @@ export default class AssignmentNewComponent extends ErrorHandlingComponent {
   @tracked sectionGroups = [];
   @tracked groupWorkspacesToMake = [];
   @tracked studentWorkspacesToMake = [];
-
+  //TODO: refactor
   @action updateLists(record) {
     if (record.constructor.modelName === 'user') {
       this.studentWorkspacesToMake.includes(record.id)

--- a/app/components/assignment-new.js
+++ b/app/components/assignment-new.js
@@ -21,6 +21,7 @@ export default class AssignmentNewComponent extends ErrorHandlingComponent {
   @tracked doCreateLinkedWorkspaces = false;
   @tracked doCreateParentWorkspace = false;
   @tracked fromProblemInfo = false;
+  @tracked parentWorkspaceAccess = false;
   tooltips = {
     class: 'Select which class you want to assign the problem',
     problem: 'Select which problem you want to assign',
@@ -87,6 +88,20 @@ export default class AssignmentNewComponent extends ErrorHandlingComponent {
       {
         value: false,
         label: 'No',
+      },
+    ],
+  };
+  parentWorkspaceAccessOptions = {
+    groupName: 'accessOptions',
+    required: false,
+    inputs: [
+      {
+        value: true,
+        label: 'Give access',
+      },
+      {
+        value: false,
+        label: 'Keep private',
       },
     ],
   };
@@ -228,6 +243,7 @@ export default class AssignmentNewComponent extends ErrorHandlingComponent {
     createAssignmentData.parentWorkspaceRequest = {
       doCreate: doCreateLinkedWorkspaces ? doCreateParentWorkspace : false,
       name: parentNameFormat,
+      giveAccess: this.parentWorkspaceAccess,
     };
 
     students.forEach((student) => {
@@ -302,6 +318,9 @@ export default class AssignmentNewComponent extends ErrorHandlingComponent {
   }
   @action updateDoCreateParentWorkspace(val) {
     this.doCreateParentWorkspace = val;
+  }
+  @action updateParentWorkspaceAccess(val) {
+    this.parentWorkspaceAccess = val;
   }
   @action validate() {
     const section = this.selectedSection;

--- a/app/components/assignment-new.js
+++ b/app/components/assignment-new.js
@@ -17,7 +17,7 @@ export default class AssignmentNewComponent extends ErrorHandlingComponent {
   @tracked formId = null;
   @tracked createRecordErrors = [];
   @tracked queryErrors = [];
-  @tracked linkedWorkspacesMode = false;
+  @tracked linkedWorkspacesMode = 'individual';
   @tracked doCreateLinkedWorkspaces = false;
   @tracked doCreateParentWorkspace = false;
   @tracked fromProblemInfo = false;
@@ -68,12 +68,16 @@ export default class AssignmentNewComponent extends ErrorHandlingComponent {
     requried: false,
     inputs: [
       {
-        value: true,
+        value: 'group',
         label: 'By Group',
       },
       {
-        value: false,
+        value: 'individual',
         label: 'By Student',
+      },
+      {
+        value: 'both',
+        label: 'Student and Group',
       },
     ],
   };
@@ -161,6 +165,20 @@ export default class AssignmentNewComponent extends ErrorHandlingComponent {
 
     return `${title} / ${nameDate}`;
   }
+  //for the 'workspaces to be created' list
+  get workspacesList() {
+    if (this.linkedWorkspacesMode === 'group') {
+      return this.sectionGroups;
+    } else if (this.linkedWorkspacesMode === 'individual') {
+      return this.selectedSection.students.content;
+    } else {
+      return [
+        ...this.sectionGroups.toArray(),
+        ...this.selectedSection.students.content.toArray(),
+      ];
+    }
+  }
+
   constructor() {
     super(...arguments);
     let selectedProblem = this.args.selectedProblem;
@@ -237,7 +255,7 @@ export default class AssignmentNewComponent extends ErrorHandlingComponent {
     createAssignmentData.linkedWorkspacesRequest = {
       doCreate: doCreateLinkedWorkspaces,
       name: linkedNameFormat,
-      linkType: this.linkedWorkspacesMode ? 'group' : 'individual',
+      linkType: this.linkedWorkspacesMode,
     };
 
     createAssignmentData.parentWorkspaceRequest = {

--- a/app/components/assignment-new.js
+++ b/app/components/assignment-new.js
@@ -116,13 +116,12 @@ export default class AssignmentNewComponent extends ErrorHandlingComponent {
 
   @action updateLists(record) {
     if (record.constructor.modelName === 'user') {
-      this.studentWorkspacesToMake.includes(record)
-        ? this.studentWorkspacesToMake.removeObject(record)
-        : this.studentWorkspacesToMake.addObject(record);
+      this.studentWorkspacesToMake = [
+        ...this.studentWorkspacesToMake,
+        record.id,
+      ];
     } else {
-      this.groupWorkspacesToMake.includes(record)
-        ? this.groupWorkspacesToMake.removeObject(record)
-        : this.groupWorkspacesToMake.addObject(record);
+      this.groupWorkspacesToMake = [...this.groupWorkspacesToMake, record.id];
     }
     console.log(this.studentWorkspacesToMake);
     console.log(this.groupWorkspacesToMake);
@@ -272,8 +271,8 @@ export default class AssignmentNewComponent extends ErrorHandlingComponent {
       doCreate: doCreateLinkedWorkspaces,
       name: linkedNameFormat,
       linkType: this.linkedWorkspacesMode,
-      groups: this.groupWorkspacesToMake,
-      students: this.studentWorkspacesToMake,
+      groupsToMake: this.groupWorkspacesToMake,
+      studentsToMake: this.studentWorkspacesToMake,
     };
 
     createAssignmentData.parentWorkspaceRequest = {

--- a/app/components/assignment-new.js
+++ b/app/components/assignment-new.js
@@ -116,12 +116,25 @@ export default class AssignmentNewComponent extends ErrorHandlingComponent {
 
   @action updateLists(record) {
     if (record.constructor.modelName === 'user') {
-      this.studentWorkspacesToMake = [
-        ...this.studentWorkspacesToMake,
-        record.id,
-      ];
+      this.studentWorkspacesToMake.includes(record.id)
+        ? this.studentWorkspacesToMake.splice(
+            this.studentWorkspacesToMake.indexOf(record.id),
+            1
+          )
+        : (this.studentWorkspacesToMake = [
+            ...this.studentWorkspacesToMake,
+            record.id,
+          ]);
     } else {
-      this.groupWorkspacesToMake = [...this.groupWorkspacesToMake, record.id];
+      this.groupWorkspacesToMake.includes(record.id)
+        ? this.groupWorkspacesToMake.splice(
+            this.groupWorkspacesToMake.indexOf(record.id),
+            1
+          )
+        : (this.groupWorkspacesToMake = [
+            ...this.groupWorkspacesToMake,
+            record.id,
+          ]);
     }
     console.log(this.studentWorkspacesToMake);
     console.log(this.groupWorkspacesToMake);

--- a/app/components/linked-workspaces-new.hbs
+++ b/app/components/linked-workspaces-new.hbs
@@ -17,11 +17,11 @@
     </div>
     <div class="name-previews">
       <p class="label">
-        Workspaces to be created
+        Choose Workspaces to be created:
       </p>
       <ul>
         {{#each @students as |student|}}
-          <li>{{if student.username student.username student.name}}: {{this.previewName}}</li>
+          <li><label><Input @type="checkbox" {{on "input" (fn this.update student)}} /> {{if student.username student.username student.name}}: {{this.previewName}}</label></li>
         {{/each}}
       </ul>
     </div>

--- a/app/components/linked-workspaces-new.hbs
+++ b/app/components/linked-workspaces-new.hbs
@@ -21,7 +21,7 @@
       </p>
       <ul>
         {{#each @students as |student|}}
-          <li><label><Input @type="checkbox" {{on "input" (fn this.update student)}} /> {{if student.username student.username student.name}}: {{this.previewName}}</label></li>
+          <li><label class="no-width"><Input @type="checkbox" {{on "input" (fn this.update student)}} /> {{if student.username student.username student.name}}: {{this.previewName}}</label></li>
         {{/each}}
       </ul>
     </div>

--- a/app/components/linked-workspaces-new.js
+++ b/app/components/linked-workspaces-new.js
@@ -23,6 +23,10 @@ export default class LinkedWorkspacesNew extends Component {
     return this.workspaceName || this.defaultName;
   }
 
+  @action update(student) {
+    return this.args.updateLists(student);
+  }
+
   @action cancel() {
     if (this.args.onCancel) {
       this.args.onCancel();

--- a/app/components/workspace-list-item.js
+++ b/app/components/workspace-list-item.js
@@ -83,8 +83,8 @@ export default Component.extend({
       if (!value) return;
       let section = await this.get('store').findRecord('section', value);
       let { value: mode } = await this.get('alert').showPromptSelect(
-        'Assign to groups or individuals?',
-        { group: 'Groups', individual: 'Individuals' },
+        'Assign to groups, individuals, or both?',
+        { group: 'Groups', individual: 'Individuals', both: 'Both' },
         'Select'
       );
       let { value: parentChoice } = await this.get('alert').showModal(

--- a/app/controllers/workspace.js
+++ b/app/controllers/workspace.js
@@ -7,9 +7,8 @@
  */
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
-import CurrentUserMixin from '../mixins/current_user_mixin';
 
-export default Controller.extend(CurrentUserMixin, {
+export default Controller.extend({
   // comments: controller(),
 
   currentSelection: null, //ENC-397, ENC-398

--- a/app/controllers/workspace/submissions/submission.js
+++ b/app/controllers/workspace/submissions/submission.js
@@ -75,10 +75,38 @@ export default Controller.extend({
 
   nonTrashedSelections: computed(
     'currentWorkspace.selections.content.@each.isTrashed',
+    'itemsToDisplay',
     function () {
-      return this.get('currentWorkspace.selections.content').rejectBy(
-        'isTrashed'
-      );
+      const nonTrashed = this.get(
+        'currentWorkspace.selections.content'
+      ).rejectBy('isTrashed');
+      if (this.itemsToDisplay === 'all') {
+        return nonTrashed;
+      }
+      if (this.itemsToDisplay === 'individual') {
+        return nonTrashed.filter((selection) => {
+          const originalSelection = selection.get('originalSelection');
+          const workspace = originalSelection.get('workspace');
+          //in case data is corrupted and workspace is missing
+          if (workspace) {
+            const group = workspace.get('group');
+            //return selections from workspaces not associated with a group
+            return !group;
+          }
+          return false;
+        });
+      }
+      if (this.itemsToDisplay === 'group') {
+        return nonTrashed.filter((selection) => {
+          const originalSelection = selection.get('originalSelection');
+          const workspace = originalSelection.get('workspace');
+          if (workspace) {
+            const group = workspace.get('group');
+            return !!group;
+          }
+          return false;
+        });
+      }
     }
   ),
 
@@ -111,16 +139,26 @@ export default Controller.extend({
         return nonTrashed.filter((comment) => {
           const originalComment = comment.get('originalComment');
           const workspace = originalComment.get('workspace');
-          const group = workspace.get('group');
-          return !group;
+          //in case data is corrupted and workspace is missing
+          if (workspace) {
+            const group = workspace.get('group');
+            //return comments from workspaces not associated with a group
+            return !group;
+          }
+          return false;
         });
       }
       if (this.itemsToDisplay === 'group') {
         return nonTrashed.filter((comment) => {
           const originalComment = comment.get('originalComment');
           const workspace = originalComment.get('workspace');
-          const group = workspace.get('group');
-          return !!group;
+          //in case data is corrupted and workspace is missing
+          if (workspace) {
+            const group = workspace.get('group');
+            //return comment from workspaces associated with a group
+            return !!group;
+          }
+          return false;
         });
       }
     }

--- a/app/controllers/workspace/submissions/submission.js
+++ b/app/controllers/workspace/submissions/submission.js
@@ -15,7 +15,7 @@ export default Controller.extend({
   workspace: controller(),
   utils: service('utility-methods'),
   alert: service('sweet-alert'),
-
+  store: service(),
   queryParams: ['vmtRoomId'],
 
   // workspaceSubmissions: Ember.inject.controller(),
@@ -38,7 +38,7 @@ export default Controller.extend({
   }),
   areFoldersHidden: false,
   areCommentsHidden: false,
-
+  itemsToDisplay: 'all',
   isParentWorkspace: equal('currentWorkspace.workspaceType', 'parent'),
 
   canSelect: computed(
@@ -188,6 +188,10 @@ export default Controller.extend({
   cannotSeeResponses: not('canSeeResponses'),
 
   actions: {
+    updateDisplayInput: function ({ target }) {
+      console.log(this.itemsToDisplay);
+      return (this.itemsToDisplay = target.value);
+    },
     startTour: function () {
       this.guider
         .createGuider(

--- a/app/controllers/workspace/submissions/submission.js
+++ b/app/controllers/workspace/submissions/submission.js
@@ -426,7 +426,7 @@ export default Controller.extend({
       var submission = this.model.submission;
       var controller = this;
       var newSelection = null;
-      var alreadyExists = this.get('model.selections').filterBy(
+      var alreadyExists = this.get('model.submission.selections').filterBy(
         'id',
         selection.id
       );
@@ -528,8 +528,8 @@ export default Controller.extend({
 
           controller.transitionToRoute(
             'workspace.submissions.submission.selections.selection',
-            workspace,
-            submission,
+            workspace.id,
+            submission.id,
             newSelection.id
           );
 

--- a/app/controllers/workspace/submissions/submission.js
+++ b/app/controllers/workspace/submissions/submission.js
@@ -26,7 +26,16 @@ export default Controller.extend({
   workspaceOwner: alias('currentWorkspace.owner'),
   permissions: service('workspace-permissions'),
   guider: service('guiders-create'),
-
+  showOptions: computed('model.assignment', function () {
+    if (
+      this.model.assignment &&
+      this.model.assignment.linkedWorkspacesRequest &&
+      this.isParentWorkspace
+    ) {
+      return this.model.assignment.linkedWorkspacesRequest.linkType === 'both';
+    }
+    return false;
+  }),
   areFoldersHidden: false,
   areCommentsHidden: false,
 
@@ -83,7 +92,7 @@ export default Controller.extend({
   nonTrashedFolders: computed(
     'currentWorkspace.folders.content.@each.isTrashed',
     function () {
-      const stuff= this.get('currentWorkspace');
+      const stuff = this.get('currentWorkspace');
       return this.get('currentWorkspace.folders.content').rejectBy('isTrashed');
     }
   ),
@@ -353,7 +362,7 @@ export default Controller.extend({
     addSelection: function (selection, isUpdateOnly) {
       var user = this.currentUser.user;
       var workspace = this.currentWorkspace;
-      var submission = this.model;
+      var submission = this.model.submission;
       var controller = this;
       var newSelection = null;
       var alreadyExists = this.get('model.selections').filterBy(
@@ -505,7 +514,10 @@ export default Controller.extend({
           null
         );
 
-        controller.transitionToRoute('workspace.submissions.submission', controller.model);
+        controller.transitionToRoute(
+          'workspace.submissions.submission',
+          controller.model
+        );
       });
     },
 

--- a/app/controllers/workspace/submissions/submission.js
+++ b/app/controllers/workspace/submissions/submission.js
@@ -27,12 +27,8 @@ export default Controller.extend({
   permissions: service('workspace-permissions'),
   guider: service('guiders-create'),
   showOptions: computed('model.assignment', function () {
-    if (
-      this.model.assignment &&
-      this.model.assignment.linkedWorkspacesRequest &&
-      (this.isParentWorkspace || this.model.workspace.group)
-    ) {
-      return this.model.assignment.linkedWorkspacesRequest.linkType === 'both';
+    if (this.isParentWorkspace || this.model.workspace.group) {
+      return true;
     }
     return false;
   }),

--- a/app/models/assignment.js
+++ b/app/models/assignment.js
@@ -37,6 +37,7 @@ export default class AssignmentModel extends Auditable {
         createdWorkspace: null,
         doAutoUpdateFromChildren: false,
         name: null,
+        giveAccess: false,
       };
     },
   })

--- a/app/models/workspace.js
+++ b/app/models/workspace.js
@@ -11,7 +11,7 @@ export default Model.extend(Auditable, {
   owner: belongsTo('user', { async: true }),
   editors: hasMany('user', { async: true }),
   folders: hasMany('folder', { async: true }),
-  group: belongsTo('group', { async: true }),
+  group: attr(),
   submissions: hasMany('submission', { async: true }),
   responses: hasMany('response', { async: true }),
   selections: hasMany('selection', { async: true }),

--- a/app/routes/workspace/submissions/submission.js
+++ b/app/routes/workspace/submissions/submission.js
@@ -6,7 +6,7 @@
   * @since 1.0.1
   * @see workspace_submissions_route
   */
-/*global _:false */
+
 import Route from '@ember/routing/route';
 import { schedule } from '@ember/runloop';
 import { hash } from 'rsvp';
@@ -50,6 +50,11 @@ export default Route.extend(VmtHostMixin, {
 
   setupController: function (controller, model) {
     this._super(controller, model);
+  },
+  resetController(controller, isExiting, transition) {
+    if (isExiting && transition.targetName !== 'error') {
+      controller.set('itemsToDisplay', 'all');
+    }
   },
 
   activate: function () {

--- a/app/routes/workspace/submissions/submission.js
+++ b/app/routes/workspace/submissions/submission.js
@@ -23,7 +23,13 @@ export default Route.extend(VmtHostMixin, {
 
   async model({ submission_id }) {
     let submissions = await this.modelFor('workspace.submissions');
-    return await submissions.findBy('id', submission_id);
+    let workspace = await this.modelFor('workspace');
+    let assignment = await workspace.get('linkedAssignment');
+    return hash({
+      workspace,
+      assignment,
+      submission: submissions.findBy('id', submission_id),
+    });
   },
 
   afterModel(submission, transition) {
@@ -67,8 +73,8 @@ export default Route.extend(VmtHostMixin, {
   },
 
   resolveVmtRoom(submission) {
-    let roomId 
-    if(submission.submission){
+    let roomId;
+    if (submission.submission) {
       roomId = submission.submission.get('vmtRoomInfo.roomId');
     } else {
       roomId = submission.get('vmtRoomInfo.roomId');

--- a/app/templates/components/undraggable-selection.hbs
+++ b/app/templates/components/undraggable-selection.hbs
@@ -1,6 +1,6 @@
 <div class="selectionLink {{if this.isImage "image-tag"}} {{if this.isSelected 'is-selected'}} {{if this.isText "selection_text"}}"
   title="{{this.titleText}} {{if this.isParentWorkspace " by "}} {{if this.isParentWorkspace this.selection.originalSelection.createdBy.username}} {{if this.isParentWorkspace " in "}} {{if this.isParentWorkspace this.selection.originalSelection.workspace.name}}">
-  <LinkTo @route="workspace.submissions.submission.selections.selection" @models={{array this.selection.workspace this.selection.submission this.selection}} @classNames={{this.linkToClassName}}>
+  <LinkTo @route="workspace.submissions.submission.selections.selection" @models={{array this.selection.workspace.id this.selection.submission.id this.selection.id}} @classNames={{this.linkToClassName}}>
     {{#if this.isImage}}
         <img class="img-tag-thmb" src={{this.selection.imageTagLink}} alt={{this.selection.text}}>
         <div class="overlay">

--- a/app/templates/workspace/submission.hbs
+++ b/app/templates/workspace/submission.hbs
@@ -31,7 +31,7 @@
 
 <!--section class="submissions"-->
 {{!-- <div id="al_center" class="{{if makingSelection 'al_makeselect'}} workspace-flex-item submission"> --}}
-  <SubmissionGroup @store={{this.store}} @canRespond={{this.canRespond}} @submissions={{this.currentWorkspace.submissions.content}} @submission={{this.model}} @addSelection={{action "addSelection"}} @deleteSelection={{action "deleteSelection"}} @currentWorkspace={{this.currentWorkspace}} @toNewResponse={{action "toNewResponse"}} @toSubmission={{action "toSubmission"}} @selections={{this.nonTrashedSelections}} @responses={{this.nonTrashedResponses}} @containerLayoutClass={{this.containerLayoutClass}} @canSeeSelections={{this.canSeeSelections}} @currentSelection={{this.currentSelection}} @isParentWorkspace={{this.isParentWorkspace}} />
+  <SubmissionGroup @store={{this.store}} @canRespond={{this.canRespond}} @submissions={{this.currentWorkspace.submissions.content}} @submission={{this.model.submission}} @addSelection={{action "addSelection"}} @deleteSelection={{action "deleteSelection"}} @currentWorkspace={{this.currentWorkspace}} @toNewResponse={{action "toNewResponse"}} @toSubmission={{action "toSubmission"}} @selections={{this.nonTrashedSelections}} @responses={{this.nonTrashedResponses}} @containerLayoutClass={{this.containerLayoutClass}} @canSeeSelections={{this.canSeeSelections}} @currentSelection={{this.currentSelection}} @isParentWorkspace={{this.isParentWorkspace}} />
 {{!-- </div> --}}
 <!--/section-->
 
@@ -42,7 +42,7 @@
     <button {{action 'toggleCommentDisplay'}}><img src="../assets/images/chevrons-left.svg"></button>
   </div>
   {{/if}}
-  <CommentList @store={{this.store}} @comments={{this.nonTrashedComments}} @currentWorkspace={{this.currentWorkspace}} @currentSelection={{this.currentSelection}} @currentSubmission={{this.model}} @allowedToComment={{this.permittedToComment}} @resetComment={{action "cancelComment"}} @isHidden={{this.areCommentsHidden}} @hideComments={{action "toggleCommentDisplay"}} @containerLayoutClass={{this.containerLayoutClass}} @isParentWorkspace={{this.isParentWorkspace}} />
+  <CommentList @store={{this.store}} @comments={{this.nonTrashedComments}} @currentWorkspace={{this.currentWorkspace}} @currentSelection={{this.currentSelection}} @currentSubmission={{this.model.submission}} @allowedToComment={{this.permittedToComment}} @resetComment={{action "cancelComment"}} @isHidden={{this.areCommentsHidden}} @hideComments={{action "toggleCommentDisplay"}} @containerLayoutClass={{this.containerLayoutClass}} @isParentWorkspace={{this.isParentWorkspace}} />
 {{!-- </div> --}}
 </div>
 

--- a/app/templates/workspace/submission.hbs
+++ b/app/templates/workspace/submission.hbs
@@ -11,7 +11,15 @@
   {{/each}}
 </div>
   <aside>
-  <a id="takeTour" class="action_button" {{action 'startTour'}}>Take Tour</a>
+    {{#if this.showOptions}}
+      <label for="dispaly-options">Work to display: </label>
+      <select id="display-options" oninput={{action "updateDisplayInput"}}>
+        <option value="all">All work</option>
+        <option value="individual">Individual work only</option>
+        <option value="group">Group work only</option>
+      </select>
+    {{/if}}
+    <a id="takeTour" class="action_button" {{action 'startTour'}}>Take Tour</a>
     {{! this needs to be here so the GuideJS can click it when done
         we don't have a better way to propagate actions }}
     <a id="doneTour" style="display:none" {{action 'doneTour'}}>Done Tour</a>

--- a/app_server/datasource/api/assignmentApi.js
+++ b/app_server/datasource/api/assignmentApi.js
@@ -258,7 +258,8 @@ const postAssignment = async (req, res, next) => {
     } = req.body.assignment;
 
     // assignedDate, dueDate should be isoDate strings
-
+    console.log(linkedWorkspacesRequest);
+    return;
     let assignedMoment = moment(assignedDate);
 
     if (!assignedMoment.isValid()) {
@@ -868,6 +869,12 @@ const removeProblem = (req, res, next) => {
     });
   });
 };
+
+/**
+ * @private
+ * @method generateLinkedWorkspacesFromAssignment
+ * @description creates linked workspaces based on linkedWorkspaceRequest in POST to assignments
+ */
 
 const generateLinkedWorkspacesFromAssignment = async (
   assignment,

--- a/app_server/datasource/api/assignmentApi.js
+++ b/app_server/datasource/api/assignmentApi.js
@@ -362,7 +362,11 @@ const postAssignment = async (req, res, next) => {
           assignment.linkedWorkspacesRequest.createdWorkspaces = linkedWorkspacesIds;
 
           if (doCreateParentWorkspace) {
-            let { name, doAutoUpdateFromChildren } = parentWorkspaceRequest;
+            let {
+              name,
+              doAutoUpdateFromChildren,
+              giveAccess,
+            } = parentWorkspaceRequest;
 
             if (typeof doAutoUpdateFromChildren !== 'boolean') {
               doAutoUpdateFromChildren = true;
@@ -379,6 +383,28 @@ const postAssignment = async (req, res, next) => {
               doAutoUpdateFromChildren,
               linkedAssignment: assignment._id,
             };
+            if (giveAccess) {
+              const { students } = await models.Section.findById(
+                assignment.section
+              );
+              parentWsConfig.permissions = students.map((student) => {
+                return {
+                  user: student,
+                  section: assignment.section,
+                  organization: user.organization,
+                  global: 'editor',
+                  submissions: {
+                    all: true,
+                    submissionIds: [],
+                    userOnly: false,
+                  },
+                  folders: 1, // none, see, add new, modify existing folder structure
+                  comments: 1,
+                  selections: 1, // if can delete other selections, can delete other taggings
+                  feedback: 'none',
+                };
+              });
+            }
             [
               parentWorkspaceError,
               parentWorkspace,

--- a/app_server/datasource/api/assignmentApi.js
+++ b/app_server/datasource/api/assignmentApi.js
@@ -915,17 +915,17 @@ const generateLinkedWorkspacesFromAssignment = async (
     });
     assignment.depopulate();
     // logger.info('students without workspaces', studentsWithoutWorkspaces.map(s => s.username));
-    if (!isNonEmptyArray(studentsWithoutWorkspaces)) {
-      // should send message detailing this
-      // logger.info('No students without a linked workspace');
-      return ['All students already own a linked workspace', null];
-    }
     // if answers convert answers to submissions
 
     let submissionObjects = await answersToSubmissions(answers);
     let workspaces;
     // create a workspace for each student in assignment
     if (linkType === 'individual') {
+      if (!isNonEmptyArray(studentsWithoutWorkspaces)) {
+        // should send message detailing this
+        // logger.info('No students without a linked workspace');
+        return ['All students already own a linked workspace', null];
+      }
       workspaces = await Promise.all(
         studentsWithoutWorkspaces.map(async (student) => {
           // create submission record copies

--- a/app_server/datasource/api/assignmentApi.js
+++ b/app_server/datasource/api/assignmentApi.js
@@ -872,6 +872,7 @@ const removeProblem = (req, res, next) => {
  * @private
  * @method generateLinkedWorkspacesFromAssignment
  * @description creates linked workspaces based on linkedWorkspaceRequest in POST to assignments
+ * @todo refactor general methods
  */
 
 const generateLinkedWorkspacesFromAssignment = async (

--- a/app_server/datasource/api/assignmentApi.js
+++ b/app_server/datasource/api/assignmentApi.js
@@ -258,8 +258,6 @@ const postAssignment = async (req, res, next) => {
     } = req.body.assignment;
 
     // assignedDate, dueDate should be isoDate strings
-    console.log(linkedWorkspacesRequest);
-    return;
     let assignedMoment = moment(assignedDate);
 
     if (!assignedMoment.isValid()) {
@@ -894,7 +892,14 @@ const generateLinkedWorkspacesFromAssignment = async (
     // assignment will have students, section populated
     let { students, answers, section } = assignment;
 
-    let { mode, name, doAllowSubmissionUpdates, linkType } = wsOptions;
+    let {
+      mode,
+      name,
+      doAllowSubmissionUpdates,
+      linkType,
+      groupsToMake,
+      studentsToMake,
+    } = wsOptions;
 
     await assignment
       .populate({ path: 'linkedWorkspaces', select: 'owner' })
@@ -934,7 +939,7 @@ const generateLinkedWorkspacesFromAssignment = async (
         return ['All students already own a linked workspace', null];
       }
       workspaces = await Promise.all(
-        studentsWithoutWorkspaces.map(async (student) => {
+        studentsToMake.map(async (student) => {
           // create submission record copies
           let submissionRecords = await Promise.all(
             submissionObjects.map((obj) => {
@@ -982,7 +987,7 @@ const generateLinkedWorkspacesFromAssignment = async (
       );
     } else if (linkType === 'group') {
       workspaces = await Promise.all(
-        groupsWithoutWorkspaces.map(async (group) => {
+        groupsToMake.map(async (group) => {
           let submissionRecords = await Promise.all(
             submissionObjects.map((obj) => {
               let sub = new models.Submission(obj);
@@ -1043,7 +1048,9 @@ const generateLinkedWorkspacesFromAssignment = async (
       );
     } else if (linkType === 'both') {
       let individualWorkspaces = await Promise.all(
-        studentsWithoutWorkspaces.map(async (student) => {
+        studentsToMake.map(async (studentId) => {
+          const student = await models.User.findById(studentId);
+          console.log(student);
           // create submission record copies
           let submissionRecords = await Promise.all(
             submissionObjects.map((obj) => {
@@ -1090,7 +1097,9 @@ const generateLinkedWorkspacesFromAssignment = async (
         })
       );
       let groupWorkspaces = await Promise.all(
-        groupsWithoutWorkspaces.map(async (group) => {
+        groupsToMake.map(async (groupId) => {
+          const group = await models.Group.findById(groupId);
+          console.log(group);
           let submissionRecords = await Promise.all(
             submissionObjects.map((obj) => {
               let sub = new models.Submission(obj);

--- a/app_server/datasource/api/selectionApi.js
+++ b/app_server/datasource/api/selectionApi.js
@@ -1,38 +1,39 @@
 /**
-  * # Selections API
-  * @description This is the API for selection based requests
-  * @author Damola Mabogunje, Daniel Kelly
-  * @since 1.0.0
-  */
+ * # Selections API
+ * @description This is the API for selection based requests
+ * @author Damola Mabogunje, Daniel Kelly
+ * @since 1.0.0
+ */
 
 //REQUIRE MODULES
-const logger   = require('log4js').getLogger('server');
+const logger = require('log4js').getLogger('server');
 const sharp = require('sharp');
 const axios = require('axios');
+const _ = require('underscore');
 
 //REQUIRE FILES
-const utils    = require('../../middleware/requestHandler');
+const utils = require('../../middleware/requestHandler');
 const userAuth = require('../../middleware/userAuth');
-const models   = require('../schemas');
-const wsAccess   = require('../../middleware/access/workspaces');
+const models = require('../schemas');
+const wsAccess = require('../../middleware/access/workspaces');
 const access = require('../../middleware/access/selections');
 
-const { isValidMongoId } = require('../../utils/mongoose');
+const { isValidMongoId, areObjectIdsEqual } = require('../../utils/mongoose');
 
 module.exports.get = {};
 module.exports.post = {};
 module.exports.put = {};
 
 /**
-  * @public
-  * @method getSelections
-  * @description __URL__: /api/selections
-  * @see [buildCriteria](../../middleware/requestHandler.html)
-  * @returns {Object} A 'named' array of selection objects: according to specified criteria
-  * @throws {NotAuthorizedError} User has inadequate permissions
-  * @throws {InternalError} Data retrieval failed
-  * @throws {RestError} Something? went wrong
-  */
+ * @public
+ * @method getSelections
+ * @description __URL__: /api/selections
+ * @see [buildCriteria](../../middleware/requestHandler.html)
+ * @returns {Object} A 'named' array of selection objects: according to specified criteria
+ * @throws {NotAuthorizedError} User has inadequate permissions
+ * @throws {InternalError} Data retrieval failed
+ * @throws {RestError} Something? went wrong
+ */
 async function getSelections(req, res, next) {
   var user = userAuth.requireUser(req);
 
@@ -43,62 +44,68 @@ async function getSelections(req, res, next) {
   let criteria;
   try {
     criteria = await access.get.selections(user, ids);
-
-  }catch(err) {
+  } catch (err) {
     console.error(`Error building selections criteria: ${err}`);
     console.trace();
     return utils.sendError.InternalError(null, res);
   }
 
-
-  models.Selection.find(criteria)
-    .exec(function(err, selections) {
-      if(err) {
-        logger.error(err);
-        return utils.sendError.InternalError(err, res);
-      }
-      var data = {'selections': selections};
-      utils.sendResponse(res, data);
-    });
+  models.Selection.find(criteria).exec(function (err, selections) {
+    if (err) {
+      logger.error(err);
+      return utils.sendError.InternalError(err, res);
+    }
+    var data = { selections: selections };
+    utils.sendResponse(res, data);
+  });
 }
 
 /**
-  * @public
-  * @method getSelection
-  * @description __URL__: /api/selections/:id
-  * @returns {Object} A 'named' selection object
-  * @throws {NotAuthorizedError} User has inadequate permissions
-  * @throws {InternalError} Data retrieval failed
-  * @throws {RestError} Something? went wrong
-  */
+ * @public
+ * @method getSelection
+ * @description __URL__: /api/selections/:id
+ * @returns {Object} A 'named' selection object
+ * @throws {NotAuthorizedError} User has inadequate permissions
+ * @throws {InternalError} Data retrieval failed
+ * @throws {RestError} Something? went wrong
+ */
 async function getSelection(req, res, next) {
   try {
     const user = userAuth.requireUser(req);
 
     if (!user) {
-      return utils.sendError.InvalidCredentialsError('You must be logged in.', res);
+      return utils.sendError.InvalidCredentialsError(
+        'You must be logged in.',
+        res
+      );
     }
 
     let id = req.params.id;
 
     let selection = await models.Selection.findById(id);
 
-    if (!selection || selection.isTrashed) { // record not found in db
+    if (!selection || selection.isTrashed) {
+      // record not found in db
       return utils.sendResponse(res, null);
     }
 
     let canLoadSelection = await access.get.selection(user, id);
 
-    if (!canLoadSelection) { // user does not have permission to access selection
-      return utils.sendError.NotAuthorizedError('You do not have permission.', res);
+    if (!canLoadSelection) {
+      // user does not have permission to access selection
+      return utils.sendError.NotAuthorizedError(
+        'You do not have permission.',
+        res
+      );
     }
 
-    const data = { // user has permission; send back record
-      selection
+    const data = {
+      // user has permission; send back record
+      selection,
     };
 
     return utils.sendResponse(res, data);
-  }catch(err) {
+  } catch (err) {
     console.error(`Error getSelection: ${err}`);
     console.trace();
     return utils.sendError.InternalError(null, res);
@@ -109,7 +116,7 @@ function getImageData(src) {
   if (typeof src !== 'string') {
     return;
   }
-  let first30Chars = src.slice(0,29);
+  let first30Chars = src.slice(0, 29);
 
   let target = 'base64,';
   let targetIndex = first30Chars.indexOf(target);
@@ -138,17 +145,18 @@ function getImageData(src) {
   if (!isValidMongoId(imageId)) {
     // try getting data from src url
     try {
-      return axios.get(src, {responseType: 'stream'})
-      .then((results) => {
+      return axios.get(src, { responseType: 'stream' }).then((results) => {
         const converter = sharp();
         return results.data.pipe(converter);
       });
-    } catch(err) {
+    } catch (err) {
       console.log('sharp err: ', err);
       return;
     }
   }
-  return models.Image.findById(imageId).lean().exec()
+  return models.Image.findById(imageId)
+    .lean()
+    .exec()
     .then((image) => {
       if (image) {
         let imageData = image.imageData;
@@ -159,33 +167,41 @@ function getImageData(src) {
         }
       }
     });
-
 }
 
 /**
-  * @public
-  * @method postSelection
-  * @description __URL__: /api/selections
-  * @throws {NotAuthorizedError} User has inadequate permissions
-  * @throws {InternalError} Data retrieval failed
-  * @throws {RestError} Something? went wrong
-  */
+ * @public
+ * @method postSelection
+ * @description __URL__: /api/selections
+ * @throws {NotAuthorizedError} User has inadequate permissions
+ * @throws {InternalError} Data retrieval failed
+ * @throws {RestError} Something? went wrong
+ */
 async function postSelection(req, res, next) {
   try {
     let user = userAuth.requireUser(req);
     let workspaceId = req.body.selection.workspace;
 
-    let ws = await models.Workspace.findById(workspaceId).lean().populate('owner').populate('editors').populate('createdBy').lean().populate('submissions').exec();
+    let ws = await models.Workspace.findById(workspaceId)
+      .lean()
+      .populate('owner')
+      .populate('editors')
+      .populate('createdBy')
+      .lean()
+      .populate('submissions')
+      .exec();
 
     if (!wsAccess.canModify(user, ws, 'selections', 2)) {
-      return utils.sendError.NotAuthorizedError('You don\'t have permission for this workspace', res);
+      return utils.sendError.NotAuthorizedError(
+        "You don't have permission for this workspace",
+        res
+      );
     }
 
     let selection = new models.Selection(req.body.selection);
 
     selection.createdBy = user;
     selection.createDate = Date.now();
-
 
     let coordinates = selection.coordinates;
     let splitCoords = coordinates.split(' ');
@@ -225,7 +241,12 @@ async function postSelection(req, res, next) {
         let croppedHeight = Math.floor(relativeSize.heightPct * height);
 
         let extraction = await sharp(bytes)
-          .extract({left: croppedLeft, top: croppedTop, width: croppedWidth, height: croppedHeight })
+          .extract({
+            left: croppedLeft,
+            top: croppedTop,
+            width: croppedWidth,
+            height: croppedHeight,
+          })
           .toBuffer();
 
         let newMetadata = await sharp(extraction).metadata();
@@ -239,7 +260,7 @@ async function postSelection(req, res, next) {
           mimetype: `image/${newMetadata.format}`,
           imageData: `data:image/${newMetadata.format};base64,${croppedImageData}`,
           createdBy: user,
-          createDate: Date.now()
+          createDate: Date.now(),
         });
 
         await croppedImage.save();
@@ -251,31 +272,27 @@ async function postSelection(req, res, next) {
         // something went wrong
         return utils.sendError.InvalidContentError(null, res);
       }
-
     }
 
     let savedSelection = await selection.save();
 
-    let data = {'selection': savedSelection};
+    let data = { selection: savedSelection };
     utils.sendResponse(res, data);
-
-  }catch(err) {
+  } catch (err) {
     console.error(`Error postSelection: ${err}`);
     console.trace();
     return utils.sendError.InternalError(err, res);
-
   }
-
 }
 
 /**
-  * @public
-  * @method putSelection
-  * @description __URL__: /api/selections
-  * @throws {NotAuthorizedError} User has inadequate permissions
-  * @throws {InternalError} Data retrieval failed
-  * @throws {RestError} Something? went wrong
-  */
+ * @public
+ * @method putSelection
+ * @description __URL__: /api/selections
+ * @throws {NotAuthorizedError} User has inadequate permissions
+ * @throws {InternalError} Data retrieval failed
+ * @throws {RestError} Something? went wrong
+ */
 async function putSelection(req, res, next) {
   try {
     let user = userAuth.requireUser(req);
@@ -287,12 +304,14 @@ async function putSelection(req, res, next) {
     let selection = await models.Selection.findById(req.params.id);
 
     if (!selection) {
-      logger.info(`${user.username} attempted to update nonexistant selection with id ${req.params.id}`);
+      logger.info(
+        `${user.username} attempted to update nonexistant selection with id ${req.params.id}`
+      );
       return utils.sendResponse(res, null);
     }
 
-    for(let field in req.body.selection) {
-      if((field !== '_id') && (field !== undefined)) {
+    for (let field in req.body.selection) {
+      if (field !== '_id' && field !== undefined) {
         selection[field] = req.body.selection[field];
       }
     }
@@ -304,14 +323,56 @@ async function putSelection(req, res, next) {
 
     let data = { selection };
     utils.sendResponse(res, data);
-
-  }catch(err) {
+  } catch (err) {
     logger.error(err);
     return utils.sendError.InternalError(err, res);
   }
 }
 
+const resolveGroupWorkspaces = async (selection) => {
+  const sourceWorkspace = await models.Workspace.findById(selection.workspace);
+  //this is only supposed to add selections to group workspaces from individual workspaces
+  if (sourceWorkspace.group || sourceWorkspace.workspaceType === 'parent') {
+    return;
+  }
+  const targetGroups = await models.Group.find({
+    students: sourceWorkspace.owner,
+  });
+  //find the group workspaces
+  const targetWorkspaces = await models.Workspace.find({
+    group: targetGroups,
+    isTrashed: false,
+    linkedAssignment: sourceWorkspace.linkedAssignment,
+  });
+  if (!targetWorkspaces.length) {
+    return;
+  }
+  //add a copy of the selection to each of those workspaces
+  const createdSelections = await Promise.all(
+    targetWorkspaces.map(async (workspace) => {
+      await selection.populate('submission').execPopulate();
+      await workspace.populate('submissions').execPopulate();
+      let childPlain = selection.toObject();
+      let fieldsToOmit = ['_id', 'workspace', 'comments', 'taggings'];
+      let childCopy = _.omit(childPlain, fieldsToOmit);
+      childCopy.originalSelection = selection._id;
+      let parentSub = _.find(workspace.submissions, (popSubmission) => {
+        return areObjectIdsEqual(
+          popSubmission.answer,
+          childCopy.submission.answer
+        );
+      });
+      childCopy.submission = parentSub._id;
+      childCopy.workspace = workspace._id;
+      const newSelection = await models.Selection.create(childCopy);
+      return newSelection;
+    })
+  );
+  return createdSelections;
+};
+
 module.exports.get.selections = getSelections;
 module.exports.get.selection = getSelection;
 module.exports.post.selection = postSelection;
 module.exports.put.selection = putSelection;
+module.exports.resolveGroupWorkspaces = resolveGroupWorkspaces;

--- a/app_server/datasource/api/workspaceApi.js
+++ b/app_server/datasource/api/workspaceApi.js
@@ -2911,7 +2911,8 @@ const batchCloneWorkspace = async (req, res = {}) => {
       groups.map(async (group) => {
         let reqCopy = { ...req.body.copyWorkspaceRequest };
         reqCopy.name = `${group.name}: ${copyWorkspaceRequest.name}`;
-        reqCopy.owner = group.students[0];
+        reqCopy.owner = req.body.user;
+        reqCopy.group = group._id;
         const workspace = await cloneSingleWorkspace({
           ...req,
           body: { copyWorkspaceRequest: reqCopy },
@@ -3053,7 +3054,7 @@ async function cloneSingleWorkspace(req, res, next) {
     }
 
     // process basic settings
-    const { name, owner, mode, createdBy } = copyWorkspaceRequest;
+    const { name, owner, mode, createdBy, group } = copyWorkspaceRequest;
 
     if (mode === 'public' || mode === 'internet') {
       let isNameUnique = await apiUtils.isRecordUniqueByStringProp(
@@ -3083,6 +3084,7 @@ async function cloneSingleWorkspace(req, res, next) {
       mode: mode || originalWs.mode,
       createdBy: createdBy || user._id,
       organization: ownerOrg,
+      group,
     });
 
     // let savedWs = await newWs.save();

--- a/app_server/datasource/schemas/assignment.js
+++ b/app_server/datasource/schemas/assignment.js
@@ -48,6 +48,7 @@ var AssignmentSchema = new Schema(
       doAutoUpdateFromChildren: { type: Boolean, default: true },
       name: { type: String },
       createDate: { type: Date },
+      giveAccess: { type: Boolean, default: false },
     },
   },
   { versionKey: false }

--- a/app_server/datasource/schemas/comment.js
+++ b/app_server/datasource/schemas/comment.js
@@ -3,24 +3,26 @@ const Schema = mongoose.Schema;
 const ObjectId = Schema.ObjectId;
 
 const { resolveParentUpdates } = require('../api/parentWorkspaceApi');
+const { resolveGroupUpdates } = require('../api/CommentApi');
 
 /**
-  * @public
-  * @class Comment
-  * @description A comment may be made by a user on a Selection, Submission, or Workspace.
-  */
-var CommentSchema = new Schema({
-//== Shared properties (Because Monggose doesn't support schema inheritance)
-  createdBy: { type: ObjectId, ref: 'User', required: true },
-  createDate: { type: Date, 'default': Date.now() },
-  isTrashed: { type: Boolean, 'default': false },
-  lastModifiedBy: { type: ObjectId, ref: 'User' },
-  lastModifiedDate: { type: Date, 'default': Date.now() },
-//====
+ * @public
+ * @class Comment
+ * @description A comment may be made by a user on a Selection, Submission, or Workspace.
+ */
+var CommentSchema = new Schema(
+  {
+    //== Shared properties (Because Monggose doesn't support schema inheritance)
+    createdBy: { type: ObjectId, ref: 'User', required: true },
+    createDate: { type: Date, default: Date.now() },
+    isTrashed: { type: Boolean, default: false },
+    lastModifiedBy: { type: ObjectId, ref: 'User' },
+    lastModifiedDate: { type: Date, default: Date.now() },
+    //====
     /* What is the nature of this comment? */
-    label: {type: String, enum: ['notice', 'wonder', 'feedback']},
-    text: {type: String, required: true},
-    useForResponse: {type: Boolean, 'default': false},
+    label: { type: String, enum: ['notice', 'wonder', 'feedback'] },
+    text: { type: String, required: true },
+    useForResponse: { type: Boolean, default: false },
     /*
       Comments can be re-used, we keep a tree representing the re-use via
       parent/child relationships.  We also store all of the ancestors
@@ -47,37 +49,42 @@ var CommentSchema = new Schema({
         ancestors:  null
         children:   null
     */
-    origin: {type: ObjectId, ref:'Comment'},
-    ancestors: [{type:ObjectId, ref:'Comment'}],
+    origin: { type: ObjectId, ref: 'Comment' },
+    ancestors: [{ type: ObjectId, ref: 'Comment' }],
     // the comment this comment was based off of (which may in turn have a parent)
-    parent: {type: ObjectId, ref:'Comment'},
-    children: [{type:ObjectId, ref:'Comment'}],
-    selection: {type: ObjectId, ref:'Selection', required: true},
-    submission: {type: ObjectId, ref:'Submission', required: true},
-    workspace: {type: ObjectId, ref:'Workspace', required: true},
+    parent: { type: ObjectId, ref: 'Comment' },
+    children: [{ type: ObjectId, ref: 'Comment' }],
+    selection: { type: ObjectId, ref: 'Selection', required: true },
+    submission: { type: ObjectId, ref: 'Submission', required: true },
+    workspace: { type: ObjectId, ref: 'Workspace', required: true },
     /* Not to be confused with label, type depends on the object this comment is for */
-    type: {type: String, enum: ['selection', 'submission', 'workspace']},
+    type: { type: String, enum: ['selection', 'submission', 'workspace'] },
     originalComment: { type: ObjectId, ref: 'Comment' }, // when in a parent workspace to ref original
 
     /*
     For post save hook use only
     */
     wasNew: { type: Boolean, default: false, select: false },
-    updatedFields: [ { type: String, select: false } ],
-  }, {versionKey: false});
+    updatedFields: [{ type: String, select: false }],
+  },
+  { versionKey: false }
+);
 
 /**
-  * ## Pre-Validation
-  * Before saving we must verify (synchonously) that:
-  */
+ * ## Pre-Validation
+ * Before saving we must verify (synchonously) that:
+ */
 
 /* + The Selection exists */
 CommentSchema.pre('save', function (next) {
   mongoose.models.Selection.findById(this.selection)
     .lean()
     .exec(function (err, found) {
-      if (err) { next(new Error(err.message)); }
-      else { next(); }
+      if (err) {
+        next(new Error(err.message));
+      } else {
+        next();
+      }
     });
 });
 
@@ -86,8 +93,11 @@ CommentSchema.pre('save', function (next) {
   mongoose.models.Submission.findById(this.submission)
     .lean()
     .exec(function (err, found) {
-      if (err) { next(new Error(err.message)); }
-      else { next(); }
+      if (err) {
+        next(new Error(err.message));
+      } else {
+        next();
+      }
     });
 });
 
@@ -96,8 +106,11 @@ CommentSchema.pre('save', function (next) {
   mongoose.models.Workspace.findById(this.workspace)
     .lean()
     .exec(function (err, found) {
-      if (err) { next(new Error(err.message)); }
-      else { next(); }
+      if (err) {
+        next(new Error(err.message));
+      } else {
+        next();
+      }
     });
 });
 
@@ -110,16 +123,17 @@ CommentSchema.pre('save', function (next) {
     this.updatedFields = this.modifiedPaths();
   }
 
-  if(this.parent) {
+  if (this.parent) {
     mongoose.models.Comment.findById(this.parent)
       .lean()
       .exec(function (err, found) {
-        if (err) { next(new Error(err.message)); }
-        else {
-          if(found.origin) {
+        if (err) {
+          next(new Error(err.message));
+        } else {
+          if (found.origin) {
             comment.origin = found.origin; //point to the parents origin
           } else {
-            comment.origin = found;        //the parent better be an origin at this point
+            comment.origin = found; //the parent better be an origin at this point
           }
 
           next();
@@ -131,65 +145,96 @@ CommentSchema.pre('save', function (next) {
 });
 
 /**
-  * ## Post-Validation
-  * After saving we must ensure (synchonously) that:
-  */
+ * ## Post-Validation
+ * After saving we must ensure (synchonously) that:
+ */
 CommentSchema.post('save', function (comment) {
   /* + If deleted, all references are also deleted */
-  if( comment.isTrashed )
-  {
-    var commentIdObj = mongoose.Types.ObjectId( comment._id );
-    mongoose.models.Workspace.update({'_id': comment.workspace},
-      {$pull: {'comments': commentIdObj}},
+  if (comment.isTrashed) {
+    var commentIdObj = mongoose.Types.ObjectId(comment._id);
+    mongoose.models.Workspace.update(
+      { _id: comment.workspace },
+      { $pull: { comments: commentIdObj } },
       function (err, affected, result) {
-        if (err) { throw new Error(err.message); }
-      });
+        if (err) {
+          throw new Error(err.message);
+        }
+      }
+    );
 
-    mongoose.models.Submission.update({'_id': comment.submission},
-      {$pull: {'comments': commentIdObj}},
+    mongoose.models.Submission.update(
+      { _id: comment.submission },
+      { $pull: { comments: commentIdObj } },
       function (err, affected, result) {
-        if (err) { throw new Error(err.message); }
-      });
+        if (err) {
+          throw new Error(err.message);
+        }
+      }
+    );
 
-    mongoose.models.Selection.update({'_id': comment.selection},
-      {$pull: {'comments': commentIdObj}},
+    mongoose.models.Selection.update(
+      { _id: comment.selection },
+      { $pull: { comments: commentIdObj } },
       function (err, affected, result) {
-        if (err) { throw new Error(err.message); }
-      });
-  }
-  else { /* + If added, references are added where necessary */
-    mongoose.models.Workspace.update({'_id': comment.workspace},
-      {$addToSet: {'comments': comment}},
+        if (err) {
+          throw new Error(err.message);
+        }
+      }
+    );
+  } else {
+    /* + If added, references are added where necessary */
+    mongoose.models.Workspace.update(
+      { _id: comment.workspace },
+      { $addToSet: { comments: comment } },
       function (err, affected, result) {
-        if (err) { throw new Error(err.message); }
-      });
+        if (err) {
+          throw new Error(err.message);
+        }
+      }
+    );
 
-    mongoose.models.Submission.update({'_id': comment.submission},
-      {$addToSet: {'comments': comment}},
+    mongoose.models.Submission.update(
+      { _id: comment.submission },
+      { $addToSet: { comments: comment } },
       function (err, affected, result) {
-        if (err) { throw new Error(err.message); }
-      });
+        if (err) {
+          throw new Error(err.message);
+        }
+      }
+    );
 
-    mongoose.models.Selection.update({'_id': comment.selection},
-      {$addToSet: {'comments': comment}},
+    mongoose.models.Selection.update(
+      { _id: comment.selection },
+      { $addToSet: { comments: comment } },
       function (err, affected, result) {
-        if (err) { throw new Error(err.message); }
-      });
+        if (err) {
+          throw new Error(err.message);
+        }
+      }
+    );
 
-    if(comment.parent) {
-      mongoose.models.Comment.findByIdAndUpdate(comment.parent,
-        {$addToSet: {'children': comment }},
-        function(error, affected, results) {
-          if(error) { throw new Error(error.message); }
-        });
+    if (comment.parent) {
+      mongoose.models.Comment.findByIdAndUpdate(
+        comment.parent,
+        { $addToSet: { children: comment } },
+        function (error, affected, results) {
+          if (error) {
+            throw new Error(error.message);
+          }
+        }
+      );
     }
 
-    if(comment.origin) {
-      mongoose.models.Comment.findByIdAndUpdate(comment.origin,
-        {$addToSet: {'ancestors': comment }},
-        function(error, affected, results) {
-          if(error) { throw new Error(error.message); }
-        });
+    if (comment.origin) {
+      mongoose.models.Comment.findByIdAndUpdate(
+        comment.origin,
+        { $addToSet: { ancestors: comment } },
+        function (error, affected, results) {
+          if (error) {
+            throw new Error(error.message);
+          }
+        }
+      );
     }
   }
 
@@ -200,14 +245,20 @@ CommentSchema.post('save', function (comment) {
 
   if (wasNew) {
     resolveParentUpdates(comment.createdBy, comment, 'comment', 'create').catch(
-      err => {
+      (err) => {
         console.log('Error creating parent comment: ', err);
       }
     );
+    resolveGroupUpdates(comment, 'create');
   } else if (wereUpdatedFields) {
-    let allowedParentUpdateFields = ['isTrashed', 'children', 'ancestors', 'parent'];
+    let allowedParentUpdateFields = [
+      'isTrashed',
+      'children',
+      'ancestors',
+      'parent',
+    ];
 
-    let parentFieldsToUpdate = updatedFields.filter(field => {
+    let parentFieldsToUpdate = updatedFields.filter((field) => {
       return allowedParentUpdateFields.includes(field);
     });
 
@@ -221,9 +272,12 @@ CommentSchema.post('save', function (comment) {
       'comment',
       'update',
       parentFieldsToUpdate
-    ).catch(err => {
+    ).catch((err) => {
       console.log('Error updating parent comment: ', err);
     });
+    if (parentFieldsToUpdate.includes('isTrashed')) {
+      resolveGroupUpdates(comment, 'delete');
+    }
   }
 });
 

--- a/app_server/datasource/schemas/comment.js
+++ b/app_server/datasource/schemas/comment.js
@@ -242,8 +242,8 @@ CommentSchema.post('save', function (comment) {
 
   let wereUpdatedFields =
     Array.isArray(updatedFields) && updatedFields.length > 0;
-
-  if (wasNew) {
+  //don't make parent copies of group workspace copies of comments
+  if (wasNew && !comment.originalComment) {
     resolveParentUpdates(comment.createdBy, comment, 'comment', 'create').catch(
       (err) => {
         console.log('Error creating parent comment: ', err);

--- a/app_server/datasource/schemas/selection.js
+++ b/app_server/datasource/schemas/selection.js
@@ -185,8 +185,8 @@ SelectionSchema.post('save', function (selection) {
 
   let wereUpdatedFields =
     Array.isArray(updatedFields) && updatedFields.length > 0;
-
-  if (wasNew) {
+  //don't make parent copies of group workspace copies of selections
+  if (wasNew && !selection.originalSelection) {
     resolveParentUpdates(
       selection.createdBy,
       selection,

--- a/app_server/datasource/schemas/selection.js
+++ b/app_server/datasource/schemas/selection.js
@@ -195,7 +195,7 @@ SelectionSchema.post('save', function (selection) {
     ).catch((err) => {
       console.log('Error creating parent selection: ', err);
     });
-    resolveGroupWorkspaces(selection);
+    resolveGroupWorkspaces(selection, 'create');
   } else if (wereUpdatedFields) {
     let allowedParentUpdateFields = [
       'isTrashed',
@@ -219,6 +219,9 @@ SelectionSchema.post('save', function (selection) {
     ).catch((err) => {
       console.log('Error updating parent selection: ', err);
     });
+    if (parentFieldsToUpdate.includes('isTrashed')) {
+      resolveGroupWorkspaces(selection, 'delete');
+    }
   }
 });
 

--- a/app_server/datasource/schemas/selection.js
+++ b/app_server/datasource/schemas/selection.js
@@ -4,40 +4,42 @@ const _ = require('underscore');
 const ObjectId = Schema.ObjectId;
 
 const { resolveParentUpdates } = require('../api/parentWorkspaceApi');
+const { resolveGroupWorkspaces } = require('../api/selectionApi');
 
 /**
-  * @public
-  * @class Selection
-  * @description A Selection is an excerpt from a student Submission, this allows for a text selection or an image tagging
-  */
-var SelectionSchema = new Schema({
-//== Shared properties (Because Monggose doesn't support schema inheritance)
+ * @public
+ * @class Selection
+ * @description A Selection is an excerpt from a student Submission, this allows for a text selection or an image tagging
+ */
+var SelectionSchema = new Schema(
+  {
+    //== Shared properties (Because Monggose doesn't support schema inheritance)
     createdBy: { type: ObjectId, ref: 'User', required: true },
-    createDate: { type: Date, 'default': Date.now() },
-    isTrashed: { type: Boolean, 'default': false },
+    createDate: { type: Date, default: Date.now() },
+    isTrashed: { type: Boolean, default: false },
     lastModifiedBy: { type: ObjectId, ref: 'User' },
-    lastModifiedDate: { type: Date, 'default': Date.now() },
-//====
+    lastModifiedDate: { type: Date, default: Date.now() },
+    //====
     /* Coordinates are used by the frontend to help highlight a selection within submission text */
     coordinates: { type: String, required: true },
     text: { type: String, required: true },
     submission: { type: ObjectId, ref: 'Submission', required: true },
     workspace: { type: ObjectId, ref: 'Workspace' },
-    comments: [{type: ObjectId, ref: 'Comment'}],
-    taggings: [{type: ObjectId, ref: 'Tagging'}],
+    comments: [{ type: ObjectId, ref: 'Comment' }],
+    taggings: [{ type: ObjectId, ref: 'Tagging' }],
     relativeCoords: {
       tagLeftPct: Number,
       tagTopPct: Number,
     },
     relativeSize: {
       widthPct: Number,
-      heightPct: Number
+      heightPct: Number,
     },
     imageTagLink: { type: String }, // for image-tag selections; link to image
-    imageSrc: { type: String}, // either base-64 for old images, or link to image record,
+    imageSrc: { type: String }, // either base-64 for old images, or link to image record,
     vmtInfo: {
       startTime: { type: Number },
-      endTime: { type: Number }
+      endTime: { type: Number },
     },
     originalSelection: { type: ObjectId, ref: 'Selection' }, // when in a parent workspace to ref original
 
@@ -45,25 +47,26 @@ var SelectionSchema = new Schema({
     For post save hook use only
     */
     wasNew: { type: Boolean, default: false, select: false },
-    updatedFields: [ { type: String, select: false } ],
-  }, {versionKey: false});
-
+    updatedFields: [{ type: String, select: false }],
+  },
+  { versionKey: false }
+);
 
 /**
-  * ## Pre-Validation
-  * Before saving we must verify (synchonously) that:
-  */
+ * ## Pre-Validation
+ * Before saving we must verify (synchonously) that:
+ */
 SelectionSchema.pre('save', function (next) {
-  var toObjectId = function(elem, ind, arr) {
-    if( !(elem instanceof mongoose.Types.ObjectId) && !_.isUndefined(elem) ) {
+  var toObjectId = function (elem, ind, arr) {
+    if (!(elem instanceof mongoose.Types.ObjectId) && !_.isUndefined(elem)) {
       arr[ind] = mongoose.Types.ObjectId(elem);
     }
   };
 
   /** + Every ID reference in our object is properly typed.
-    *   This needs to be done BEFORE any other operation so
-    *   that native lookups and updates don't fail.
-    */
+   *   This needs to be done BEFORE any other operation so
+   *   that native lookups and updates don't fail.
+   */
   try {
     this.wasNew = this.isNew;
     if (!this.wasNew) {
@@ -73,24 +76,24 @@ SelectionSchema.pre('save', function (next) {
     this.comments.forEach(toObjectId);
     this.taggings.forEach(toObjectId);
     next();
-  }
-  catch(err) {
+  } catch (err) {
     next(new Error(err.message));
   }
 });
 
 /** And (asynchronously) that:
-  *
-  * + The Submission exists
-  */
+ *
+ * + The Submission exists
+ */
 SelectionSchema.pre('save', true, function (next, done) {
   mongoose.models.Submission.findById(this.submission)
     .lean()
     .exec(function (err, found) {
       if (err) {
         next(new Error(err.message));
+      } else {
+        next();
       }
-      else { next(); }
       done();
     });
 });
@@ -102,42 +105,46 @@ SelectionSchema.pre('save', true, function (next, done) {
     .exec(function (err, found) {
       if (err) {
         next(new Error(err.message));
+      } else {
+        next();
       }
-      else { next(); }
       done();
     });
 });
 
 /**
-  * ## Post-Validation
-  * After saving we must ensure (synchonously) that:
-  */
+ * ## Post-Validation
+ * After saving we must ensure (synchonously) that:
+ */
 SelectionSchema.post('save', function (selection) {
-  let selectionIdObj = mongoose.Types.ObjectId( selection._id );
+  let selectionIdObj = mongoose.Types.ObjectId(selection._id);
 
   /* + If deleted, all references are also deleted */
-  if( selection.isTrashed )
-  {
-    mongoose.models.Workspace.update({_id: selection.workspace},
-      {$pull: { selections : selectionIdObj }},
+  if (selection.isTrashed) {
+    mongoose.models.Workspace.update(
+      { _id: selection.workspace },
+      { $pull: { selections: selectionIdObj } },
       function (err, affected, result) {
         if (err) {
           throw new Error(err.message);
         }
-      });
+      }
+    );
 
-    mongoose.models.Submission.update({_id: selection.submission},
-      {$pull: { selections : selectionIdObj }},
+    mongoose.models.Submission.update(
+      { _id: selection.submission },
+      { $pull: { selections: selectionIdObj } },
       function (err, affected, result) {
         if (err) {
           throw new Error(err.message);
         }
-      });
+      }
+    );
 
     /*    + Note: Downstream reference updates must be `save`d
             to trigger their respective validators
     */
-    selection.populate('taggings comments', function(err, doc) {
+    selection.populate('taggings comments', function (err, doc) {
       if (err) {
         throw new Error(err.message);
       }
@@ -151,23 +158,27 @@ SelectionSchema.post('save', function (selection) {
         tag.save();
       });
     });
-  }
-  else { /* + If added, references are added everywhere necessary */
-    mongoose.models.Workspace.update({_id: selection.workspace},
-      {$addToSet: { selections : selectionIdObj}},
+  } else {
+    /* + If added, references are added everywhere necessary */
+    mongoose.models.Workspace.update(
+      { _id: selection.workspace },
+      { $addToSet: { selections: selectionIdObj } },
       function (err, affected, result) {
         if (err) {
           throw new Error(err.message);
         }
-      });
+      }
+    );
 
-    mongoose.models.Submission.update({_id: selection.submission},
-      {$addToSet: { selections : selectionIdObj }},
+    mongoose.models.Submission.update(
+      { _id: selection.submission },
+      { $addToSet: { selections: selectionIdObj } },
       function (err, affected, result) {
         if (err) {
           throw new Error(err.message);
         }
-      });
+      }
+    );
   }
 
   let { updatedFields, wasNew } = selection;
@@ -181,16 +192,17 @@ SelectionSchema.post('save', function (selection) {
       selection,
       'selection',
       'create'
-    ).catch(err => {
+    ).catch((err) => {
       console.log('Error creating parent selection: ', err);
     });
+    resolveGroupWorkspaces(selection);
   } else if (wereUpdatedFields) {
     let allowedParentUpdateFields = [
       'isTrashed',
       'relativeCoords',
-      'relativeSize'
+      'relativeSize',
     ];
-    let parentFieldsToUpdate = updatedFields.filter(field => {
+    let parentFieldsToUpdate = updatedFields.filter((field) => {
       return allowedParentUpdateFields.includes(field);
     });
 
@@ -204,7 +216,7 @@ SelectionSchema.post('save', function (selection) {
       'selection',
       'update',
       parentFieldsToUpdate
-    ).catch(err => {
+    ).catch((err) => {
       console.log('Error updating parent selection: ', err);
     });
   }


### PR DESCRIPTION
This update creates a new type of workspace that is between individual workspaces and parent workspaces:
- teachers can opt to create both individual and group linked workspaces for assignments
- submissions get copies to all workspaces
- comments and selections made in individual workspaces get added to group and parent workspaces
- comments and selections made in group workspaces do not get copied to individual workspaces
- instructors and filter between group work and individual work
- instructors now get their own linked workspaces when creating an assignment
- addresses issue #588 