### PR TITLE
fix for Info link on WS grid

### DIFF
--- a/app/templates/components/workspace-list-item.hbs
+++ b/app/templates/components/workspace-list-item.hbs
@@ -93,9 +93,9 @@
       <div class="item-card name">
         <LinkTo @route="workspace.work" @model={{this.workspace.id}} class="workspace-name">
           <span class={{if this.workspace.isTrashed 'strikethrough'}}>{{{this.workspace.name}}}</span>
-            <LinkTo @route="workspace.info" @model={{this.workspace.id}}>
-              <i class="fa fa-info-circle workspace_info" aria-hidden="true"></i>
-            </LinkTo>
+        </LinkTo>
+        <LinkTo @route="workspace.info" @model={{this.workspace.id}}>
+          <i class="fa fa-info-circle workspace_info" aria-hidden="true"></i>
         </LinkTo>
       </div>
     </div>


### PR DESCRIPTION
Pull request includes a fix for the proper links when user is in grid view, when clicking the "i" button.