### PR TITLE
Fix/workspace new navigation and filter crash

### DIFF
--- a/app/components/submissions-filter.js
+++ b/app/components/submissions-filter.js
@@ -9,6 +9,7 @@ import isObject from 'lodash-es/isObject';
 import isNull from 'lodash-es/isNull';
 import map from 'lodash-es/map';
 import each from 'lodash-es/each';
+import { capitalize } from '@ember/string';
 
 export default Component.extend({
   elementId: 'submissions-filter',
@@ -121,7 +122,7 @@ export default Component.extend({
 
     for (let attr of ['sections', 'assignments', 'users']) {
       let modelProp = this.get(attr);
-      let newProp = `base${attr.capitalize()}`;
+      let newProp = `base${capitalize(attr)}`;
       if (modelProp) {
         this.set(newProp, modelProp.toArray());
       } else {

--- a/app/styles/_filter-list.scss
+++ b/app/styles/_filter-list.scss
@@ -552,9 +552,14 @@
             border-radius: 50%;
             text-align: center;
             margin-top: -46px;
-            line-height: 42px;
             height: 40px;
             width: 40px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            line-height: 40px;
+            position: relative;
+            z-index: 1;
             &:hover {
               cursor: pointer;
               background: darken($accent-color, 10%);


### PR DESCRIPTION
**Description**
The test environment couldn’t reliably create workspaces: the “+” button didn’t navigate and `/workspaces/new` crashed on render. This PR restores the workspace creation flow by fixing the render error in `submissions-filter` and making the “+” button fully clickable.

**Problem (from Mr. Steve discussion)**
- Workspace creation in test was broken; the “+” button appeared dead.
- Navigating directly to `/workspaces/new` produced a render error in the submissions filter.
- Error observed: `attr.capitalize is not a function` in `submissions-filter` during render.

**Solution**
- Fix render error by replacing invalid `attr.capitalize()` with `capitalize(attr)` from `@ember/string`.
- Make the “+” button’s link itself the full circular hit‑area so it’s reliably clickable.

**File Changes**
- `app/components/submissions-filter.js`
  - Use `capitalize(attr)` from `@ember/string` to avoid render crash.
- `app/styles/_filter-list.scss`
  - Update `#workspace-new-link` styles to use inline‑flex, centered content, matched size/line‑height, and z‑index for a reliable hit‑area.

**Testing**
- Navigated to `/workspaces/new` directly (no render crash).
- Clicked “+” button from the workspace list and confirmed it navigates correctly.
- Verified workspace creation UI appears and is usable.

**Notes / Needs Upgrading**
- These components are still in classic Ember; this is a current‑flow fix.
- `submissions-filter` and related workspace components should be modernized later, but this change keeps behavior intact while restoring functionality.