### PR TITLE
fix(workspace-reports): exclude trashed selections, comments, and folders from CSV exports

### DIFF
--- a/app/services/workspace-reports.js
+++ b/app/services/workspace-reports.js
@@ -16,7 +16,8 @@ export default class WorkspaceReportsService extends Service {
 
   getUniqueFolderNames(selection) {
     const folderNames = new Set();
-    const folders = selection.get('folders') || [];
+    const folders = (selection.get('folders') || [])
+      .filterBy('isTrashed', false);
     folders.forEach((folder) => {
       folderNames.add(folder.get('name'));
     });
@@ -143,7 +144,9 @@ export default class WorkspaceReportsService extends Service {
         'Number of Notice/Wonder/Feedback': model.workspace.commentsLength,
         'EnCoMPASS templated response': '',
       };
-      const selections = submission.get('selections').slice();
+      const selections = submission.get('selections')
+        .filterBy('isTrashed', false)
+        .slice();
       if (selections.length === 0) {
         // For submissions without selections, return the base data only
         return [baseData];
@@ -152,7 +155,8 @@ export default class WorkspaceReportsService extends Service {
         return selections.flatMap((selection) => {
           const selectorInfo = this.createSelectorInfo(selection);
           const folders = this.getUniqueFolderNames(selection).join('; ');
-          const comments = selection.get('comments') || [];
+          const comments = (selection.get('comments') || [])
+            .filterBy('isTrashed', false);
 
           if (comments.length === 0) {
             const selectionData = {


### PR DESCRIPTION
### Problem
Workspace report CSV exports were including deleted selections, comments, and folders. When teachers deleted items (marked as `isTrashed: true`), those items still appeared in the exported reports, polluting the data.

### Cause
The `workspace-reports.js` service was not filtering out trashed items when building the CSV export - it processed all selections, comments, and folders regardless of their `isTrashed` status.

### Solution
Added `.filterBy('isTrashed', false)` filters in three locations in `app/services/workspace-reports.js`:
- Filter trashed folders in `getUniqueFolderNames()` method
- Filter trashed selections before generating CSV rows
- Filter trashed comments before including in export

This is consistent with how other parts of the codebase handle soft-deleted items.

### Manual Testing
- Created workspace with submissions, selections, comments, and folders
- Exported CSV - verified all items appear correctly
- Deleted some selections, comments, and removed folders
- Re-exported CSV - confirmed deleted items no longer appear
- Verified active items still export correctly
- No errors or console warnings

### Files Changed
- `app/services/workspace-reports.js`