### PR TITLE
Wp report/add problem text

### DIFF
--- a/app/routes/metrics/workspace.js
+++ b/app/routes/metrics/workspace.js
@@ -11,6 +11,15 @@ export default class MetricsWorkspaceRoute extends Route {
     const submissions = await workspace.submissions;
     await Promise.all(
       submissions.map(async (submission) => {
+        await submission.problem;
+        const answer = await submission.answer;
+        if (answer) {
+          await answer.problem;
+          const assignment = await answer.assignment;
+          if (assignment) {
+            await assignment.problem;
+          }
+        }
         const selections = await submission.selections;
         await Promise.all(
           selections.map(async (selection) => {

--- a/app/routes/metrics/workspace.js
+++ b/app/routes/metrics/workspace.js
@@ -11,15 +11,18 @@ export default class MetricsWorkspaceRoute extends Route {
     const submissions = await workspace.submissions;
     await Promise.all(
       submissions.map(async (submission) => {
-        await submission.problem;
+        // Preload puzzle text relationships
+        await submission.answer;
         const answer = await submission.answer;
-        if (answer) {
-          await answer.problem;
-          const assignment = await answer.assignment;
-          if (assignment) {
-            await assignment.problem;
-          }
-        }
+        await answer.assignment;
+        const assignment = await answer.assignment;
+        await assignment.problem;
+        await submission.problem;
+        await submission.pdSet;
+        await submission.publication;
+        await submission.clazz;
+
+        // Preload selection relationships
         const selections = await submission.selections;
         await Promise.all(
           selections.map(async (selection) => {

--- a/app/services/workspace-reports.js
+++ b/app/services/workspace-reports.js
@@ -24,29 +24,22 @@ export default class WorkspaceReportsService extends Service {
   }
 
   getPuzzleText(submission) {
+    // Primary: assignment problem description
     const assignmentProblemText = this.stripHtml(
       submission.get('answer.assignment.problem.text')
     );
     if (assignmentProblemText) return assignmentProblemText;
 
-    const puzzleTitle = this.stripHtml(
-      submission.get('publication.puzzle.title')
-    );
-    if (puzzleTitle) return puzzleTitle;
-
+    // Secondary: problem text via problemId
     const puzzleProblemId = submission.get('publication.puzzle.problemId');
     if (puzzleProblemId) {
       const submissionProblemText = this.stripHtml(
         submission.get('problem.text')
       );
       if (submissionProblemText) return submissionProblemText;
-
-      const submissionProblemTitle = this.stripHtml(
-        submission.get('problem.title')
-      );
-      if (submissionProblemTitle) return submissionProblemTitle;
     }
 
+    // Fallback: pdSet context for legacy data
     const pdSetTitle = this.stripHtml(submission.get('pdSet'));
     if (pdSetTitle) {
       const fallbackParts = [pdSetTitle.split(' - ')[0].trim()];
@@ -59,6 +52,7 @@ export default class WorkspaceReportsService extends Service {
       )}. The student is sharing their mathematical thinking and work.`;
     }
 
+    // Final fallback
     return 'The student is sharing their mathematical thinking and work.';
   }
 

--- a/app/services/workspace-reports.js
+++ b/app/services/workspace-reports.js
@@ -23,6 +23,45 @@ export default class WorkspaceReportsService extends Service {
     return Array.from(folderNames);
   }
 
+  getPuzzleText(submission) {
+    const assignmentProblemText = this.stripHtml(
+      submission.get('answer.assignment.problem.text')
+    );
+    if (assignmentProblemText) return assignmentProblemText;
+
+    const puzzleTitle = this.stripHtml(
+      submission.get('publication.puzzle.title')
+    );
+    if (puzzleTitle) return puzzleTitle;
+
+    const puzzleProblemId = submission.get('publication.puzzle.problemId');
+    if (puzzleProblemId) {
+      const submissionProblemText = this.stripHtml(
+        submission.get('problem.text')
+      );
+      if (submissionProblemText) return submissionProblemText;
+
+      const submissionProblemTitle = this.stripHtml(
+        submission.get('problem.title')
+      );
+      if (submissionProblemTitle) return submissionProblemTitle;
+    }
+
+    const pdSetTitle = this.stripHtml(submission.get('pdSet'));
+    if (pdSetTitle) {
+      const fallbackParts = [pdSetTitle.split(' - ')[0].trim()];
+      const powId = submission.get('publication.publicationId');
+      if (powId) fallbackParts.push(`PoW ID: ${powId}`);
+      const className = this.stripHtml(submission.get('clazz.name'));
+      if (className) fallbackParts.push(`Class: ${className}`);
+      return `${fallbackParts.join(
+        '. '
+      )}. The student is sharing their mathematical thinking and work.`;
+    }
+
+    return 'The student is sharing their mathematical thinking and work.';
+  }
+
   submissionReportCsv(model) {
     const submissionsArray = model.submissions.slice();
 
@@ -58,6 +97,7 @@ export default class WorkspaceReportsService extends Service {
         'Workspace URL': window.location.href,
         'Workspace Owner': model.workspace.get('owner.username'),
         'Original Submitter': submission.student,
+        'Puzzle text': this.getPuzzleText(submission),
         'Text of Submission': `Summary: ${
           submission.shortAnswer
             ? this.stripHtml(submission.shortAnswer)
@@ -73,6 +113,7 @@ export default class WorkspaceReportsService extends Service {
         'Submission or Revision': submission.submissionLabel,
         'Number of Workspace Folders': model.workspace.foldersLength,
         'Number of Notice/Wonder/Feedback': model.workspace.commentsLength,
+        'EnCoMPASS templated response': '',
       };
       const selections = submission.get('selections').slice();
       if (selections.length === 0) {


### PR DESCRIPTION
## Problem
Workspace report exports lack puzzle/problem context for each student submission.

## Solution
Added "Puzzle text" column to workspace report CSV with smart fallback:
1. Assignment problem text
2. Problem text via problemId
3. pdSet + PoW ID + class name (legacy)
4. Generic fallback

## Changes
- app/services/workspace-reports.js: getPuzzleText() + column integration
- app/routes/metrics/workspace.js: Preload relationships

## Testing
- Lint passes
- CSV includes puzzle context for all submissions
- Graceful fallbacks for missing data