### PR TITLE
fix: selection navigation 404 errors and comment filter checkbox sync

### DIFF
--- a/app/components/comment-list.js
+++ b/app/components/comment-list.js
@@ -135,17 +135,17 @@ export default class CommentListComponent extends Component {
     return {
       thisWorkspaceOnly: {
         label: 'This Workspace Only',
-        isChecked: true,
+        isChecked: this.thisWorkspaceOnly,
         isDisabled: this.args.isParentWorkspace,
       },
       thisSubmissionOnly: {
         label: 'This Submission Only',
-        isChecked: true,
+        isChecked: this.thisSubmissionOnly,
         isDisabled: false,
       },
       myCommentsOnly: {
         label: 'My Comments Only',
-        isChecked: !this.args.isParentWorkspace,
+        isChecked: this.myCommentsOnly,
         isDisabled: false,
       },
     };

--- a/app/routes/workspace/submissions/submission/selections/selection.js
+++ b/app/routes/workspace/submissions/submission/selections/selection.js
@@ -1,35 +1,56 @@
+/* eslint-disable ember/no-controller-access-in-routes */
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 
 export default class SelectionRoute extends Route {
-  // @service('workspace') workspaceController;
-  // @service('application') applicationController;
-  // afterModel(model) {
-  //   this.workspaceController.set('currentSelection', model);
-  // }
-  // deactivate() {
-  //   this.workspaceController.set('currentSelection', null);
-  // }
-  // get shouldDoTour() {
-  //   let user = this.applicationController.model;
-  //   let userSeenTour = user.get('seenTour');
-  //   let redoTour = this.Encompass.redoTour;
-  //   return userSeenTour || redoTour;
-  // }
-  // doTour = observer('shouldDoTour', function () {
-  //   let user = this.applicationController.model;
-  //   scheduleOnce('afterRender', this, function () {
-  //     if (!user.get('seenTour')) {
-  //       window.guiders.hideAll();
-  //       // guiders.show('comments');
-  //     }
-  //   });
-  // });
-  // renderTemplate() {
-  //   super.renderTemplate();
-  //   $('#commentTextarea').focus();
-  //   // Uncomment to trigger tour based on conditions
-  //   // if (!this.applicationController.model.get('seenTour')) {
-  //   //   this.doTour();
-  //   // }
-  // }
+  @service store;
+
+  model(params) {
+    return this.store.findRecord('selection', params.selection_id);
+  }
+
+  setupController(controller, model, ...args) {
+    super.setupController(controller, model, ...args);
+    const workspaceController = this.controllerFor('workspace');
+    workspaceController.currentSelection = model;
+  }
+
+  resetController(controller, isExiting, ...args) {
+    super.resetController(controller, isExiting, ...args);
+    if (isExiting) {
+      const workspaceController = this.controllerFor('workspace');
+      workspaceController.currentSelection = null;
+    }
+  }
 }
+// @service('workspace') workspaceController;
+// @service('application') applicationController;
+// afterModel(model) {
+//   this.workspaceController.set('currentSelection', model);
+// }
+// deactivate() {
+//   this.workspaceController.set('currentSelection', null);
+// }
+// get shouldDoTour() {
+//   let user = this.applicationController.model;
+//   let userSeenTour = user.get('seenTour');
+//   let redoTour = this.Encompass.redoTour;
+//   return userSeenTour || redoTour;
+// }
+// doTour = observer('shouldDoTour', function () {
+//   let user = this.applicationController.model;
+//   scheduleOnce('afterRender', this, function () {
+//     if (!user.get('seenTour')) {
+//       window.guiders.hideAll();
+//       // guiders.show('comments');
+//     }
+//   });
+// });
+// renderTemplate() {
+//   super.renderTemplate();
+//   $('#commentTextarea').focus();
+//   // Uncomment to trigger tour based on conditions
+//   // if (!this.applicationController.model.get('seenTour')) {
+//   //   this.doTour();
+//   // }
+// }


### PR DESCRIPTION
## Description

Fixes two issues in workspace comment panel:
1. Comment filter checkboxes not reflecting actual filter state
2. Clicking on selections resulting in 404 errors

**Problem 1 - Comment Filters:** Filter checkboxes appeared checked but didn't reflect the actual filter state. When users toggled filters, the checkboxes didn't update visually, causing confusion about which filters were active.

**Root Cause 1:** The `filterOptions` getter was using hardcoded boolean values instead of referencing the tracked properties that control filtering behavior.

**Solution 1:** Updated `filterOptions` getter to use tracked property values (`this.thisWorkspaceOnly`, `this.thisSubmissionOnly`, `this.myCommentsOnly`) instead of hardcoded booleans.

**Problem 2 - Selection Navigation:** Clicking on selections resulted in 404 errors in develop branch. Selection context (currentSelection) was not being set/cleared properly, preventing users from navigating to or highlighting selected text portions.

**Root Cause 2:** During Glimmer component migration, the entire selection route logic was commented out in `workspace/submissions/submission/selections/selection.js`. lifecycle hooks (afterModel, deactivate) were removed, and ESLint disable comment was added but underlying functionality was lost.

**Solution 2:** Restored selection route functionality using modern Ember Octane patterns:
- Replaced commented afterModel/deactivate hooks with setupController/resetController
- setupController sets workspaceController.currentSelection when entering route
- resetController clears workspaceController.currentSelection when exiting route (only when isExiting)
- Used controllerFor() to access workspace controller (requires ESLint disable comment until refactored to use services)

## Changes

### Modified Files
- **`app/components/comment-list.js`**
  - Updated `filterOptions` getter to use tracked properties for `isChecked` values
  - Changed from hardcoded `(true, true, !this.args.isParentWorkspace)` to `(this.thisWorkspaceOnly, this.thisSubmissionOnly, this.myCommentsOnly)`
  - Ensures checkbox state matches actual filter behavior

- **`app/routes/workspace/submissions/submission/selections/selection.js`**
  - Restored selection route functionality with modern Ember Octane patterns
  - Added setupController() to set workspaceController.currentSelection when entering route
  - Added resetController() to clear workspaceController.currentSelection when exiting route (isExiting check prevents clearing on controller refresh)
  - Maintains same functionality as original code while following Ember best practices

## Testing

### Comment Filters
- All existing tests pass without modification
- Tests already verify correct checkbox behavior (implementation now matches test expectations)
- Manually verified filter checkboxes update correctly when toggled
- Confirmed filters apply correctly when checkboxes are checked/unchecked

### Selection Navigation
- Manually verified selection clicks now navigate correctly
- Selection highlights properly display in submission view
- No 404 errors when accessing selection routes
- Selection context correctly set/cleared during navigation