### PR TITLE
Fix/null api payloads

### DIFF
--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -6,4 +6,22 @@ import RESTSerializer from '@ember-data/serializer/rest';
  */
 export default class ApplicationSerializer extends RESTSerializer {
   primaryKey = '_id'; // Use Mongoose's _id as the primary key
+
+  normalizeResponse(store, primaryModelClass, payload, id, requestType) {
+    if (payload && typeof payload === 'object') {
+      Object.keys(payload).forEach((key) => {
+        const value = payload[key];
+        if (Array.isArray(value)) {
+          payload[key] = value.filter(Boolean);
+        }
+      });
+    }
+    return super.normalizeResponse(
+      store,
+      primaryModelClass,
+      payload,
+      id,
+      requestType
+    );
+  }
 }

--- a/app_server/datasource/api/commentApi.js
+++ b/app_server/datasource/api/commentApi.js
@@ -23,6 +23,17 @@ module.exports.get = {};
 module.exports.post = {};
 module.exports.put = {};
 
+function sanitizeCommentRefs(comment) {
+  if (!comment) return comment;
+  if (Array.isArray(comment.children)) {
+    comment.children = comment.children.filter(Boolean);
+  }
+  if (Array.isArray(comment.ancestors)) {
+    comment.ancestors = comment.ancestors.filter(Boolean);
+  }
+  return comment;
+}
+
 /**
  * @public
  * @method getComments
@@ -166,7 +177,7 @@ async function getComments(req, res, next) {
       }
     });
     if (!hasMissingRelationship) {
-      data.comments.push(comment);
+      data.comments.push(sanitizeCommentRefs(comment));
     }
   });
 

--- a/app_server/datasource/api/responseApi.js
+++ b/app_server/datasource/api/responseApi.js
@@ -24,6 +24,17 @@ module.exports.get = {};
 module.exports.post = {};
 module.exports.put = {};
 
+function sanitizeResponseRefs(response) {
+  if (!response) return response;
+  if (Array.isArray(response.comments)) {
+    response.comments = response.comments.filter(Boolean);
+  }
+  if (Array.isArray(response.selections)) {
+    response.selections = response.selections.filter(Boolean);
+  }
+  return response;
+}
+
 /**
  * @public
  * @method getResponse
@@ -63,6 +74,7 @@ function getResponse(req, res, next) {
         // recipient of mentor reply should not see note to approver
         delete response.note;
       }
+      sanitizeResponseRefs(response);
       response.depopulate('createdBy');
       response.depopulate('recipient');
       response.depopulate('workspace');
@@ -98,6 +110,7 @@ function getResponses(req, res, next) {
         .exec()
         .then((responses) => {
           responses.forEach((response) => {
+            sanitizeResponseRefs(response);
             if (
               response.responseType === 'mentor' &&
               areObjectIdsEqual(response.recipient, user._id)

--- a/app_server/datasource/api/selectionApi.js
+++ b/app_server/datasource/api/selectionApi.js
@@ -25,6 +25,17 @@ module.exports.get = {};
 module.exports.post = {};
 module.exports.put = {};
 
+function sanitizeSelectionRefs(selection) {
+  if (!selection) return selection;
+  if (Array.isArray(selection.comments)) {
+    selection.comments = selection.comments.filter(Boolean);
+  }
+  if (Array.isArray(selection.taggings)) {
+    selection.taggings = selection.taggings.filter(Boolean);
+  }
+  return selection;
+}
+
 /**
  * @public
  * @method getSelections
@@ -113,6 +124,7 @@ async function getSelections(req, res, next) {
       logger.error(err);
       return utils.sendError.InternalError(err, res);
     }
+    selections = selections.map((sel) => sanitizeSelectionRefs(sel));
     var data = { selections: selections };
     utils.sendResponse(res, data);
   });
@@ -159,7 +171,7 @@ async function getSelection(req, res, next) {
 
     const data = {
       // user has permission; send back record
-      selection,
+      selection: sanitizeSelectionRefs(selection),
     };
 
     return utils.sendResponse(res, data);


### PR DESCRIPTION
## Description

Prevents Ember Data crashes on initial load by stripping null IDs from API payloads and guarding client normalization. The test environment was failing with `Cannot read properties of null (reading 'lid')` when responses/selections/comments contained null refs; this patch sanitizes those arrays server‑side and adds a serializer guard client‑side.

**Stability Components:**
1. Server null filtering for responses, selections, and comments
2. Client serializer guard for any remaining null array items
3. No change to existing logging or other endpoints

---

## Changes

### Modified Files

- **`app_server/datasource/api/responseApi.js`**
  - `sanitizeResponseRefs` filters null IDs from `comments` and `selections` before sending payloads

- **`app_server/datasource/api/selectionApi.js`**
  - `sanitizeSelectionRefs` removes nulls from `comments` and `taggings` in selection payloads

- **`app_server/datasource/api/commentApi.js`**
  - `sanitizeCommentRefs` drops nulls from `children` and `ancestors` arrays

- **`app/serializers/application.js`**
  - Adds a defensive array filter to discard null items during normalization (catch‑all client safety net)

---