### PR TITLE
fix(responses): allow responding to and generating AI drafts for any revisions

### DIFF
--- a/app/components/response-mentor-reply.hbs
+++ b/app/components/response-mentor-reply.hbs
@@ -169,8 +169,8 @@
       {{/if}}
     {{/each}}
 
-    {{! NEW: Show "New Response" button after responses when no drafts exist }}
-    {{#unless @isOlderRevision}}
+    {{! Show "New Response" button after responses when no drafts exist }}
+    {{! Removed @isOlderRevision check - allow responding to any revision }}
       {{#unless this.hasDrafts}}
         {{#unless @isCreating}}
           <div class="new-response-section">
@@ -189,25 +189,23 @@
           </div>
         {{/unless}}
       {{/unless}}
-    {{/unless}}
 
   {{else}}
-    {{#unless @isOlderRevision}}
-      <p class='info'>No Mentor Feedback for this revision yet.</p>
-      <img src='/assets/images/no-message.svg' alt='No Replies' />
-      {{#if this.canSendNew}}
-        Click 'New Response' to begin composing a new Mentor Reply.
-        <div class="submit-buttons button-row">
-          <LinkTo
-            @route="responses.new.submission"
-            @model={{@submission.id}}
-            class="primary-button"
-          >
-            New Response
-          </LinkTo>
-        </div>
-      {{/if}}
-    {{/unless}}
+    {{! Removed @isOlderRevision check - allow responding to any revision }}
+    <p class='info'>No Mentor Feedback for this revision yet.</p>
+    <img src='/assets/images/no-message.svg' alt='No Replies' />
+    {{#if this.canSendNew}}
+      Click 'New Response' to begin composing a new Mentor Reply.
+      <div class="submit-buttons button-row">
+        <LinkTo
+          @route="responses.new.submission"
+          @model={{@submission.id}}
+          class="primary-button"
+        >
+          New Response
+        </LinkTo>
+      </div>
+    {{/if}}
   {{/if}}
   {{! page pagination for mentor replies }}
   {{!-- <div class="mentor-replies">

--- a/app/components/response-mentor-reply.js
+++ b/app/components/response-mentor-reply.js
@@ -348,7 +348,11 @@ export default class ResponseMentorReplyComponent extends Component {
 
     this._startLoading();
     try {
-      const draft = await this.aiDraft.generateDraft(this.args.submission.id);
+      const draft = await this.aiDraft.generateDraft(
+        this.args.submission.id,
+        'A',
+        this.args.workspace?.id
+      );
       this.aiGeneratedText = draft;
       this.quillKey++;
       this.editRevisionText = draft;

--- a/app/components/response-new.js
+++ b/app/components/response-new.js
@@ -622,7 +622,11 @@ export default class ResponseNewComponent extends Component {
       'doShowLoadingMessage'
     );
     try {
-      const draft = await this.aiDraft.generateDraft(submissionId);
+      const draft = await this.aiDraft.generateDraft(
+        submissionId,
+        'A',
+        this.args.workspace?.id
+      );
 
       // Clear any pending content from previous "Bring it Down"
       this.pendingContent = null;

--- a/app/routes/responses/new/submission.js
+++ b/app/routes/responses/new/submission.js
@@ -121,17 +121,11 @@ export default class ResponsesNewSubmissionRoute extends Route {
     }
 
     // Load all async data in parallel
-    const [submissions, recipient, selections, comments] = await Promise.all([
-      workspace.submissions,
+    const [recipient, selections, comments] = await Promise.all([
       this.resolveRecipient(submission, workspace),
       submission.selections,
       submission.comments,
     ]);
-
-    // should we check the student ids rather than the objects?
-    const studentSubmissions = submissions.filter(
-      (sub) => sub.uniqueIdentifier === submission.uniqueIdentifier
-    );
 
     const associatedResponses = this._filterResponsesBySubmission(
       allResponses,
@@ -151,7 +145,9 @@ export default class ResponsesNewSubmissionRoute extends Route {
       submission,
       workspace,
       responses: associatedResponses,
-      submissions: studentSubmissions,
+      // Only pass the single target submission, not entire revision thread
+      // This ensures "Draft From AI" and "Respond" work on the correct revision
+      submissions: [submission],
     };
   }
 

--- a/app/routes/responses/submission.js
+++ b/app/routes/responses/submission.js
@@ -63,11 +63,15 @@ export default class ResponsesRoute extends AuthenticatedRoute {
       'student',
       submission.get('student')
     );
-    const latestSubmission = submissionThread
-      .slice()
-      .sort((a, b) => new Date(b.createDate) - new Date(a.createDate))
-      .at(0);
-    const activeSubmission = latestSubmission || submission;
+    // OLD BEHAVIOR: Always used latest submission for Respond button
+    // const latestSubmission = submissionThread
+    //   .slice()
+    //   .sort((a, b) => new Date(b.createDate) - new Date(a.createDate))
+    //   .at(0);
+    // const activeSubmission = latestSubmission || submission;
+
+    // NEW BEHAVIOR: Use the submission being viewed (from URL params)
+    const activeSubmission = submission;
 
     let allResponses = this.store.peekAll('response');
     let additionalDrafts = allResponses.filter((response) => {


### PR DESCRIPTION
### Problem
Teachers could only respond to the most recent student revision. Clicking "Respond" 
or "Draft From AI" on older revisions always used the latest revision's data.

### Root Causes & Fixes
1. **Response viewing route** - forced `activeSubmission` to latest → now uses URL param
2. **New response route** - passed entire revision thread → now passes single target submission
3. **Button visibility** - `@isOlderRevision` conditional hid buttons → removed conditional
4. **AI context** - missing workspace ID → now passed to AI service

### Files Changed
- `app/routes/responses/submission.js` - Use submission from URL
- `app/routes/responses/new/submission.js` - Pass single submission, removed unnecessary queries
- `app/components/response-mentor-reply.hbs` - Show button for all revisions
- `app/components/response-mentor-reply.js` - Pass workspace ID to AI
- `app/components/response-new.js` - Pass workspace ID to AI

### Testing
- Manually tested all revisions - buttons appear correctly
- Respond button opens correct revision
- AI Draft generates for correct revision with proper context
- Performance optimization verified (removed unnecessary queries)

### Notes
Integration tests in progress, will be added in follow-up PR.
Merged quickly to unblock AI testing for researchers.

```