### PR TITLE
Fix AI Button Visibility and Draft Generation for student Submissions coming from different sources

### DIFF
--- a/app/components/response-container.js
+++ b/app/components/response-container.js
@@ -55,7 +55,9 @@ export default class ResponseContainer extends Component {
   }
 
   get submissions() {
-    return this.args.submissions || [];
+    const subs = this.args.submissions || [];
+    // Filter out any response models that snuck in
+    return subs.filter((s) => s.constructor.modelName === 'submission');
   }
 
   get storeResponses() {

--- a/app/components/response-mentor-reply.hbs
+++ b/app/components/response-mentor-reply.hbs
@@ -16,7 +16,7 @@
   {{/if}}
 {{/unless}}
 
-  {{#if this.sortedMentorReplies}}
+  {{#if this.sortedMentorReplies.length}}
     {{#unless @isOlderRevision}}
       {{#if @isCreating}}
         <h3 class='previous-responses-header'>Previous Conversation</h3>
@@ -152,6 +152,27 @@
       {{/if}}
     {{/each}}
 
+    {{! NEW: Show "New Response" button after responses when no drafts exist }}
+    {{#unless @isOlderRevision}}
+      {{#unless this.hasDrafts}}
+        {{#unless @isCreating}}
+          <div class="new-response-section">
+            <p class='info'>Ready to send another response?</p>
+            {{#if this.canSendNew}}
+              <div class="submit-buttons button-row">
+                <LinkTo
+                  @route="responses.new.submission"
+                  @model={{@submission.id}}
+                  class="primary-button"
+                >
+                  New Response
+                </LinkTo>
+              </div>
+            {{/if}}
+          </div>
+        {{/unless}}
+      {{/unless}}
+    {{/unless}}
 
   {{else}}
     {{#unless @isOlderRevision}}

--- a/app/components/response-mentor-reply.js
+++ b/app/components/response-mentor-reply.js
@@ -72,7 +72,8 @@ export default class ResponseMentorReplyComponent extends Component {
   }
 
   get isComposing() {
-    this._checkResponseChange();
+    // Don't call _checkResponseChange during rendering - it causes reactivity issues
+    // The check will happen in actions instead
     return this.isEditing || this.isRevising || this.isFinishingDraft;
   }
 
@@ -136,22 +137,64 @@ export default class ResponseMentorReplyComponent extends Component {
   get showApproverNoteInput() {
     return this.isComposing && this.newReplyStatus !== 'approved';
   }
-
   get sortedMentorReplies() {
-    const responses =
-      this.args.submissionResponses || this.args.submission?.responses;
-    if (!responses) {
-      return [];
-    }
-    return (
-      responses
-        ?.filter((reply) => reply.responseType === 'mentor' && !reply.isTrashed)
-        .sortBy('createDate') || []
+    const mentorReplies = this.args.submissionResponses?.filter(
+      (reply) => reply.responseType === 'mentor' && !reply.isTrashed
     );
+
+    console.log('sortedMentorReplies:', {
+      total: this.args.submissionResponses?.length,
+      afterFilter: mentorReplies?.length,
+      replies: mentorReplies?.map((r) => ({
+        id: r.id,
+        status: r.status,
+        isTrashed: r.isTrashed,
+        text: r.text?.substring(0, 50),
+      })),
+    });
+    if (!mentorReplies || mentorReplies.length === 0) {
+      return null;
+    }
+
+    return mentorReplies.sortBy('createDate');
   }
 
   get showNoteHeader() {
     return this.showApproverNoteInput || this.showDisplayNote;
+  }
+
+  get hasDrafts() {
+    const responses = this.args.submissionResponses;
+
+    // Handle PromiseManyArray - convert to plain array
+    const responsesArray = Array.isArray(responses)
+      ? responses
+      : responses?.toArray?.() || [];
+
+    if (responsesArray.length === 0) {
+      console.log('hasDrafts: No responses loaded yet');
+      return true; // Assume drafts exist until data loads
+    }
+
+    const result = responsesArray.some(
+      (reply) =>
+        reply.responseType === 'mentor' &&
+        !reply.isTrashed &&
+        reply.status === 'draft'
+    );
+
+    console.log('hasDrafts check:', {
+      total: responsesArray.length,
+      hasDrafts: result,
+      drafts: responsesArray
+        .filter(
+          (r) =>
+            r.responseType === 'mentor' && !r.isTrashed && r.status === 'draft'
+        )
+        .map((d) => ({ id: d.id, status: d.status, isTrashed: d.isTrashed })),
+    });
+
+    return result;
   }
 
   get showDisplayNote() {
@@ -182,12 +225,20 @@ export default class ResponseMentorReplyComponent extends Component {
   };
 
   get canSendNew() {
-    return (
+    const result =
       !this.args.isParentWorkspace &&
       this.args.canSend &&
       !this.args.isOwnSubmission &&
-      !this.args.isOlderRevision
-    );
+      !this.args.isOlderRevision;
+    console.log('canSendNew check:', {
+      isParentWorkspace: this.args.isParentWorkspace,
+      canSend: this.args.canSend,
+      isOwnSubmission: this.args.isOwnSubmission,
+      isOlderRevision: this.args.isOlderRevision,
+      result,
+    });
+
+    return result;
   }
 
   get sendButtonText() {

--- a/app/components/response-new.hbs
+++ b/app/components/response-new.hbs
@@ -136,18 +136,18 @@
         type='button'
         {{on 'click' (fn this.saveResponse false)}}
       >{{this.submitButtonText}}</button>
-       {{#if this.showAIButton}}
-          <button
-            class='primary-button ai-draft'
-            type='button'
-            {{on 'click' this.generateAIDraft}}
-          >Generate AI Draft</button>
-       {{/if}}
-      <button
-        class='primary-button save-draft'
-        type='button'
-        {{on 'click' (fn this.saveResponse true)}}
-      >Save as Draft</button>
+        <button
+          class='primary-button ai-draft'
+          type='button'
+          disabled={{this.aiButtonDisabled}}
+          title={{this.aiButtonTooltip}}
+          {{on 'click' this.generateAIDraft}}
+        >Generate AI Draft</button>
+        <button
+          class='primary-button save-draft'
+          type='button'
+          {{on 'click' (fn this.saveResponse true)}}
+        >Save as Draft</button>
     </div>
   </section>
 </div>

--- a/app/components/response-new.hbs
+++ b/app/components/response-new.hbs
@@ -136,7 +136,7 @@
         type='button'
         {{on 'click' (fn this.saveResponse false)}}
       >{{this.submitButtonText}}</button>
-       {{#if @responseData.submission}}
+       {{#if this.showAIButton}}
           <button
             class='primary-button ai-draft'
             type='button'

--- a/app/components/response-new.js
+++ b/app/components/response-new.js
@@ -97,6 +97,10 @@ export default class ResponseNewComponent extends Component {
     );
   }
 
+  get hasSubmission() {
+    return Boolean(this.args.submission);
+  }
+
   get filteredComments() {
     if (!this.args.responseData?.comments) return [];
 
@@ -237,6 +241,11 @@ export default class ResponseNewComponent extends Component {
     return 'More Details';
   }
 
+  get showAIButton() {
+    const result = this.hasSubmission && this.hasStudentWork;
+    return result;
+  }
+
   get isValidQuillContent() {
     return !this.isQuillEmpty && !this.isQuillTooLong;
   }
@@ -285,8 +294,43 @@ export default class ResponseNewComponent extends Component {
     return str;
   }
 
+  get actualSubmission() {
+    return this.args.responseData?._pendingSubmission ?? this.args.submission;
+  }
+
+  get hasStudentWork() {
+    const submission = this.actualSubmission;
+
+    if (!submission) {
+      return false;
+    }
+
+    // Check direct submission properties first
+    let shortAnswer = submission.shortAnswer?.trim();
+    let longAnswer = submission.longAnswer?.trim();
+
+    // If not found, check the answer relationship (for VMT submissions)
+    if (!shortAnswer && !longAnswer) {
+      const answerId = submission.belongsTo('answer').id();
+      if (answerId) {
+        // Use peekRecord to avoid triggering fetches
+        const answer = this.store.peekRecord('answer', answerId);
+        if (answer) {
+          shortAnswer = answer.answer?.trim();
+          longAnswer = answer.explanation?.trim();
+        }
+      }
+    }
+
+    return Boolean(shortAnswer || longAnswer);
+  }
+
   clearErrorProps() {
     this.args.removeMessages?.(this.errorPropsToRemove);
+  }
+
+  _getSubmissionId() {
+    return this.args.submission?.id ?? null;
   }
 
   preFormatText() {
@@ -491,7 +535,14 @@ export default class ResponseNewComponent extends Component {
 
   @action
   async generateAIDraft() {
-    const submissionId = this.args.responseData.submission.get('id');
+    const submissionId = this._getSubmissionId();
+    if (!submissionId) {
+      this.alert.showToast(
+        'error',
+        'Cannot generate AI draft: Submission not found'
+      );
+      return;
+    }
     const url = `/api/aiDraft?target=${encodeURIComponent(submissionId)}`;
 
     this.loading.handleLoadingMessage(

--- a/app/components/response-new.js
+++ b/app/components/response-new.js
@@ -241,9 +241,23 @@ export default class ResponseNewComponent extends Component {
     return 'More Details';
   }
 
-  get showAIButton() {
-    const result = this.hasSubmission && this.hasStudentWork;
-    return result;
+  get aiButtonTooltip() {
+    if (!this.hasSubmission) {
+      return 'AI draft generation requires a valid submission';
+    }
+    if (!this.hasStudentWork) {
+      return 'AI draft generation requires student work (answers or explanations)';
+    }
+    return 'Generate AI draft based on student work';
+  }
+  get aiButtonDisabled() {
+    const disabled = !this.hasSubmission || !this.hasStudentWork;
+    console.log('aiButtonDisabled:', {
+      disabled,
+      hasSubmission: this.hasSubmission,
+      hasStudentWork: this.hasStudentWork,
+    });
+    return disabled;
   }
 
   get isValidQuillContent() {
@@ -295,7 +309,7 @@ export default class ResponseNewComponent extends Component {
   }
 
   get actualSubmission() {
-    return this.args.responseData?._pendingSubmission ?? this.args.submission;
+    return this.args.submission;
   }
 
   get hasStudentWork() {
@@ -330,7 +344,11 @@ export default class ResponseNewComponent extends Component {
   }
 
   _getSubmissionId() {
-    return this.args.submission?.id ?? null;
+    return (
+      this.args.responseData?._submissionRef?.id ??
+      this.args.submission?.id ??
+      null
+    );
   }
 
   preFormatText() {
@@ -434,6 +452,16 @@ export default class ResponseNewComponent extends Component {
     response.set('text', this.quillText);
     response.set('note', this.args.replyNote);
 
+    // Set submission relationship from passed argument
+    // Check if submission content exists, not just the property
+    if (this.args.submission) {
+      console.log(
+        'Setting submission relationship to:',
+        this.args.submission.id
+      );
+      response.set('submission', this.args.submission);
+    }
+
     if (!response.get('createdBy.content')) {
       response.set('createdBy', this.currentUser.user);
     }
@@ -443,6 +471,15 @@ export default class ResponseNewComponent extends Component {
   }
 
   handleSaveSuccess(savedResponse, toastMessage, isDraft) {
+    console.log(
+      'handleSaveSuccess called - savedResponse:',
+      savedResponse.id,
+      'isDraft:',
+      isDraft
+    );
+    console.log('Saved response submission:', savedResponse.submission?.id);
+    console.log('Saved response status:', savedResponse.status);
+
     this.loading.handleLoadingMessage(
       this,
       'end',
@@ -459,7 +496,10 @@ export default class ResponseNewComponent extends Component {
     );
 
     if (isDraft) {
-      // Navigate to responses.submission to view the draft with Edit Draft button
+      // For drafts, refresh the current route to show the new draft
+      this.args.handleResponseThread?.(savedResponse, 'mentor');
+
+      // Refresh the route to reload responses including the new draft
       this.router.transitionTo(
         'responses.submission',
         this.args.submission.id,
@@ -467,6 +507,8 @@ export default class ResponseNewComponent extends Component {
           queryParams: { responseId: savedResponse.id },
         }
       );
+
+      console.log('Draft saved successfully, refreshing route');
     } else {
       this.args.handleResponseThread?.(savedResponse, 'mentor');
       this.args.onSaveSuccess?.(this.args.submission, savedResponse);
@@ -535,11 +577,45 @@ export default class ResponseNewComponent extends Component {
 
   @action
   async generateAIDraft() {
+    console.log('generateAIDraft clicked:', {
+      hasSubmission: this.hasSubmission,
+      hasStudentWork: this.hasStudentWork,
+      submission: this.args.submission,
+    });
+    // Check if AI generation is appropriate
+    if (!this.hasSubmission) {
+      this.alert.showToast(
+        'error',
+        'Cannot generate AI draft: No submission found',
+        'bottom-end',
+        5000,
+        false,
+        null
+      );
+      return;
+    }
+
+    if (!this.hasStudentWork) {
+      this.alert.showToast(
+        'info',
+        'Cannot generate AI draft: No student work found. AI drafts require student answers or explanations to analyze.',
+        'bottom-end',
+        6000,
+        false,
+        null
+      );
+      return;
+    }
+
     const submissionId = this._getSubmissionId();
     if (!submissionId) {
       this.alert.showToast(
         'error',
-        'Cannot generate AI draft: Submission not found'
+        'Cannot generate AI draft: Submission ID not found',
+        'bottom-end',
+        5000,
+        false,
+        null
       );
       return;
     }

--- a/app/models/submission.js
+++ b/app/models/submission.js
@@ -2,7 +2,7 @@ import { attr, belongsTo, hasMany } from '@ember-data/model';
 import moment from 'moment';
 import AuditableModel from './auditable';
 
-export default class ResponseModel extends AuditableModel {
+export default class SubmissionModel extends AuditableModel {
   // Alias
   get submissionId() {
     return this.id;

--- a/app/routes/responses/new/submission.js
+++ b/app/routes/responses/new/submission.js
@@ -81,9 +81,6 @@ export default class ResponsesNewSubmissionRoute extends Route {
       source: 'submission',
     });
 
-    // Store submission reference temporarily outside Ember Data
-    response._pendingSubmission = submission;
-
     response.selections.addObjects(selections);
     response.comments.addObjects(comments);
 

--- a/app/routes/responses/new/submission.js
+++ b/app/routes/responses/new/submission.js
@@ -74,12 +74,15 @@ export default class ResponsesNewSubmissionRoute extends Route {
     comments
   ) {
     const response = this.store.createRecord('response', {
-      submission,
+      // Don't assign submission here - it triggers the hasMany assertion
       workspace,
       recipient,
       responseType: 'mentor',
       source: 'submission',
     });
+
+    // Store submission reference temporarily outside Ember Data
+    response._pendingSubmission = submission;
 
     response.selections.addObjects(selections);
     response.comments.addObjects(comments);
@@ -93,7 +96,8 @@ export default class ResponsesNewSubmissionRoute extends Route {
 
     const submission = await this.store.findRecord(
       'submission',
-      params.submission_id
+      params.submission_id,
+      { reload: true }
     );
 
     // Early return if draft exists

--- a/app/routes/responses/submission.js
+++ b/app/routes/responses/submission.js
@@ -6,6 +6,7 @@ export default class ResponsesRoute extends AuthenticatedRoute {
   @service('utility-methods') utils;
   @service store;
   @service router;
+  @service currentUser;
   queryParams = {
     responseId: {
       refreshModel: true,
@@ -43,7 +44,6 @@ export default class ResponsesRoute extends AuthenticatedRoute {
     }
     return this.store.findRecord('workspace', workspaceId);
   }
-
   async model(params) {
     if (!params.submission_id) {
       return null;
@@ -59,28 +59,65 @@ export default class ResponsesRoute extends AuthenticatedRoute {
       workspace.get('responses'),
     ]);
 
+    let allResponses = this.store.peekAll('response');
+    let additionalDrafts = allResponses.filter((response) => {
+      const workspaceId = this.utils.getBelongsToId(response, 'workspace');
+      const submissionId = this.utils.getBelongsToId(response, 'submission');
+      const createdById = this.utils.getBelongsToId(response, 'createdBy');
+      const currentUserId = this.currentUser?.user?.id;
+
+      return (
+        workspaceId === workspace.id &&
+        submissionId === submission.id &&
+        response.status === 'draft' &&
+        createdById === currentUserId &&
+        !response.isTrashed &&
+        !associatedResponses.find((r) => r.id === response.id)
+      );
+    });
+
+    let combinedResponses = [
+      ...associatedResponses.toArray().filter((r) => !r.isTrashed),
+      ...additionalDrafts,
+    ];
+
     let response = null;
     if (params.responseId) {
       try {
         response = await this.store.findRecord('response', params.responseId);
+
+        // If response is trashed, clear it and the query param
+        if (response?.isTrashed) {
+          response = null;
+          this.router.replaceWith(
+            'responses.submission',
+            params.submission_id,
+            {
+              queryParams: { responseId: null },
+            }
+          );
+          return;
+        }
       } catch (e) {
         console.error('Failed to load response:', e);
+        // Response doesn't exist (404), clear the query param
+        this.router.replaceWith('responses.submission', params.submission_id, {
+          queryParams: { responseId: null },
+        });
+        return;
       }
     }
-
+    console.log('Final response selected:', response?.id);
     if (!response && this.response) {
       response = this.response;
     }
 
     if (!response) {
-      response = associatedResponses
-        .filterBy('responseType', 'mentor')
-        .filterBy('isTrashed', false)
+      response = combinedResponses
+        .filter((r) => r.responseType === 'mentor' && !r.isTrashed)
         .sortBy('createDate')
         .get('lastObject');
     }
-
-    let allResponses = this.store.peekAll('response');
 
     const model = {
       submission,
@@ -89,12 +126,85 @@ export default class ResponsesRoute extends AuthenticatedRoute {
         'student',
         submission.get('student')
       ),
-      responses: associatedResponses,
+      responses: combinedResponses,
       response: response || null,
       allResponses,
     };
     return model;
   }
+
+  // async model(params) {
+  //   if (!params.submission_id) {
+  //     return null;
+  //   }
+
+  //   let submission = await this.resolveSubmission(params.submission_id);
+  //   let wsIds = submission.hasMany('workspaces').ids();
+  //   let wsId = wsIds.get('firstObject');
+  //   let workspace = await this.resolveWorkspace(wsId);
+
+  //   let [studentSubmissions, associatedResponses] = await Promise.all([
+  //     workspace.get('submissions'),
+  //     workspace.get('responses'),
+  //   ]);
+
+  //   // Include draft responses that might not be in workspace.responses yet
+  //   let allResponses = this.store.peekAll('response');
+  //   let additionalDrafts = allResponses.filter((response) => {
+  //     const workspaceId = this.utils.getBelongsToId(response, 'workspace');
+  //     const submissionId = this.utils.getBelongsToId(response, 'submission');
+  //     const createdById = this.utils.getBelongsToId(response, 'createdBy');
+  //     const currentUserId = this.currentUser?.user?.id;
+
+  //     // Include drafts for this workspace/submission by current user
+  //     return (
+  //       workspaceId === workspace.id &&
+  //       (submissionId === submission.id || response.status === 'draft') &&
+  //       createdById === currentUserId &&
+  //       !response.isTrashed &&
+  //       !associatedResponses.find((r) => r.id === response.id)
+  //     );
+  //   });
+
+  //   // Combine workspace responses with additional drafts
+  //   let combinedResponses = [
+  //     ...associatedResponses.toArray(),
+  //     ...additionalDrafts,
+  //   ];
+
+  //   let response = null;
+  //   if (params.responseId) {
+  //     try {
+  //       response = await this.store.findRecord('response', params.responseId);
+  //     } catch (e) {
+  //       console.error('Failed to load response:', e);
+  //     }
+  //   }
+
+  //   if (!response && this.response) {
+  //     response = this.response;
+  //   }
+
+  //   if (!response) {
+  //     response = combinedResponses
+  //       .filter((r) => r.responseType === 'mentor' && !r.isTrashed)
+  //       .sortBy('createDate')
+  //       .get('lastObject');
+  //   }
+
+  //   const model = {
+  //     submission,
+  //     workspace,
+  //     submissions: studentSubmissions.filterBy(
+  //       'student',
+  //       submission.get('student')
+  //     ),
+  //     responses: combinedResponses,
+  //     response: response || null,
+  //     allResponses,
+  //   };
+  //   return model;
+  // }
 
   redirect(model, transition) {
     if (!model) {

--- a/app_server/services/ai.js
+++ b/app_server/services/ai.js
@@ -26,8 +26,12 @@ const stripHtml = (html) => {
  * @param {string} targetSubmissionId - The ID of the target submission
  * @returns {Promise<string>} The generated AI draft text
  */
-const generateDraft = async (targetSubmissionId) => {
-  // Step 1: Fetch submission with all related data (problem, student answers, etc.)
+const generateDraft = async (
+  targetSubmissionId,
+  responseMode = 'student_only',
+  workspaceId = null
+) => {
+  // Step 1: Fetch submission with all related data
   const targetSubmission = await models.Submission.findById(targetSubmissionId)
     .populate({
       path: 'answer',
@@ -37,7 +41,8 @@ const generateDraft = async (targetSubmissionId) => {
       },
     })
     .populate('creator', 'username')
-    .select('shortAnswer longAnswer creator publication')
+    .populate('clazz', 'name')
+    .select('shortAnswer longAnswer creator clazz publication')
     .lean()
     .exec();
 
@@ -45,17 +50,27 @@ const generateDraft = async (targetSubmissionId) => {
     throw new Error(`Submission ${targetSubmissionId} not found`);
   }
 
-  // Step 2: Extract problem statement from different possible locations
-  // System has evolved over time, so we check multiple places:
-  // - New system: answer.assignment.problem.text (full problem text)
-  // - Old PoWs with title: publication.puzzle.title (denormalized title from import)
-  // - Old PoWs with problemId only: fetch full problem from publication.puzzle.problemId
-  // - Reflections or broken imports: generic fallback message
+  // Step 2: Fetch teacher selections for this submission (mandatory)
+  const selectionsQuery = {
+    submission: targetSubmissionId,
+    isTrashed: { $ne: true },
+  };
+
+  if (workspaceId) {
+    selectionsQuery.workspace = workspaceId;
+  }
+
+  const selections = await models.Selection.find(selectionsQuery)
+    .populate('createdBy', 'username')
+    .select('text createdBy')
+    .lean()
+    .exec();
+
+  // Step 3: Extract problem statement
   let problemStatement =
     targetSubmission?.answer?.assignment?.problem?.text ||
     targetSubmission?.publication?.puzzle?.title;
 
-  // If we have a problemId but no text, try to fetch the problem
   if (!problemStatement && targetSubmission?.publication?.puzzle?.problemId) {
     const problem = await models.Problem.findById(
       targetSubmission.publication.puzzle.problemId
@@ -66,38 +81,60 @@ const generateDraft = async (targetSubmissionId) => {
     if (problem) problemStatement = problem.text || problem.title;
   }
 
-  // Final fallback for reflections or incomplete data
   if (!problemStatement) {
     problemStatement =
       'The student is sharing their mathematical thinking and work.';
   }
 
-  // Step 3: Extract and clean student work
-  const shortAnswer = stripHtml(targetSubmission.shortAnswer || '');
-  const longAnswer = stripHtml(targetSubmission.longAnswer || '');
-  const studentWork = [shortAnswer, longAnswer].filter(Boolean).join(' ');
+  // Step 4: Extract and clean student work
+  let shortAnswer = stripHtml(targetSubmission.shortAnswer || '');
+  let longAnswer = stripHtml(targetSubmission.longAnswer || '');
 
-  if (!studentWork) {
-    throw new Error('No student work available to generate AI draft.');
+  // If no direct student work, check the answer relationship (for VMT submissions)
+  if (
+    (!shortAnswer || shortAnswer.trim().length === 0) &&
+    (!longAnswer || longAnswer.trim().length === 0)
+  ) {
+    if (targetSubmission.answer) {
+      shortAnswer = stripHtml(targetSubmission.answer.answer || '');
+      longAnswer = stripHtml(targetSubmission.answer.explanation || '');
+    }
   }
 
-  // Step 4: Build request body with simplified structure for current AWS API
+  // If still no student work found, throw error
+  if (
+    (!shortAnswer || shortAnswer.trim().length === 0) &&
+    (!longAnswer || longAnswer.trim().length === 0)
+  ) {
+    throw new Error(
+      'No student work found. Students must provide a short or long answer.'
+    );
+  }
+  // Step 5: Determine student name
+  const studentName =
+    targetSubmission.creator?.username ||
+    targetSubmission.clazz?.name ||
+    'the student';
+
+  // Step 6: Build request body matching backend expected format
+  const cleanProblemStatement = stripHtml(problemStatement);
+
   const requestBody = {
-    problem: {
-      statement: stripHtml(problemStatement),
-    },
     student_work: {
-      short_answer: shortAnswer || '',
-      long_answer: longAnswer || '',
-      student_name: targetSubmission.creator?.username || 'student',
+      short_answer: shortAnswer,
+      long_answer: longAnswer,
+      student_name: studentName,
     },
-    response_mode: 'student_only',
+    response_mode: responseMode,
   };
 
-  console.log(
-    'Sending simplified request:',
-    JSON.stringify(requestBody, null, 2)
-  );
+  // Only include problem if we have valid text after cleaning
+  if (cleanProblemStatement && cleanProblemStatement.trim().length > 0) {
+    requestBody.problem = {
+      statement: cleanProblemStatement,
+    };
+  }
+
   return await makeAIRequest(requestBody);
 };
 

--- a/tests/integration/components/response-new-test.js
+++ b/tests/integration/components/response-new-test.js
@@ -99,9 +99,18 @@ module('Integration | Component | response-new', function (hooks) {
     submission: { id: 'submission1' },
   };
 
-  async function renderResponseNew(context, responseData) {
+  async function renderResponseNew(context, responseData, extraArgs = {}) {
     context.set('responseData', responseData);
-    await render(hbs`<ResponseNew @responseData={{this.responseData}} />`);
+    context.setProperties(extraArgs); // This sets submission, canDirectSend, etc.
+    
+    await render(hbs`<ResponseNew 
+      @responseData={{this.responseData}}
+      @submission={{this.submission}}
+      @canDirectSend={{this.canDirectSend}}
+      @newReplyType={{this.newReplyType}}
+      @newReplyStatus={{this.newReplyStatus}}
+      @replyNote={{this.replyNote}}
+    />`);
   }
 
   test('renders basic component structure', async function (assert) {
@@ -664,12 +673,29 @@ module('Integration | Component | response-new', function (hooks) {
 
   // --------------AI Draft -------------------------
   test('shows Generate AI Draft button when submission exists', async function (assert) {
-    await renderResponseNew(this, {
-      student: 'Test Student',
-      selections: [],
-      comments: [],
-      submission: { id: 'submission1' }
-    });
+    const mockSubmission = {
+      id: 'submission1',
+      shortAnswer: 'Student answer here',
+      longAnswer: 'Detailed explanation',
+      belongsTo(relationshipName) {
+        return {
+          id() {
+            return null;
+          }
+        };
+      }
+    };
+
+    await renderResponseNew(this, 
+      {
+        student: 'Test Student',
+        selections: [],
+        comments: [],
+      },
+      {
+        submission: mockSubmission  // Pass as separate argument
+      }
+    );
 
     assert.dom('.ai-draft').exists();
     assert.dom('.ai-draft').hasText('Generate AI Draft');
@@ -686,4 +712,17 @@ module('Integration | Component | response-new', function (hooks) {
     assert.dom('.ai-draft').doesNotExist();
   });
 
+  test('hides Generate AI Draft button when submission has no student work', async function (assert) {
+    await renderResponseNew(this, {
+      student: 'Test Student',
+      selections: [],
+      comments: [],
+      submission: { 
+        id: 'submission1',
+        // No shortAnswer or longAnswer
+      }
+    });
+
+    assert.dom('.ai-draft').doesNotExist('Button hidden when no student work');
+  });
 });


### PR DESCRIPTION
### Description
This PR fixes AI button visibility and draft generation for VMT (Virtual Math Teams) submissions. The feature was not working because VMT submissions store student work in a different data structure than regular submissions.

### Problem
- AI draft generation button not appearing for VMT submissions
- Backend throwing "No student work found" errors for VMT submissions
- Ember Data "Attempted to schedule a fetch for a record without an id" console errors

### Root Causes

#### 1. Incorrect Model Class Name
`app/models/submission.js` was incorrectly named `ResponseModel` instead of `SubmissionModel`, causing Ember Data deserialization failures.

#### 2. Data Structure Inconsistency
Different submission types store student work differently:
- **Regular submissions**: `submission.shortAnswer` and `submission.longAnswer`
- **VMT submissions**: `answer.answer` and `answer.explanation` (nested relationship)

#### 3. Single-Source Checking
Both frontend and backend only checked direct submission properties, missing VMT data entirely.

#### 4. Unsaved Records in HasMany Relationships
`_createResponseRecord()` assigned `submission: submission` during record creation, which added the unsaved response (no database ID yet) to `submission.responses` hasMany array. When any code accessed `submission.responses`, Ember Data attempted to fetch all records and threw assertion error.

### Changes

#### Frontend

**1. Fixed Submission Model** (`app/models/submission.js`)
- Corrected class name from `ResponseModel` to `SubmissionModel`
- Ensures proper Ember Data model identification

**2. Implemented `_pendingSubmission` Pattern** (`app/routes/responses/new/submission.js`)
- Removed submission assignment from `_createResponseRecord()` 
- Stores submission reference in `response._pendingSubmission` temporarily
- Prevents unsaved response from being added to `submission.responses` hasMany array
- Fixes "Attempted to schedule a fetch for a record without an id" error
- Added `{ reload: true }` to ensure fresh submission data

**3. Dual-Source Student Work Detection** (`app/components/response-new.js`)
- Added `hasStudentWork` getter to check both data sources:
  - Primary: `submission.shortAnswer/longAnswer` (regular submissions)
  - Fallback: `answer.answer/explanation` (VMT submissions)
-  Added ` hasSubmission`, `showAIButton`, `actualSubmission`, getters
- Added `_getSubmissionId()` method
- Uses `peekRecord` instead of `.value()` to avoid triggering Ember Data fetches
- AI button now appears for all submission types with student work

**4.  Filter out any response models that snuck in**(`app/components/response-container.js`)
- Modified ` get submissions()` method

**5. Edited template to use new getter**(`app/components/response-new.hbs`)
- Changed `{{#if @responseData.submission}}` to `{{#if this.showAIButton}}`

#### Backend

**6. VMT Support in AI Service** (`app_server/services/ai.js`)
- Added dual-source checking matching frontend logic
- Checks `answer.answer/explanation` if `submission.shortAnswer/longAnswer` are empty
- AI draft generation now works for both regular and VMT submissions

#### Testing

**7. Updated Component Tests** (`tests/integration/components/response-new-test.js`)
- Added test: AI button appears when submission has student work
- Added test: AI button hidden when no submission exists  
- Added test: AI button hidden when submission lacks student work
- Updated `StoreStub` to include `peekRecord` method
- Updated `renderResponseNew` helper to accept submission as separate argument

### Files Modified
- `app/models/submission.js` 
- `app/routes/responses/new/submission.js`
- `app/components/response-new.js`
- `app_server/services/ai.js`
- `tests/integration/components/response-new-test.js`