### PR TITLE
Wp report/problem_statement: Fixes missing problem text in workspace exports

### DIFF
--- a/app/services/workspace-reports.js
+++ b/app/services/workspace-reports.js
@@ -17,8 +17,10 @@ export default class WorkspaceReportsService extends Service {
 
   getUniqueFolderNames(selection) {
     const folderNames = new Set();
-    const folders = (selection.get('folders') || [])
-      .filterBy('isTrashed', false);
+    const folders = (selection.get('folders') || []).filterBy(
+      'isTrashed',
+      false
+    );
     folders.forEach((folder) => {
       folderNames.add(folder.get('name'));
     });
@@ -67,6 +69,32 @@ export default class WorkspaceReportsService extends Service {
       return variantsBySubmission;
     } catch (error) {
       console.error('[Workspace Report] Error fetching variants:', error);
+      return {};
+    }
+  }
+
+  async fetchProblemTextsForSubmissions(submissions, workspaceId) {
+    if (!workspaceId || !Array.isArray(submissions) || submissions.length === 0)
+      return {};
+
+    const submissionIds = submissions.map((s) => s.id).join(',');
+
+    try {
+      const response = await fetch(
+        `/api/workspaces/${workspaceId}/problemTexts?submissionIds=${submissionIds}`,
+        {
+          credentials: 'include',
+        }
+      );
+
+      if (!response.ok) {
+        return {};
+      }
+
+      const data = await response.json();
+      return data.problemTexts || {};
+    } catch (error) {
+      console.error('[Workspace Report] Error fetching problem texts:', error);
       return {};
     }
   }
@@ -144,6 +172,10 @@ export default class WorkspaceReportsService extends Service {
     const variantsBySubmission = await this.fetchVariantsForSubmissions(
       submissionsArray
     );
+    const problemTextsBySubmission = await this.fetchProblemTextsForSubmissions(
+      submissionsArray,
+      model.workspace?.id
+    );
 
     // Group submissions by submitter
     const submissionsByUser = submissionsArray.reduce((acc, submission) => {
@@ -194,7 +226,10 @@ export default class WorkspaceReportsService extends Service {
         'Workspace URL': window.location.href,
         'Workspace Owner': model.workspace.get('owner.username'),
         'Original Submitter': submission.student,
-        'Puzzle text': this.getPuzzleText(submission),
+        'Puzzle text': this.stripHtml(
+          problemTextsBySubmission[submission.id] ||
+            this.getPuzzleText(submission)
+        ),
         'Text of Submission': `Summary: ${
           submission.shortAnswer
             ? this.stripHtml(submission.shortAnswer)
@@ -213,7 +248,8 @@ export default class WorkspaceReportsService extends Service {
         'EnCoMPASS templated response': '',
         ...variantData, // Add AI variant columns
       };
-      const selections = submission.get('selections')
+      const selections = submission
+        .get('selections')
         .filterBy('isTrashed', false)
         .slice();
       if (selections.length === 0) {
@@ -224,8 +260,10 @@ export default class WorkspaceReportsService extends Service {
         return selections.flatMap((selection) => {
           const selectorInfo = this.createSelectorInfo(selection);
           const folders = this.getUniqueFolderNames(selection).join('; ');
-          const comments = (selection.get('comments') || [])
-            .filterBy('isTrashed', false);
+          const comments = (selection.get('comments') || []).filterBy(
+            'isTrashed',
+            false
+          );
 
           if (comments.length === 0) {
             const selectionData = {

--- a/app_server/datasource/api/aiApi.js
+++ b/app_server/datasource/api/aiApi.js
@@ -43,7 +43,7 @@ async function aiDraft(req, res, next) {
 
   try {
     // A/B TEST: Generate AI draft using the AI service with variant
-    const draft = await aiService.generateDraft(
+    const draftResult = await aiService.generateDraft(
       target,
       variant,
       workspace,
@@ -66,6 +66,10 @@ async function aiDraft(req, res, next) {
         isTrashed: false,
       });
 
+      const draftText =
+        typeof draftResult === 'object' && draftResult?.draft
+          ? draftResult.draft
+          : draftResult;
       if (!existingVariant) {
         await models.AIVariant.create({
           submission: target,
@@ -73,11 +77,11 @@ async function aiDraft(req, res, next) {
           variantKey: variant,
           variantLabel: variantConfigData.label,
           inputType: variantConfigData.inputType,
-          draftText: draft,
+          draftText: draftText,
           createdBy: user._id,
         });
       } else {
-        existingVariant.draftText = draft;
+        existingVariant.draftText = draftText;
         existingVariant.lastModifiedDate = new Date();
         existingVariant.lastModifiedBy = user._id;
         await existingVariant.save();
@@ -86,11 +90,15 @@ async function aiDraft(req, res, next) {
       console.error('[AI Variant] Failed to save variant:', saveError);
     }
 
+    const draftText =
+      typeof draftResult === 'object' && draftResult?.draft
+        ? draftResult.draft
+        : draftResult;
     const response = {
       target: target,
       variant: variant, // A/B TEST: Include variant in response
       message: `AI draft generated for target submission: ${target}`,
-      draft,
+      draft: draftText,
     };
 
     return utils.sendResponse(res, response);

--- a/app_server/datasource/api/workspaceApi.js
+++ b/app_server/datasource/api/workspaceApi.js
@@ -40,6 +40,13 @@ module.exports.get = {};
 module.exports.post = {};
 module.exports.put = {};
 
+const stripHtml = (text) => {
+  if (!text) return '';
+  return String(text)
+    .replace(/<\/?[^>]+(>|$)/g, '')
+    .trim();
+};
+
 function getRestrictedDataMap(user, permissions, ws, isBasicStudentAccess) {
   // check if user has specific permissions in ws permissions array
   // ws has selections, submissions, folders, taggings populated
@@ -249,6 +256,149 @@ function getWorkspace(
       });
       callback(data);
     });
+}
+
+async function getWorkspaceProblemTexts(req, res, next) {
+  try {
+    const user = userAuth.requireUser(req);
+    if (!user) {
+      return utils.sendError.InvalidCredentialsError(
+        'You must be logged in.',
+        res
+      );
+    }
+
+    const workspaceId = req.params.id;
+    const canLoad = await access.get.workspace(user, workspaceId);
+    if (!canLoad) {
+      return utils.sendError.NotAuthorizedError(
+        'You do not have permission.',
+        res
+      );
+    }
+
+    const workspace = await models.Workspace.findById(workspaceId, {
+      submissions: 1,
+    })
+      .lean()
+      .exec();
+
+    if (!workspace) {
+      return utils.sendResponse(res, null);
+    }
+
+    const allowedIds = (workspace.submissions || []).map((id) => id.toString());
+    const requestedIds = req.query.submissionIds
+      ? req.query.submissionIds.split(',').filter(Boolean)
+      : [];
+    const idsToFetch =
+      requestedIds.length > 0
+        ? requestedIds.filter((id) => allowedIds.includes(id))
+        : allowedIds;
+
+    if (!idsToFetch.length) {
+      return utils.sendResponse(res, { problemTexts: {} });
+    }
+
+    const submissions = await models.Submission.find({
+      _id: { $in: idsToFetch },
+    })
+      .populate({
+        path: 'answer',
+        populate: {
+          path: 'assignment',
+          populate: { path: 'problem', select: 'text title' },
+        },
+      })
+      .select('answer publication pdSet clazz')
+      .lean()
+      .exec();
+
+    const problemById = new Map();
+    const problemByPuzzleId = new Map();
+
+    const getProblemById = async (id) => {
+      if (!id) return null;
+      const key = id.toString();
+      if (problemById.has(key)) return problemById.get(key);
+      const problem = await models.Problem.findById(id)
+        .select('text title')
+        .lean()
+        .exec();
+      problemById.set(key, problem || null);
+      return problem;
+    };
+
+    const getProblemByPuzzleId = async (puzzleId) => {
+      if (!puzzleId) return null;
+      const key = String(puzzleId);
+      if (problemByPuzzleId.has(key)) return problemByPuzzleId.get(key);
+      const problem = await models.Problem.findOne({
+        puzzleId,
+        isTrashed: { $ne: true },
+      })
+        .select('text title')
+        .lean()
+        .exec();
+      problemByPuzzleId.set(key, problem || null);
+      return problem;
+    };
+
+    const problemTexts = {};
+    for (const submission of submissions) {
+      let statement =
+        submission?.answer?.assignment?.problem?.text ||
+        submission?.answer?.assignment?.problem?.title;
+
+      if (!statement && submission?.answer?.problem) {
+        const problem = await getProblemById(submission.answer.problem);
+        if (problem) statement = problem.text || problem.title;
+      }
+
+      if (!statement && submission?.publication?.publicationId) {
+        const problem = await getProblemByPuzzleId(
+          submission.publication.publicationId
+        );
+        if (problem) statement = problem.text || problem.title;
+      }
+
+      if (!statement && submission?.publication?.puzzle?.problemId) {
+        const problem = await getProblemById(
+          submission.publication.puzzle.problemId
+        );
+        if (problem) statement = problem.text || problem.title;
+      }
+
+      if (!statement && submission?.publication?.puzzle?.title) {
+        statement = submission.publication.puzzle.title;
+      }
+
+      if (!statement && submission?.pdSet) {
+        const pdSetTitle = stripHtml(submission.pdSet).split(' - ')[0].trim();
+        const fallbackParts = [pdSetTitle];
+        const powId = submission?.publication?.publicationId;
+        if (powId) fallbackParts.push(`PoW ID: ${powId}`);
+        const className = stripHtml(submission?.clazz?.name || '');
+        if (className) fallbackParts.push(`Class: ${className}`);
+        statement = `${fallbackParts.join(
+          '. '
+        )}. The student is sharing their mathematical thinking and work.`;
+      }
+
+      if (!statement) {
+        statement =
+          'The student is sharing their mathematical thinking and work.';
+      }
+
+      problemTexts[submission._id] = statement;
+    }
+
+    return utils.sendResponse(res, { problemTexts });
+  } catch (err) {
+    console.error(`Error getWorkspaceProblemTexts: ${err}`);
+    console.trace();
+    return utils.sendError.InternalError(null, res);
+  }
 }
 
 /**
@@ -3824,6 +3974,7 @@ module.exports.post.workspaceEnc = postWorkspaceEnc;
 module.exports.post.cloneWorkspace = cloneWorkspace;
 module.exports.get.workspace = sendWorkspace;
 module.exports.get.workspaces = getWorkspaces;
+module.exports.get.workspaceProblemTexts = getWorkspaceProblemTexts;
 module.exports.put.workspace = putWorkspace;
 module.exports.post.workspace = postWorkspace;
 module.exports.post.newWorkspaceRequest = newWorkspaceRequest;

--- a/app_server/server.js
+++ b/app_server/server.js
@@ -228,6 +228,11 @@ server.get('/api/users', api.get.users);
 server.get('/api/users/:id', pathMw.validateId(), api.get.user);
 server.get('/api/workspaces', paginate.middleware(20, 100), api.get.workspaces);
 server.get('/api/workspaces/:id', pathMw.validateId(), api.get.workspace);
+server.get(
+  '/api/workspaces/:id/problemTexts',
+  pathMw.validateId(),
+  api.get.workspaceProblemTexts
+);
 server.get('/api/folders', api.get.folders);
 server.get('/api/folders/:id', pathMw.validateId(), api.get.folder);
 server.get('/api/foldersets', api.get.folderSets);

--- a/app_server/services/ai.js
+++ b/app_server/services/ai.js
@@ -26,6 +26,24 @@ const stripHtml = (html) => {
 };
 
 const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const buildLooseTitleRegex = (title) => {
+  if (!title) return null;
+  const clean = stripHtml(title)
+    .replace(/[^\w\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!clean) return null;
+  const words = clean.split(' ');
+  const pattern = words
+    .map((word) => {
+      const escaped = escapeRegex(word);
+      if (escaped.length <= 2) return escaped;
+      if (escaped.endsWith('s')) return escaped;
+      return `${escaped}s?`;
+    })
+    .join('\\s+');
+  return new RegExp(pattern, 'i');
+};
 
 /**
  * Generate an AI draft response based on submission
@@ -58,7 +76,7 @@ const generateDraft = async (
     })
     .populate('creator', 'username')
     .populate('clazz', 'name')
-    .select('shortAnswer longAnswer creator clazz publication pdSet')
+    .select('shortAnswer longAnswer answer creator clazz publication pdSet')
     .lean()
     .exec();
 
@@ -67,9 +85,36 @@ const generateDraft = async (
   }
 
   // Step 2: Extract problem statement
+  const puzzleTitle = targetSubmission?.publication?.puzzle?.title;
+
   let problemStatement =
     targetSubmission?.answer?.assignment?.problem?.text ||
-    targetSubmission?.publication?.puzzle?.title;
+    targetSubmission?.answer?.assignment?.problem?.title;
+
+  if (!problemStatement && targetSubmission?.answer?.problem) {
+    const problem = await models.Problem.findById(
+      targetSubmission.answer.problem
+    )
+      .select('text title')
+      .lean()
+      .exec();
+    if (problem) {
+      problemStatement = problem.text || problem.title;
+    }
+  }
+
+  if (!problemStatement && targetSubmission?.publication?.publicationId) {
+    const problem = await models.Problem.findOne({
+      puzzleId: targetSubmission.publication.publicationId,
+      isTrashed: { $ne: true },
+    })
+      .select('text title')
+      .lean()
+      .exec();
+    if (problem) {
+      problemStatement = problem.text || problem.title;
+    }
+  }
 
   if (!problemStatement && targetSubmission?.publication?.puzzle?.problemId) {
     const problem = await models.Problem.findById(
@@ -78,7 +123,13 @@ const generateDraft = async (
       .select('text title')
       .lean()
       .exec();
-    if (problem) problemStatement = problem.text || problem.title;
+    if (problem) {
+      problemStatement = problem.text || problem.title;
+    }
+  }
+
+  if (!problemStatement && puzzleTitle) {
+    problemStatement = puzzleTitle;
   }
 
   const pdSetTitle = targetSubmission?.pdSet
@@ -86,7 +137,9 @@ const generateDraft = async (
     : '';
 
   if (!problemStatement && pdSetTitle) {
-    const titleRegex = new RegExp(escapeRegex(pdSetTitle), 'i');
+    const titleRegex =
+      buildLooseTitleRegex(pdSetTitle) ||
+      new RegExp(escapeRegex(pdSetTitle), 'i');
     const matchedProblem = await models.Problem.findOne({
       title: titleRegex,
       isTrashed: { $ne: true },


### PR DESCRIPTION
## Description
Fixes missing problem text in workspace exports by resolving problem statements server‑side and using that map in the CSV report. This avoids legacy linkage gaps on the client and keeps report output consistent with the AI payload.

## Changes
- Add `/api/workspaces/:id/problemTexts` to resolve problem text per submission.
- Use the returned map in the workspace CSV export (fallback to existing client lookup when missing).

## Files
- app_server/datasource/api/workspaceApi.js
- app_server/server.js
- app/services/workspace-reports.js

## Testing
- Manual: called `/api/workspaces/:id/problemTexts` in browser and verified problem text returned for target submissions.
- Manual: exported workspace CSV and verified problem text column populates correctly.

**Note:** Problem‑text resolution is duplicated between the AI input and workspace report paths. I’ll consolidate the logic into a shared resolver and clean up the flow in a follow‑up PR.