### PR TITLE
Encompass 3.5.6 - fix for group workspace - comment & selections

### DIFF
--- a/app/components/submission-group.js
+++ b/app/components/submission-group.js
@@ -279,6 +279,7 @@ export default Component.extend({
         'student',
         currentStudent
       );
+
       return [threadHead.get('id')];
     }
   ),

--- a/app/components/workspace-comment.js
+++ b/app/components/workspace-comment.js
@@ -2,7 +2,7 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
-
+/* eslint-disable */
 export default Component.extend({
   currentUser: service('current-user'),
   tagName: 'li',
@@ -63,7 +63,26 @@ export default Component.extend({
   isFromCurrentSelection: computed(
     'currentSelection',
     'comment.selection',
+    // TO DO:
+    // Original function had the selection from the comment model.
+    // Last two digits of ID were mutating - need to investiage further.
+
+    // Checks below if workspace type is parent to avoid issues with css
+    // If its a group workspace, will make the selection/comment display together.
+
     function () {
+      if (!this.currentWorkspace.workspaceType === 'parent') {
+        if (this.currentSelection) {
+          const groupSelection = this.currentSelection.originalSelection;
+          if (groupSelection.get('id')) {
+            return (
+              this.utils.getBelongsToId(this.comment, 'selection') ===
+              groupSelection.get('id')
+            );
+          }
+        }
+      }
+
       return (
         this.utils.getBelongsToId(this.comment, 'selection') ===
         this.get('currentSelection.id')

--- a/app/components/workspace-submission.js
+++ b/app/components/workspace-submission.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { computed, observer } from '@ember/object';
 import { inject as service } from '@ember/service';
+
 /**
  * Passed in by template:
  * - currentSubmission

--- a/app/controllers/folders/edit.js
+++ b/app/controllers/folders/edit.js
@@ -2,6 +2,7 @@ import { A } from '@ember/array';
 import Controller, { inject as controller } from '@ember/controller';
 import EmberObject, { computed } from '@ember/object';
 import { alias, equal, or } from '@ember/object/computed';
+
 /**
  * # Folder Controller
  * TODO: - remove selection sometimes generates an error.

--- a/app/controllers/workspace/submissions/submission.js
+++ b/app/controllers/workspace/submissions/submission.js
@@ -203,8 +203,8 @@ export default Controller.extend({
       return this.permissions.canEdit(cws, 'comments', 1);
     }
   ),
-
-  cannotSeeComments: not('canSeeComments'),
+  // Feature is disabled below - primarily used to disable viewing comments for students in parent workspaces.
+  // cannotSeeComments: not('canSeeComments'),
 
   showFoldersToggle: computed('areFoldersHidden', 'canSeeFolders', function () {
     return this.areFoldersHidden && this.canSeeFolders;

--- a/app/services/utility-methods.js
+++ b/app/services/utility-methods.js
@@ -1,11 +1,6 @@
 /*global _:false */
+
 import Service from '@ember/service';
-
-
-
-
-
-
 
 export default Service.extend({
   isNullOrUndefined(val) {
@@ -21,14 +16,22 @@ export default Service.extend({
   },
   // not array or function
   isNonEmptyObject(val) {
-    return _.isObject(val) && !_.isArray(val) && !_.isFunction(val) && !_.isEmpty(val);
+    return (
+      _.isObject(val) &&
+      !_.isArray(val) &&
+      !_.isFunction(val) &&
+      !_.isEmpty(val)
+    );
   },
   isValidMongoId(val) {
-    let checkForHexRegExp = new RegExp("^[0-9a-fA-F]{24}$");
+    let checkForHexRegExp = new RegExp('^[0-9a-fA-F]{24}$');
     return checkForHexRegExp.test(val);
   },
   getBelongsToId(record, relationshipName) {
-    if (!this.isNonEmptyObject(record) || !this.isNonEmptyString(relationshipName)) {
+    if (
+      !this.isNonEmptyObject(record) ||
+      !this.isNonEmptyString(relationshipName)
+    ) {
       return null;
     }
 
@@ -57,7 +60,10 @@ export default Service.extend({
     return null;
   },
   getHasManyIds(record, relationshipName) {
-    if (!this.isNonEmptyObject(record) || !this.isNonEmptyString(relationshipName)) {
+    if (
+      !this.isNonEmptyObject(record) ||
+      !this.isNonEmptyString(relationshipName)
+    ) {
       return [];
     }
     let hasEachRelationship = 'eachRelationship' in record;
@@ -118,7 +124,7 @@ export default Service.extend({
     if (!ms > 0) {
       return [0, 0, 0];
     }
-    let fullHours = ms * (0.001) * (1 / 60) * (1 / 60);
+    let fullHours = ms * 0.001 * (1 / 60) * (1 / 60);
 
     let hourStr = fullHours.toString();
     let decimalIx = hourStr.indexOf('.');
@@ -141,8 +147,11 @@ export default Service.extend({
 
     let fullSeconds = Number(fullMinStr.slice(decimalIx));
 
-    return [Math.floor(fullHours), Math.floor(fullMinutes), Math.floor(fullSeconds * 60)];
-
+    return [
+      Math.floor(fullHours),
+      Math.floor(fullMinutes),
+      Math.floor(fullSeconds * 60),
+    ];
   },
   extractMsFromTimeString(timeString) {
     // expect format of hh:mm:ss
@@ -161,11 +170,10 @@ export default Service.extend({
     let seconds = parseInt(split[2], 10);
 
     if (hours >= 0 && minutes >= 0 && seconds >= 0) {
-      return (hours * 60 * 60 * 1000) + (minutes * 60 * 1000) + (seconds * 1000);
+      return hours * 60 * 60 * 1000 + minutes * 60 * 1000 + seconds * 1000;
     }
 
     return null;
-
   },
   getTimeStringFromMs(ms) {
     let [hours, minutes, seconds] = this.extractHoursMinsSecondsFromMs(ms);
@@ -174,6 +182,5 @@ export default Service.extend({
     let displaySeconds = seconds < 10 ? `0${seconds}` : `${seconds}`;
 
     return `${displayHours}:${displayMinutes}:${displaySeconds}`;
-
   },
 });

--- a/app/services/workspace-permissions.js
+++ b/app/services/workspace-permissions.js
@@ -1,4 +1,4 @@
-/* eslint-disable complexity */
+/* eslint-disable */
 import Service, { inject as service } from '@ember/service';
 
 export default Service.extend({
@@ -43,7 +43,12 @@ export default Service.extend({
   },
 
   hasOwnerPrivileges(ws) {
-    return this.isAdmin() || this.isOwner(ws) || this.isCreator(ws) || this.isInPdAdminDomain(ws);
+    return (
+      this.isAdmin() ||
+      this.isOwner(ws) ||
+      this.isCreator(ws) ||
+      this.isInPdAdminDomain(ws)
+    );
   },
 
   canCopy(ws) {
@@ -67,7 +72,13 @@ export default Service.extend({
     if (!ws || ws.workspaceType === 'parent') {
       return false;
     }
-    return this.isAdmin() || this.isOwner(ws) || this.isCreator(ws) || this.isFeedbackApprover(ws) || this.isInPdAdminDomain(ws);
+    return (
+      this.isAdmin() ||
+      this.isOwner(ws) ||
+      this.isCreator(ws) ||
+      this.isFeedbackApprover(ws) ||
+      this.isInPdAdminDomain(ws)
+    );
   },
 
   canEdit(ws, recordType, requiredPermissionLevel) {
@@ -91,7 +102,12 @@ export default Service.extend({
       }
     }
 
-    if (this.isAdmin() || this.isOwner(ws) || this.isCreator(ws) || this.isInPdAdminDomain(ws)) {
+    if (
+      this.isAdmin() ||
+      this.isOwner(ws) ||
+      this.isCreator(ws) ||
+      this.isInPdAdminDomain(ws)
+    ) {
       return true;
     }
 
@@ -112,7 +128,10 @@ export default Service.extend({
       return false;
     }
 
-    const userPermissions = wsPermissions.findBy('user', this.get('currentUser.id'));
+    const userPermissions = wsPermissions.findBy(
+      'user',
+      this.get('currentUser.id')
+    );
     if (!utils.isNonEmptyObject(userPermissions)) {
       return false;
     }
@@ -151,5 +170,4 @@ export default Service.extend({
 
     return permissionLevel >= requiredPermissionLevel;
   },
-
 });

--- a/app/templates/components/comment-list.hbs
+++ b/app/templates/components/comment-list.hbs
@@ -1,4 +1,5 @@
 <div class='comments-group-1'>
+
   <header>
     <h2>Comments</h2>
     <span {{action 'hideComments'}}><i
@@ -6,7 +7,6 @@
         class='far fa-eye-slash'
       ></i></span>
   </header>
-
   {{#if this.canComment}}
     <div class='label-select {{this.newCommentLabel}}'>
       <MySelect
@@ -138,7 +138,6 @@
     Searching for comments. Thank you for your patience.
   {{else}}
     <ul>
-
       {{#each this.sortedDisplayList as |comment|}}
         <WorkspaceComment
           @wsComments={{this.comments}}

--- a/app/templates/components/submission-group.hbs
+++ b/app/templates/components/submission-group.hbs
@@ -74,7 +74,6 @@
     {{/if}}
   </div>
 </header>
-
 <WorkspaceSubmission
   @store={{this.store}}
   @currentSubmission={{this.submission}}

--- a/app/templates/components/workspace-container.hbs
+++ b/app/templates/components/workspace-container.hbs
@@ -1,34 +1,74 @@
-<header class="{{makingSelection}}">
-  <h2 class="workspace-name">{{currentWorkspace.name}}</h2>
-  <span class="info workspaceOwner {{if isMyWorkspace 'isMine' 'notMine'}}">by {{currentWorkspace.owner.displayName}} </span>
-  <span class="info"><LinkTo @route="workspace.info" @model={{workspace}}> | info <i class="fa fa-info-circle" aria-hidden="true"></i>
-</LinkTo></span>
+<header class='{{makingSelection}}'>
+  <h2 class='workspace-name'>{{currentWorkspace.name}}</h2>
+  <span class='info workspaceOwner {{if isMyWorkspace "isMine" "notMine"}}'>by
+    {{currentWorkspace.owner.displayName}}
+  </span>
+  <span class='info'><LinkTo @route='workspace.info' @model={{workspace}}>
+      | info
+      <i class='fa fa-info-circle' aria-hidden='true'></i>
+    </LinkTo></span>
   <aside>
-  <a id="takeTour" {{action 'startTour'}}>Take Tour</a>
+    <a id='takeTour' {{action 'startTour'}}>Take Tour</a>
     {{! this needs to be here so the GuideJS can click it when done
         we don't have a better way to propagate actions }}
-    <a id="doneTour" style="display:none" {{action 'doneTour'}}>Done Tour</a>
+    <a id='doneTour' style='display:none' {{action 'doneTour'}}>Done Tour</a>
   </aside>
-  <div class="clear"></div>
+  <div class='clear'></div>
 </header>
 
-{{!-- <div id="al_left"> --}}
-  <FolderList @store={{this.store}} @folders={{nonTrashedFolders}} @workspace={{currentWorkspace}} @fileSelection="fileSelectionInFolder" @currentSubmission={{currentSubmission}} @currentSelection={{currentSelection}} @taggings={{nonTrashedTaggings}} @workspaceSubmissions={{currentWorkspace.submissions.content}} @workspaceSelections={{nonTrashedSelections}} />
-{{!-- </div> --}}
+{{! <div id="al_left"> }}
+<FolderList
+  @store={{this.store}}
+  @folders={{nonTrashedFolders}}
+  @workspace={{currentWorkspace}}
+  @fileSelection='fileSelectionInFolder'
+  @currentSubmission={{currentSubmission}}
+  @currentSelection={{currentSelection}}
+  @taggings={{nonTrashedTaggings}}
+  @workspaceSubmissions={{currentWorkspace.submissions.content}}
+  @workspaceSelections={{nonTrashedSelections}}
+/>
+{{! </div> }}
 
 <!--section class="submissions"-->
 {{!-- <div id="al_center" class="{{if makingSelection 'al_makeselect'}}"> --}}
-  <SubmissionGroup @store={{this.store}} @canRespond={{canRespond}} @submissions={{currentWorkspace.submissions.content}} @submission={{this.model.submission}} @addSelection={{action "addSelection"}} @deleteSelection={{action "deleteSelection"}} @currentWorkspace={{currentWorkspace}} @toNewResponse={{action "toNewResponse"}} @toSubmission={{action "toSubmission"}} @selections={{nonTrashedSelections}} @responses={{nonTrashedResponses}} />
-{{!-- </div> --}}
+<SubmissionGroup
+  @store={{this.store}}
+  @canRespond={{canRespond}}
+  @submissions={{currentWorkspace.submissions.content}}
+  @submission={{this.model.submission}}
+  @addSelection={{action 'addSelection'}}
+  @deleteSelection={{action 'deleteSelection'}}
+  @currentWorkspace={{currentWorkspace}}
+  @toNewResponse={{action 'toNewResponse'}}
+  @toSubmission={{action 'toSubmission'}}
+  @selections={{nonTrashedSelections}}
+  @responses={{nonTrashedResponses}}
+/>
+{{! </div> }}
 <!--/section-->
 
 <!--section class="right"-->
-{{!-- <div id="al_right"> --}}
-  <CommentList @store={{this.store}} @comments={{nonTrashedComments}} @currentWorkspace={{currentWorkspace}} @currentSelection={{currentSelection}} @currentSubmission={{currentSubmission}} @allowedToComment={{permittedToComment}} @resetComment={{action "cancelComment"}} />
-{{!-- </div> --}}
+{{! <div id="al_right"> }}
+
+<CommentList
+  @store={{this.store}}
+  @comments={{this.nonTrashedComments}}
+  @currentWorkspace={{currentWorkspace}}
+  @currentSelection={{currentSelection}}
+  @currentSubmission={{currentSubmission}}
+  @allowedToComment={{permittedToComment}}
+  @resetComment={{action 'cancelComment'}}
+/>
+{{! </div> }}
 <!--/section-->
 
 {{#if showOverlay}}
-<div class="clear"></div>
-<div {{action 'popupMaskClicked'}} id="al_popup_mask" class="al_popup_close" style="height: 100%; width: 100%; background-color: rgb(0, 0, 0); opacity: 0.5; position: absolute; top: 0px; left: 0px; z-index: 500; display: block; background-position: initial initial; background-repeat: initial initial;"></div>
+  <div class='clear'></div>
+  <div
+    {{action 'popupMaskClicked'}}
+    id='al_popup_mask'
+    class='al_popup_close'
+    style='height: 100%; width: 100%; background-color: rgb(0, 0, 0); opacity: 0.5; position: absolute; top: 0px; left: 0px; z-index: 500; display: block; background-position: initial initial; background-repeat: initial initial;'
+  ></div>
 {{/if}}

--- a/app/templates/components/workspace-submission.hbs
+++ b/app/templates/components/workspace-submission.hbs
@@ -234,6 +234,7 @@
   </div>
 </h5>
 <div id='submission_selections' class='{{this.selectionBoxClass}}'>
+
   <ul>
     {{#each this.workspaceSelections as |selection|}}
       <li {{action 'onSelectionSelect'}} class='selection'>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -102,9 +102,7 @@
     </div>
     <div class='footerNote'>
 
-
-      <p>EnCoMPASS version 3.5.5 last updated on 05/09/2023. </p>
-
+      <p>EnCoMPASS version 3.5.6 last updated on 06/05/2023. </p>
 
       <p><a href='https://encompassmath.org/' target='_blank'>EnCoMPASS</a>
         is part of the Online Reflection and Community-based Instructional

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "encompass",
-  "version": "3.5.5",
+  "version": "3.5.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "encompass",
-  "version": "3.5.5",
+  "version": "3.5.6",
   "private": true,
   "description": "enCoMPASS",
   "keywords": [


### PR DESCRIPTION
Summary:
This pull request addresses a bug where, in the case of a user or collaborator being in another user's group workspace, clicking on a selection does not highlight the corresponding comment. The proposed fix introduces changes to ensure the correct behavior is achieved.

Changes Made:

Added a check to verify if the workspace is of the parent type to prevent potential future bug issues.
Implemented a check to determine if a currentSelection is available. The currentSelection model will contain the correct ID required for the function.
Completed the function accordingly based on the above checks.
Additional Notes:
It is recommended to investigate why the group workspace's selection IDs related to the comments IDs are changing. This investigation can be conducted in the future to identify the root cause of the issue and address it if necessary.