### PR TITLE
Fix/ai draft error handling notification sanitization

### DIFF
--- a/app/services/ai-draft.js
+++ b/app/services/ai-draft.js
@@ -57,10 +57,15 @@ export default class AiDraftService extends Service {
    * @returns {Promise<String>} HTML string containing the generated draft
    * @throws {Error} If API call fails or no content is received
    */
-  async generateDraft(submissionId, variant = 'A') {
-    const url = `/api/aiDraft?target=${encodeURIComponent(
-      submissionId
-    )}&variant=${encodeURIComponent(variant)}`;
+  async generateDraft(submissionId, variant = 'A', workspaceId = null) {
+    const params = new URLSearchParams({
+      target: submissionId,
+      variant,
+    });
+    if (workspaceId) {
+      params.set('workspace', workspaceId);
+    }
+    const url = `/api/aiDraft?${params.toString()}`;
     const response = await fetch(url, {
       method: 'GET',
       headers: { 'Content-Type': 'application/json' },
@@ -68,11 +73,25 @@ export default class AiDraftService extends Service {
     });
 
     if (!response.ok) {
-      const err = await response.json();
-      throw new Error(err.message || 'Failed to generate AI draft');
+      const raw = await response.text();
+      let errMessage = 'Failed to generate AI draft';
+      try {
+        const parsed = JSON.parse(raw);
+        errMessage = parsed.message || parsed.error || errMessage;
+      } catch (e) {
+        // Upstream errors may return HTML/plain text (e.g., 502), preserve status.
+        errMessage = `Failed to generate AI draft (${response.status})`;
+      }
+      throw new Error(errMessage);
     }
 
-    const data = await response.json();
+    const raw = await response.text();
+    let data;
+    try {
+      data = JSON.parse(raw);
+    } catch (e) {
+      throw new Error('Invalid response format from AI draft endpoint');
+    }
     if (!data || !data.draft) {
       throw new Error('No content received');
     }

--- a/app_server/datasource/api/userApi.js
+++ b/app_server/datasource/api/userApi.js
@@ -59,8 +59,30 @@ async function sendUsers(req, res, next) {
     }
 
     if (req.query.alias === 'current') {
-      // if all they wanted was the current user, fine
-      return utils.sendResponse(res, { user });
+      // if all they wanted was the current user, return a sanitized copy
+      // so stale notification refs do not crash Ember Data relationship loading.
+      const safeUser = user.toObject ? user.toObject() : { ...user };
+      const ntfIds = Array.isArray(safeUser.notifications)
+        ? safeUser.notifications.filter(Boolean)
+        : [];
+
+      if (ntfIds.length > 0) {
+        const validNotifications = await models.Notification.find({
+          _id: { $in: ntfIds },
+          isTrashed: { $ne: true },
+        })
+          .select('_id')
+          .lean()
+          .exec();
+        const validIds = validNotifications.map((n) => String(n._id));
+        safeUser.notifications = ntfIds.filter((id) =>
+          validIds.includes(String(id))
+        );
+      } else {
+        safeUser.notifications = [];
+      }
+
+      return utils.sendResponse(res, { user: safeUser });
     }
 
     let criteria;


### PR DESCRIPTION
## Description

This PR adds defensive handling for two classes of runtime failures observed during AI draft generation and page data loading:

1. **AI draft request failures with non-JSON backend responses** (e.g., 502/504 HTML/plain-text gateway errors causing frontend parse crashes).
2. **Potential Ember Data relationship loading mismatch** when a `user.notifications` reference exists but the corresponding notification record is missing from adapter payloads.

The goal is **stability and graceful degradation** during testing, without changing existing product behavior or response formats in normal success paths.

---

## Problem Context / Cause Assumptions

### 1) AI Draft Errors (`/api/aiDraft`)
Observed behavior included backend 5xx responses and frontend errors like:
- `SyntaxError: The string did not match the expected pattern`
- generic “Failed to generate AI draft”

**Assumption:** when upstream returns non-JSON (gateway HTML/text), frontend attempted JSON parsing and threw a client-side parse error, masking the original server problem.

### 2) Ember Data Notification Error
Observed error (reported in demo logs):
- `Expected: '<notification:...>' to be present in the adapter provided payload, but it was not found`

**Assumption:** at least one user record may contain stale notification IDs that no longer resolve to valid notification documents, triggering Ember Data relationship materialization failure.

---

## Current Scope

This PR is intentionally scoped to **low-risk defensive fixes** in two files:

### `app/services/ai-draft.js`
- Added robust query construction via `URLSearchParams` for:
  - `target`
  - `variant`
  - optional `workspace`
- Hardened non-OK response handling:
  - reads raw response text
  - parses JSON only when possible
  - falls back to status-based error message
- Hardened success-path parsing:
  - throws explicit error if “successful” response is malformed/non-JSON

### `app_server/datasource/api/userApi.js`
- In `alias=current` flow, sanitized `user.notifications` before response:
  - validates notification IDs against existing, non-trashed notification records
  - removes stale references
  - falls back safely to empty array when needed

---

## Why This Is Low Risk

- No contract-breaking API changes.
- No schema changes.
- No change to successful-path payload shape expected by existing clients.
- Behavior changes only in failure/edge paths:
  - clearer frontend error handling for bad upstream responses
  - safer user payload consistency for Ember Data relationship loading

---

## Unencountered Error Note (Repro Status)

The notification mismatch issue was **not reproducible locally or in test** despite multiple attempts.  
Given that:
- the error was observed in a real demo session,
- the stacktrace points to a known Ember Data relationship consistency requirement, this fix is an **educated, preventive, low-risk mitigation** to reduce recurrence probability in account/data-specific edge cases.

---

## Testing Performed

- Verified AI draft flow still works for normal successful responses (no behavior change in happy path).
- Could not reliably reproduce the original notification mismatch error locally or in test after multiple attempts.
- Manually validated that the new defensive branches do not alter successful response contracts:
  - `ai-draft` keeps existing success parsing/output behavior
  - `alias=current` still returns user payload with safe `notifications` references
- Regression check: no expected changes to standard UI flow for successful requests.


