### PR TITLE
Add alternate problem context when problem fields are missing

### DIFF
--- a/app_server/services/ai.js
+++ b/app_server/services/ai.js
@@ -25,6 +25,8 @@ const stripHtml = (html) => {
     .trim();
 };
 
+const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 /**
  * Generate an AI draft response based on submission
  * @param {string} targetSubmissionId - The ID of the target submission
@@ -56,7 +58,7 @@ const generateDraft = async (
     })
     .populate('creator', 'username')
     .populate('clazz', 'name')
-    .select('shortAnswer longAnswer creator clazz publication')
+    .select('shortAnswer longAnswer creator clazz publication pdSet')
     .lean()
     .exec();
 
@@ -77,6 +79,35 @@ const generateDraft = async (
       .lean()
       .exec();
     if (problem) problemStatement = problem.text || problem.title;
+  }
+
+  const pdSetTitle = targetSubmission?.pdSet
+    ? stripHtml(targetSubmission.pdSet).split(' - ')[0].trim()
+    : '';
+
+  if (!problemStatement && pdSetTitle) {
+    const titleRegex = new RegExp(escapeRegex(pdSetTitle), 'i');
+    const matchedProblem = await models.Problem.findOne({
+      title: titleRegex,
+      isTrashed: { $ne: true },
+    })
+      .select('text title')
+      .lean()
+      .exec();
+    if (matchedProblem) {
+      problemStatement = matchedProblem.text || matchedProblem.title;
+    }
+  }
+
+  if (!problemStatement && pdSetTitle) {
+    const fallbackParts = [pdSetTitle];
+    const powId = targetSubmission?.publication?.publicationId;
+    if (powId) fallbackParts.push(`PoW ID: ${powId}`);
+    const className = targetSubmission?.clazz?.name;
+    if (className) fallbackParts.push(`Class: ${className}`);
+    problemStatement = `${fallbackParts.join(
+      '. '
+    )}. The student is sharing their mathematical thinking and work.`;
   }
 
   if (!problemStatement) {


### PR DESCRIPTION
## Description

Fixes missing problem context in AI draft requests for older submissions. I found that many legacy records only store `publicationId` and `pdSet`, so the AI request was falling back to a generic sentence. This change adds a clear, step‑by‑step fallback so the AI always receives useful problem context.

**What this does:**
1. Uses the normal problem text/title when available
2. If missing, tries to match a Problem by searching titles using the `pdSet` name
3. If still missing, sends a structured fallback sentence that includes:
   - the `pdSet` name
   - PoW ID
   - class name
   - the generic context line

---

## Changes

### Modified Files

- **`app_server/services/ai.js`**
  - Include `pdSet` in the submission query
  - Add title‑based lookup using `pdSet`
  - Add a structured fallback statement to avoid empty/too‑short problem text

---

## Testing

### Manual
- Generated AI drafts for legacy submissions missing problem fields
- Verified payload now includes problem context instead of only the generic line
- Checked that variants A–D still run as expected

### Automated
- Not run
