### PR TITLE
ai/report: centralize problem text resolution

### DIFF
--- a/app_server/datasource/api/workspaceApi.js
+++ b/app_server/datasource/api/workspaceApi.js
@@ -40,12 +40,7 @@ module.exports.get = {};
 module.exports.post = {};
 module.exports.put = {};
 
-const stripHtml = (text) => {
-  if (!text) return '';
-  return String(text)
-    .replace(/<\/?[^>]+(>|$)/g, '')
-    .trim();
-};
+const { resolveProblemText } = require('../../services/problemText');
 
 function getRestrictedDataMap(user, permissions, ws, isBasicStudentAccess) {
   // check if user has specific permissions in ws permissions array
@@ -314,82 +309,13 @@ async function getWorkspaceProblemTexts(req, res, next) {
       .lean()
       .exec();
 
-    const problemById = new Map();
-    const problemByPuzzleId = new Map();
-
-    const getProblemById = async (id) => {
-      if (!id) return null;
-      const key = id.toString();
-      if (problemById.has(key)) return problemById.get(key);
-      const problem = await models.Problem.findById(id)
-        .select('text title')
-        .lean()
-        .exec();
-      problemById.set(key, problem || null);
-      return problem;
+    const cache = {
+      problemById: new Map(),
+      problemByPuzzleId: new Map(),
     };
-
-    const getProblemByPuzzleId = async (puzzleId) => {
-      if (!puzzleId) return null;
-      const key = String(puzzleId);
-      if (problemByPuzzleId.has(key)) return problemByPuzzleId.get(key);
-      const problem = await models.Problem.findOne({
-        puzzleId,
-        isTrashed: { $ne: true },
-      })
-        .select('text title')
-        .lean()
-        .exec();
-      problemByPuzzleId.set(key, problem || null);
-      return problem;
-    };
-
     const problemTexts = {};
     for (const submission of submissions) {
-      let statement =
-        submission?.answer?.assignment?.problem?.text ||
-        submission?.answer?.assignment?.problem?.title;
-
-      if (!statement && submission?.answer?.problem) {
-        const problem = await getProblemById(submission.answer.problem);
-        if (problem) statement = problem.text || problem.title;
-      }
-
-      if (!statement && submission?.publication?.publicationId) {
-        const problem = await getProblemByPuzzleId(
-          submission.publication.publicationId
-        );
-        if (problem) statement = problem.text || problem.title;
-      }
-
-      if (!statement && submission?.publication?.puzzle?.problemId) {
-        const problem = await getProblemById(
-          submission.publication.puzzle.problemId
-        );
-        if (problem) statement = problem.text || problem.title;
-      }
-
-      if (!statement && submission?.publication?.puzzle?.title) {
-        statement = submission.publication.puzzle.title;
-      }
-
-      if (!statement && submission?.pdSet) {
-        const pdSetTitle = stripHtml(submission.pdSet).split(' - ')[0].trim();
-        const fallbackParts = [pdSetTitle];
-        const powId = submission?.publication?.publicationId;
-        if (powId) fallbackParts.push(`PoW ID: ${powId}`);
-        const className = stripHtml(submission?.clazz?.name || '');
-        if (className) fallbackParts.push(`Class: ${className}`);
-        statement = `${fallbackParts.join(
-          '. '
-        )}. The student is sharing their mathematical thinking and work.`;
-      }
-
-      if (!statement) {
-        statement =
-          'The student is sharing their mathematical thinking and work.';
-      }
-
+      const statement = await resolveProblemText(submission, models, cache);
       problemTexts[submission._id] = statement;
     }
 

--- a/app_server/services/ai.js
+++ b/app_server/services/ai.js
@@ -25,25 +25,7 @@ const stripHtml = (html) => {
     .trim();
 };
 
-const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-const buildLooseTitleRegex = (title) => {
-  if (!title) return null;
-  const clean = stripHtml(title)
-    .replace(/[^\w\s]/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
-  if (!clean) return null;
-  const words = clean.split(' ');
-  const pattern = words
-    .map((word) => {
-      const escaped = escapeRegex(word);
-      if (escaped.length <= 2) return escaped;
-      if (escaped.endsWith('s')) return escaped;
-      return `${escaped}s?`;
-    })
-    .join('\\s+');
-  return new RegExp(pattern, 'i');
-};
+const { resolveProblemText } = require('./problemText');
 
 /**
  * Generate an AI draft response based on submission
@@ -85,88 +67,7 @@ const generateDraft = async (
   }
 
   // Step 2: Extract problem statement
-  const puzzleTitle = targetSubmission?.publication?.puzzle?.title;
-
-  let problemStatement =
-    targetSubmission?.answer?.assignment?.problem?.text ||
-    targetSubmission?.answer?.assignment?.problem?.title;
-
-  if (!problemStatement && targetSubmission?.answer?.problem) {
-    const problem = await models.Problem.findById(
-      targetSubmission.answer.problem
-    )
-      .select('text title')
-      .lean()
-      .exec();
-    if (problem) {
-      problemStatement = problem.text || problem.title;
-    }
-  }
-
-  if (!problemStatement && targetSubmission?.publication?.publicationId) {
-    const problem = await models.Problem.findOne({
-      puzzleId: targetSubmission.publication.publicationId,
-      isTrashed: { $ne: true },
-    })
-      .select('text title')
-      .lean()
-      .exec();
-    if (problem) {
-      problemStatement = problem.text || problem.title;
-    }
-  }
-
-  if (!problemStatement && targetSubmission?.publication?.puzzle?.problemId) {
-    const problem = await models.Problem.findById(
-      targetSubmission.publication.puzzle.problemId
-    )
-      .select('text title')
-      .lean()
-      .exec();
-    if (problem) {
-      problemStatement = problem.text || problem.title;
-    }
-  }
-
-  if (!problemStatement && puzzleTitle) {
-    problemStatement = puzzleTitle;
-  }
-
-  const pdSetTitle = targetSubmission?.pdSet
-    ? stripHtml(targetSubmission.pdSet).split(' - ')[0].trim()
-    : '';
-
-  if (!problemStatement && pdSetTitle) {
-    const titleRegex =
-      buildLooseTitleRegex(pdSetTitle) ||
-      new RegExp(escapeRegex(pdSetTitle), 'i');
-    const matchedProblem = await models.Problem.findOne({
-      title: titleRegex,
-      isTrashed: { $ne: true },
-    })
-      .select('text title')
-      .lean()
-      .exec();
-    if (matchedProblem) {
-      problemStatement = matchedProblem.text || matchedProblem.title;
-    }
-  }
-
-  if (!problemStatement && pdSetTitle) {
-    const fallbackParts = [pdSetTitle];
-    const powId = targetSubmission?.publication?.publicationId;
-    if (powId) fallbackParts.push(`PoW ID: ${powId}`);
-    const className = targetSubmission?.clazz?.name;
-    if (className) fallbackParts.push(`Class: ${className}`);
-    problemStatement = `${fallbackParts.join(
-      '. '
-    )}. The student is sharing their mathematical thinking and work.`;
-  }
-
-  if (!problemStatement) {
-    problemStatement =
-      'The student is sharing their mathematical thinking and work.';
-  }
+  const problemStatement = await resolveProblemText(targetSubmission, models);
 
   // Step 3: Extract and clean student work
   let shortAnswer = stripHtml(targetSubmission.shortAnswer || '');

--- a/app_server/services/problemText.js
+++ b/app_server/services/problemText.js
@@ -1,0 +1,131 @@
+const he = require('he');
+
+const DEFAULT_STATEMENT =
+  'The student is sharing their mathematical thinking and work.';
+
+const stripHtml = (html) => {
+  if (!html) return '';
+  return he
+    .decode(String(html).replace(/<[^>]*>/g, ''))
+    .replace(/\s+/g, ' ')
+    .trim();
+};
+
+const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const buildLooseTitleRegex = (title) => {
+  if (!title) return null;
+  const clean = stripHtml(title)
+    .replace(/[^\w\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!clean) return null;
+  const words = clean.split(' ');
+  const pattern = words
+    .map((word) => {
+      const escaped = escapeRegex(word);
+      if (escaped.length <= 2) return escaped;
+      if (escaped.endsWith('s')) return escaped;
+      return `${escaped}s?`;
+    })
+    .join('\\s+');
+  return new RegExp(pattern, 'i');
+};
+
+const resolveProblemText = async (submission, models, cache = {}) => {
+  if (!submission || !models) {
+    return DEFAULT_STATEMENT;
+  }
+
+  const problemById = cache.problemById || new Map();
+  const problemByPuzzleId = cache.problemByPuzzleId || new Map();
+
+  const getProblemById = async (id) => {
+    if (!id) return null;
+    const key = id.toString();
+    if (problemById.has(key)) return problemById.get(key);
+    const problem = await models.Problem.findById(id)
+      .select('text title')
+      .lean()
+      .exec();
+    problemById.set(key, problem || null);
+    return problem;
+  };
+
+  const getProblemByPuzzleId = async (puzzleId) => {
+    if (!puzzleId) return null;
+    const key = String(puzzleId);
+    if (problemByPuzzleId.has(key)) return problemByPuzzleId.get(key);
+    const problem = await models.Problem.findOne({
+      puzzleId,
+      isTrashed: { $ne: true },
+    })
+      .select('text title')
+      .lean()
+      .exec();
+    problemByPuzzleId.set(key, problem || null);
+    return problem;
+  };
+
+  let statement =
+    submission?.answer?.assignment?.problem?.text ||
+    submission?.answer?.assignment?.problem?.title;
+
+  if (!statement && submission?.answer?.problem) {
+    const problem = await getProblemById(submission.answer.problem);
+    if (problem) statement = problem.text || problem.title;
+  }
+
+  if (!statement && submission?.publication?.publicationId) {
+    const problem = await getProblemByPuzzleId(
+      submission.publication.publicationId
+    );
+    if (problem) statement = problem.text || problem.title;
+  }
+
+  if (!statement && submission?.publication?.puzzle?.problemId) {
+    const problem = await getProblemById(
+      submission.publication.puzzle.problemId
+    );
+    if (problem) statement = problem.text || problem.title;
+  }
+
+  if (!statement && submission?.publication?.puzzle?.title) {
+    statement = submission.publication.puzzle.title;
+  }
+
+  const pdSetTitle = submission?.pdSet
+    ? stripHtml(submission.pdSet).split(' - ')[0].trim()
+    : '';
+
+  if (!statement && pdSetTitle) {
+    const titleRegex =
+      buildLooseTitleRegex(pdSetTitle) ||
+      new RegExp(escapeRegex(pdSetTitle), 'i');
+    const matchedProblem = await models.Problem.findOne({
+      title: titleRegex,
+      isTrashed: { $ne: true },
+    })
+      .select('text title')
+      .lean()
+      .exec();
+    if (matchedProblem) {
+      statement = matchedProblem.text || matchedProblem.title;
+    }
+  }
+
+  if (!statement && pdSetTitle) {
+    const fallbackParts = [pdSetTitle];
+    const powId = submission?.publication?.publicationId;
+    if (powId) fallbackParts.push(`PoW ID: ${powId}`);
+    const className = stripHtml(submission?.clazz?.name || '');
+    if (className) fallbackParts.push(`Class: ${className}`);
+    statement = `${fallbackParts.join('. ')}. ${DEFAULT_STATEMENT}`;
+  }
+
+  return statement || DEFAULT_STATEMENT;
+};
+
+module.exports = {
+  resolveProblemText,
+};


### PR DESCRIPTION
## Description
Refactors problem‑text resolution into a shared server helper so AI input and workspace report paths use the same logic. This removes duplicate lookup code and keeps behavior consistent across features.

## Changes
- Added a shared resolver for problem text (single source of truth)
- Updated AI draft generation to use the shared resolver
- Updated workspace report endpoint to use the shared resolver

## Files
- app_server/services/problemText.js
- app_server/services/ai.js
- app_server/datasource/api/workspaceApi.js

## Testing
- Manual: generated AI draft and verified problem statement still resolves
- Manual: called `/api/workspaces/:id/problemTexts` and confirmed output unchanged