### PR TITLE
My feedback tab refractor

### DIFF
--- a/app/components/home-page.hbs
+++ b/app/components/home-page.hbs
@@ -1,4 +1,4 @@
-<div class='home--container{{unless this.isExpanded ' closed'}}'>
+<div class='home--container{{unless this.isExpanded " closed"}}'>
   <EmberTable as |t|>
     <t.head
       @columns={{@tableColumns}}
@@ -25,7 +25,9 @@
               @model={{rowValue.id}}
             >{{format-date cellValue 'MM/DD/YYYY'}}</LinkTo>
           {{else if (is-equal @type 'feedback')}}
-            {{#if (is-equal columnValue.name 'Workspace')}}
+            {{#if (is-equal columnValue.name 'Student Submission')}}
+              <a {{on 'click' (fn this.toResponse rowValue)}}>{{cellValue}}</a>
+            {{else if (is-equal columnValue.name 'Mentor')}}
               <a {{on 'click' (fn this.toResponse rowValue)}}>{{cellValue}}</a>
             {{else if (is-equal columnValue.name 'Status')}}
               <svg height='20' width='20'>

--- a/app/components/response-mentor-thread.js
+++ b/app/components/response-mentor-thread.js
@@ -1,9 +1,17 @@
+/**
+ * #
+ * @description 
+  Class component file to response-mentor-thread component. Purpose is to show responses for a mentor thread.
+ * @author Yousof Wakili
+ * @since 3.6.2
+ */
+
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class ResponseMentorThreadComponent extends Component {
-  @tracked show = false;
+  @tracked show = true;
 
   get showResponsesText() {
     return this.showResponses

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -84,10 +84,11 @@ export default class IndexController extends Controller {
               : 'mentorDisplay'
           }`,
         },
-        { name: 'Workspace', valuePath: 'workspaceName' },
+
         { name: 'Latest Feedback', valuePath: 'latestReply.createDate' },
         { name: 'Latest Revision', valuePath: 'latestRevision.createDate' },
         { name: 'Status', valuePath: 'statusMessage' },
+        { name: 'Workspace', valuePath: 'workspaceName' },
       ];
     }
 

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -74,22 +74,23 @@ export default class IndexController extends Controller {
     }
     if (this.dataToShow === 'feedback') {
       return [
-        { name: 'Workspace', valuePath: 'workspaceName' },
-        { name: 'Latest Feedback', valuePath: 'latestReply.createDate' },
-        { name: 'Latest Revision', valuePath: 'latestRevision.createDate' },
         {
-          name: `${this.activeDetailTab === 'Given' ? 'Student' : 'Mentor'}`,
+          name: `${
+            this.activeDetailTab === 'Given' ? 'Student Submission' : 'Mentor'
+          }`,
           valuePath: `${
             this.activeDetailTab === 'Given'
               ? 'studentDisplay'
               : 'mentorDisplay'
           }`,
         },
+        { name: 'Workspace', valuePath: 'workspaceName' },
+        { name: 'Latest Feedback', valuePath: 'latestReply.createDate' },
+        { name: 'Latest Revision', valuePath: 'latestRevision.createDate' },
         { name: 'Status', valuePath: 'statusMessage' },
       ];
     }
 
-    //getter must return a value
     return [];
   }
   // updates when user changes tabs and gets sent to table
@@ -178,10 +179,12 @@ export default class IndexController extends Controller {
       const received = responses.filter(
         (response) => response.threadType === 'submitter'
       );
+      // Under "given" tab
       const sent = responses.filter(
         (response) =>
           response.threadType === 'mentor' || response.threadType === 'approver'
       );
+
       const threads = [
         { label: 'Given', details: sent, type: 'response' },
         { label: 'Received', details: received, type: 'response' },


### PR DESCRIPTION
This pull request includes the following updates:

- In the "feedback" tab of the index page it will default to the student name directing the user to the responses.
- Workspace name is at the end of the column
- In the mentor thread, all responses will default to being in open state instead of closed on first render. 