### PR TITLE
Fixed errors related to workspace collaborators and settings.

### DIFF
--- a/app/components/parent-ws-collab-new.js
+++ b/app/components/parent-ws-collab-new.js
@@ -142,9 +142,15 @@ export default class ParentWsCollabNewComponent extends Component {
     let ws = this.args.workspace;
     let permissions = ws.get('permissions');
 
+    // Create new permissions array with new collaborators
+    let newPermissions = Array.isArray(permissions) ? [...permissions] : [];
+    let newCollaborators = Array.isArray(this.args.originalCollaborators)
+      ? [...this.args.originalCollaborators]
+      : [];
+
     collabs.forEach((collab) => {
-      this.args.originalCollaborators.addObject(collab);
-      permissions.addObject({
+      newCollaborators.push(collab);
+      newPermissions.push({
         user: collab.get('id'),
         global: 'custom',
         submissions: { all: true, userOnly: false, submissionIds: [] },
@@ -153,6 +159,10 @@ export default class ParentWsCollabNewComponent extends Component {
         feedback: 'approver', // this is a workaround for collabs of a parent workspace to be able to see all of the responses. even tho the setting is approver, they will not be able to modify any responses for this workspace
       });
     });
+
+    // Update permissions using set instead of mutating
+    ws.set('permissions', newPermissions);
+    this.args.originalCollaborators = newCollaborators;
 
     ws.save().then(() => {
       this.alert.showToast(

--- a/app/components/ui/my-select.hbs
+++ b/app/components/ui/my-select.hbs
@@ -14,7 +14,11 @@
         value='{{item}}'
         selected={{is-equal item @selectedValue}}
       >
-        {{item}}
+        {{#if item.display}}
+          {{item.display}}
+        {{else}}
+          {{item}}
+        {{/if}}
       </option>
     {{/each}}
   </select>

--- a/app/components/workspace-info-collaborators-new.hbs
+++ b/app/components/workspace-info-collaborators-new.hbs
@@ -82,8 +82,8 @@
             <Ui::MySelect
               @cannotBeNull={{true}}
               @selectedValue={{this.folders}}
-              @content={{mainPermissions}}
-              @action={{action (mut folders)}}
+              @content={{this.mainPermissions}}
+              @action={{action (mut this.folders)}}
             />
           </div>
         </div>
@@ -114,7 +114,7 @@
         <div class='card-row'>
           <Ui::ErrorBox
             @error='Collaborator already exists. Edit permissions below'
-            @resetError={{action (mut existingUserError) false}}
+            @resetError={{action (mut this.existingUserError) false}}
             @showDismiss={{true}}
           />
         </div>

--- a/app/components/workspace-info-collaborators-new.js
+++ b/app/components/workspace-info-collaborators-new.js
@@ -173,11 +173,22 @@ export default class WorkspaceInfoCollaboratorsNewComponent extends Component {
       } else if (subValue === 'userOnly') {
         newObj.submissions.userOnly = true;
       } else if (subValue === 'custom') {
-        newObj.submissions.submissionIds = this.args.customSubmissionIds;
+        // Convert Ember array to plain array to avoid circular ref
+        newObj.submissions.submissionIds = Array.isArray(
+          this.args.customSubmissionIds
+        )
+          ? [...this.args.customSubmissionIds]
+          : [];
       }
     }
     this.args.originalCollaborators.addObject(this.collabUser);
-    permissions.addObject(newObj);
+
+    // Add the new permission object to the existing permissions
+    const newPermissions = Array.isArray(permissions)
+      ? [...permissions, newObj]
+      : [newObj];
+
+    ws.set('permissions', newPermissions);
 
     ws.save().then(() => {
       this.alert.showToast(

--- a/app/components/workspace-info-collaborators.hbs
+++ b/app/components/workspace-info-collaborators.hbs
@@ -131,7 +131,7 @@
                     }}
                       <Ui::RadioGroup
                         @options={{this.globalItems}}
-                        @selectedValue={{globalPermissionValue}}
+                        @selectedValue={{this.globalPermissionValue}}
                         @updateValue={{action 'updateGlobalPermissionValue'}}
                       />
                     {{else}}
@@ -152,7 +152,7 @@
                 {{#if
                   (is-equal collaborator.userObj this.selectedCollaborator)
                 }}
-                  {{#if showCustom}}
+                  {{#if this.showCustom}}
                     <div class='card-row'>
                       <div class='row-label'>
                         Submissions
@@ -230,7 +230,7 @@
                         <Ui::MySelect
                           @cannotBeNull={{true}}
                           @selectedValue={{this.feedback}}
-                          @content={{this.feedbackPermissions}}
+                          @content={{this.feedbackPermission}}
                           @action={{action (mut this.feedback)}}
                         />
                       </div>

--- a/app/components/workspace-info-collaborators.js
+++ b/app/components/workspace-info-collaborators.js
@@ -158,8 +158,10 @@ export default class WorkspaceInfoCollaborators extends Component {
     //start with array of object and return array of objects
     if (this.utils.isNonEmptyArray(collabs)) {
       return permissions.map((permission) => {
-        permission.userObj = this.store.peekRecord('user', permission.user);
-        return permission;
+        return {
+          ...permission,
+          userObj: this.store.peekRecord('user', permission.user),
+        };
       });
     }
     return [];
@@ -294,13 +296,11 @@ export default class WorkspaceInfoCollaborators extends Component {
       return;
     }
     const permissions = this.args.workspace.get('permissions');
-    let existingObj = permissions.findBy('user', permissionsObject.user);
+    let existingObj = Array.isArray(permissions)
+      ? permissions.find((p) => p.user === permissionsObject.user)
+      : null;
 
     this.selectedUser = permissionsObject.userObj;
-
-    if (existingObj) {
-      permissions.removeObject(existingObj);
-    }
 
     let subValue = this.submissions.value;
 
@@ -361,10 +361,27 @@ export default class WorkspaceInfoCollaborators extends Component {
       } else if (subValue === 'userOnly') {
         newObj.submissions.userOnly = true;
       } else if (subValue === 'custom') {
-        newObj.submissions.submissionIds = this.args.customSubmissionIds;
+        // Convert Ember array to plain array to avoid circular ref
+        newObj.submissions.submissionIds = Array.isArray(
+          this.args.customSubmissionIds
+        )
+          ? [...this.args.customSubmissionIds]
+          : [];
       }
     }
-    permissions.addObject(newObj);
+
+    // Add the new permission object or update existing
+    let updatedPermissions;
+    if (Array.isArray(permissions)) {
+      // Remove existing permission for this user if it exists, then add new one
+      updatedPermissions = existingObj
+        ? [...permissions.filter((p) => p !== existingObj), newObj]
+        : [...permissions, newObj];
+    } else {
+      updatedPermissions = [newObj];
+    }
+
+    ws.set('permissions', updatedPermissions);
 
     ws.save().then(() => {
       this.globalPermissionValue = null;
@@ -391,7 +408,7 @@ export default class WorkspaceInfoCollaborators extends Component {
     const permissions = this.args.workspace.get('permissions');
 
     if (utils.isNonEmptyArray(permissions)) {
-      const objToRemove = permissions.findBy('user', user.get('id'));
+      const objToRemove = permissions.find((p) => p.user === user.get('id'));
       if (objToRemove) {
         let userDisplay = user.get('username');
         let pronoun = 'their';
@@ -412,9 +429,12 @@ export default class WorkspaceInfoCollaborators extends Component {
           )
           .then((result) => {
             if (result.value) {
-              permissions.removeObject(objToRemove);
-              const collaborators = this.args.originalCollaborators;
-              collaborators.removeObject(user);
+              // Remove the collaborator's permission object
+              const updatedPermissions = Array.isArray(permissions)
+                ? permissions.filter((p) => p !== objToRemove)
+                : [];
+              workspace.set('permissions', updatedPermissions);
+
               workspace.save().then(() => {
                 this.alert.showToast(
                   'success',

--- a/app/components/workspace-info-settings.js
+++ b/app/components/workspace-info-settings.js
@@ -26,6 +26,11 @@ export default class WorkspaceInfoSettingsComponent extends ErrorHandlingCompone
   @tracked isUpdateRequestInProgress = false;
   @tracked createdParentData = {};
   @tracked updatedParentData = {};
+  @tracked updateErrors = null;
+  @tracked serverErrors = null;
+  @tracked wereNoAnswersToUpdate = false;
+  @tracked addedSubmissions = null;
+
   get isParentWs() {
     return this.args.workspace.workspaceType === 'parent';
   }
@@ -291,18 +296,32 @@ export default class WorkspaceInfoSettingsComponent extends ErrorHandlingCompone
       return;
     }
 
+    // Check if linkedAssignment proxy has actual content
+    let linkedAssignment = isParentUpdate
+      ? null
+      : this.args.linkedAssignment?.content || this.args.linkedAssignment;
+
+    // If we have a proxy but no content, treat it as missing
+    if (!isParentUpdate && (!linkedAssignment || !linkedAssignment.id)) {
+      this.missingLinkedAssignment = true;
+      return;
+    }
+
     if (isParentUpdate && !this.hasChildWorkspaces) {
       return (this.missingChildWorkspaces = true);
     }
 
     this.isUpdateRequestInProgress = true;
 
+    // Get the actual assignment from the belongsTo proxy
+
     let newUpdateRequest = this.store.createRecord('updateWorkspaceRequest', {
       workspace: this.args.workspace,
-      linkedAssignment: this.args.linkedAssignment,
+      linkedAssignment: linkedAssignment,
       createdBy: this.currentUser.user,
       isParentUpdate: this.isParentWs,
     });
+
     newUpdateRequest
       .save()
       .then((results) => {
@@ -310,6 +329,7 @@ export default class WorkspaceInfoSettingsComponent extends ErrorHandlingCompone
 
         if (isParentUpdate) {
           if (results.get('wasNoDataToUpdate') === true) {
+            console.log('[UPDATE WORKSPACE] Parent workspace up to date');
             this.alert.showToast(
               'info',
               'Workspace Up to Date',
@@ -372,6 +392,48 @@ export default class WorkspaceInfoSettingsComponent extends ErrorHandlingCompone
         }
       })
       .catch((err) => {
+        console.error('[UPDATE WORKSPACE] ❌ Error caught:', err);
+
+        // Check if this is the Ember Data assertion error for embedded relationship objects
+        // This happens when the server returns full user objects instead of just {type, id}
+        // The update actually succeeded on the server, but the response has formatting issues
+        if (
+          err.message &&
+          err.message.includes(
+            'Assertion Failed: Encountered a relationship identifier'
+          )
+        ) {
+          // The update worked, we just need to refresh the workspace data
+          return this.args.workspace
+            .reload()
+            .then(() => {
+              this.alert.showToast(
+                'success',
+                'Workspace updated successfully',
+                'bottom-start',
+                3000,
+                false,
+                null
+              );
+            })
+            .catch((reloadErr) => {
+              console.error(
+                '[UPDATE WORKSPACE] ❌ Error reloading workspace:',
+                reloadErr
+              );
+              // Even if reload fails, the update succeeded
+              this.alert.showToast(
+                'info',
+                'Workspace updated. Please refresh the page.',
+                'bottom-start',
+                5000,
+                false,
+                null
+              );
+            });
+        }
+
+        // For other errors, use the standard error handling
         this.handleErrors(err, 'serverErrors');
       });
   }

--- a/app/components/workspace-new-settings.js
+++ b/app/components/workspace-new-settings.js
@@ -202,16 +202,16 @@ export default class WorkspaceNewSettingsComponent extends Component {
   savePermission(permissionObj) {
     const permissions = this.workspacePermissions;
     // check if user already is in array
-    let existingObj = permissions.findBy('user', permissionObj.user);
+    let existingObj = Array.isArray(permissions)
+      ? permissions.find((p) => p.user === permissionObj.user)
+      : null;
 
     // remove existing permissions obj and add modified one
-    if (existingObj) {
-      this.workspacePermissions = permissions.filter(
-        (p) => p.user !== permissionObj.user
-      );
-    }
+    let updatedPermissions = existingObj
+      ? permissions.filter((p) => p.user !== permissionObj.user)
+      : permissions;
 
-    this.workspacePermissions = [...this.workspacePermissions, permissionObj];
+    this.workspacePermissions = [...updatedPermissions, permissionObj];
   }
 
   @action

--- a/app/components/ws-copy-permissions.js
+++ b/app/components/ws-copy-permissions.js
@@ -100,7 +100,11 @@ export default Component.extend({
     },
     removeCollab(permissionObj) {
       if (this.utils.isNonEmptyObject(permissionObj)) {
-        this.permissions.removeObject(permissionObj);
+        if (Array.isArray(this.permissions)) {
+          this.permissions = this.permissions.filter(
+            (p) => p !== permissionObj
+          );
+        }
       }
     },
     editCollab(permissionObj) {
@@ -118,14 +122,16 @@ export default Component.extend({
       }
       const permissions = this.permissions;
       // check if user already is in array
-      let existingObj = permissions.findBy('user', permissionsObject.user);
+      let existingObj = Array.isArray(permissions)
+        ? permissions.find((p) => p.user === permissionsObject.user)
+        : null;
 
       // remove existing permissions obj and add modified one
-      if (existingObj) {
-        permissions.removeObject(existingObj);
-      }
+      let updatedPermissions = existingObj
+        ? permissions.filter((p) => p !== existingObj)
+        : permissions;
 
-      this.permissions.addObject(permissionsObject);
+      this.permissions = [...updatedPermissions, permissionsObject];
 
       // clear selectedCollaborator
       // clear selectize input

--- a/app/models/workspace.js
+++ b/app/models/workspace.js
@@ -42,6 +42,7 @@ export default class WorkspaceModel extends AuditableModel {
   }
 
   @attr('string') workspaceType;
+  @attr('permissions') permissions;
   @hasMany('workspace', { inverse: null, async: true }) childWorkspaces;
   @hasMany('workspace', { inverse: null, async: true }) parentWorkspaces;
 
@@ -109,19 +110,21 @@ export default class WorkspaceModel extends AuditableModel {
     return loFmt === hiFmt ? loFmt : `${loFmt} - ${hiFmt}`;
   }
 
-  @attr() permissions;
   get collaborators() {
     const permissions = this.permissions;
     if (Array.isArray(permissions)) {
-      return permissions.mapBy('user');
+      return permissions.map((p) => p.user).filter((id) => id);
     }
-    return permissions;
+    return [];
   }
 
   get feedbackAuthorizers() {
     const permissions = this.permissions;
     if (Array.isArray(permissions)) {
-      return permissions.filterBy('feedback', 'approver').mapBy('user');
+      return permissions
+        .filter((p) => p.feedback === 'approver')
+        .map((p) => p.user)
+        .filter((id) => id);
     }
     return [];
   }

--- a/app/routes/workspace/info.js
+++ b/app/routes/workspace/info.js
@@ -12,10 +12,17 @@ export default class WorkspaceInfoRoute extends Route {
   async model() {
     let workspace = this.modelFor('workspace');
     let originalCollaborators = [];
-    if (workspace.get('collaborators.length')) {
-      originalCollaborators = await this.store.query('user', {
-        ids: workspace.collaborators,
-      });
+
+    // Safely access permissions to get user IDs
+    const permissions = workspace.get('permissions');
+    if (Array.isArray(permissions) && permissions.length > 0) {
+      // Extract only user IDs (plain values, not objects)
+      const userIds = permissions.map((p) => p.user).filter((id) => id);
+      if (userIds.length > 0) {
+        originalCollaborators = await this.store.query('user', {
+          ids: userIds,
+        });
+      }
     }
     return hash({
       workspace,

--- a/app/services/workspace-permissions.js
+++ b/app/services/workspace-permissions.js
@@ -125,7 +125,7 @@ export default class WorkspacePermissionsService extends Service {
       return false;
     }
 
-    const userPermissions = wsPermissions.findBy('user', this.user.id);
+    const userPermissions = wsPermissions.find((p) => p.user === this.user.id);
     if (!utils.isNonEmptyObject(userPermissions)) {
       return false;
     }

--- a/app/transforms/permissions.js
+++ b/app/transforms/permissions.js
@@ -1,0 +1,82 @@
+import Transform from '@ember-data/serializer/transform';
+
+/**
+ * PermissionsTransform
+ *
+ * Defines the structure and serialization logic for the workspace permissions attribute.
+ * Permissions is an array of permission objects, each defining a user's access level
+ * and specific permissions for folders, selections, comments, and feedback.
+ *
+ * This transform ensures that:
+ * 1. Permissions are always returned/stored as plain JavaScript objects (no Ember wrappers)
+ * 2. The structure is consistent and validated
+ * 3. Circular references from Ember tracking are prevented at the source
+ */
+export default class PermissionsTransform extends Transform {
+  /**
+   * Deserialize incoming data from the API into our internal format.
+   * The API should return an array of permission objects.
+   */
+  deserialize(serialized) {
+    if (!Array.isArray(serialized)) {
+      return [];
+    }
+
+    // Return plain array of plain objects with only the data we need
+    return serialized.map((p) => this._cleanPermission(p));
+  }
+
+  /**
+   * Serialize outgoing data to send to the API.
+   * Ensures we're sending only plain objects without Ember internals.
+   */
+  serialize(deserialized) {
+    if (!Array.isArray(deserialized)) {
+      return [];
+    }
+
+    // Return plain array of plain objects
+    return deserialized.map((p) => this._cleanPermission(p));
+  }
+
+  /**
+   * Extract only the properties we care about from a permission object.
+   * This removes any Ember tracking wrappers, observers, or circular references.
+   */
+  _cleanPermission(p) {
+    if (!p || typeof p !== 'object') {
+      return null;
+    }
+
+    return {
+      user: p.user,
+      global: p.global,
+      selections: p.selections,
+      comments: p.comments,
+      folders: p.folders,
+      feedback: p.feedback,
+      submissions: this._cleanSubmissions(p.submissions),
+    };
+  }
+
+  /**
+   * Clean the submissions sub-object which contains both flags and an array of IDs.
+   */
+  _cleanSubmissions(submissions) {
+    if (!submissions || typeof submissions !== 'object') {
+      return {
+        all: false,
+        userOnly: false,
+        submissionIds: [],
+      };
+    }
+
+    return {
+      all: Boolean(submissions.all),
+      userOnly: Boolean(submissions.userOnly),
+      submissionIds: Array.isArray(submissions.submissionIds)
+        ? [...submissions.submissionIds]
+        : [],
+    };
+  }
+}

--- a/tests/integration/components/workspace-info-collaborators-test.js
+++ b/tests/integration/components/workspace-info-collaborators-test.js
@@ -1,0 +1,390 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click, fillIn, findAll } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import Service from '@ember/service';
+
+module(
+  'Integration | Component | workspace-info-collaborators',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+      const store = this.owner.lookup('service:store');
+
+      // Mock services
+      class UtilityMethodsService extends Service {
+        isNonEmptyObject(obj) {
+          return obj && typeof obj === 'object' && Object.keys(obj).length > 0;
+        }
+        isNonEmptyArray(arr) {
+          return Array.isArray(arr) && arr.length > 0;
+        }
+      }
+
+      class CurrentUserService extends Service {
+        user = { id: 'current-user', username: 'currentuser', isAdmin: false };
+      }
+
+      class SweetAlertService extends Service {
+        showToast() {
+          return Promise.resolve();
+        }
+        showModal() {
+          return Promise.resolve({ value: true });
+        }
+      }
+
+      class WorkspacePermissionsService extends Service {
+        canEdit() {
+          return true;
+        }
+      }
+
+      this.owner.register('service:utility-methods', UtilityMethodsService);
+      this.owner.register('service:current-user', CurrentUserService);
+      this.owner.register('service:sweet-alert', SweetAlertService);
+      this.owner.register(
+        'service:workspace-permissions',
+        WorkspacePermissionsService
+      );
+
+      // Create test users
+      const user1 = store.createRecord('user', {
+        id: 'user-1',
+        username: 'testuser1',
+      });
+
+      const user2 = store.createRecord('user', {
+        id: 'user-2',
+        username: 'testuser2',
+      });
+
+      // Create workspace with permissions
+      const workspace = store.createRecord('workspace', {
+        id: 'ws-1',
+        name: 'Test Workspace',
+        workspaceType: 'individual',
+        permissions: [
+          {
+            user: 'user-1',
+            global: 'editor',
+            selections: 4,
+            comments: 4,
+            folders: 3,
+            feedback: 'none',
+            submissions: { all: true, userOnly: false, submissionIds: [] },
+          },
+          {
+            user: 'user-2',
+            global: 'viewOnly',
+            selections: 1,
+            comments: 1,
+            folders: 1,
+            feedback: 'none',
+            submissions: { all: true, userOnly: false, submissionIds: [] },
+          },
+        ],
+      });
+
+      this.set('workspace', workspace);
+      this.set('originalCollaborators', [user1, user2]);
+      this.set('canEdit', true);
+      this.set('selectedCollaborators', { 'user-1': true, 'user-2': true });
+      this.set('initialCollabOptions', [user1, user2]);
+      this.set('customSubmissionIds', []);
+      this.set('isShowingCustomViewer', false);
+      this.set('toggleIsShowingCustomViewer', () => {
+        this.set('isShowingCustomViewer', !this.isShowingCustomViewer);
+      });
+    });
+
+    test('it renders collaborators list', async function (assert) {
+      await render(hbs`
+        <WorkspaceInfoCollaborators
+          @workspace={{this.workspace}}
+          @originalCollaborators={{this.originalCollaborators}}
+          @canEdit={{this.canEdit}}
+          @selectedCollaborators={{this.selectedCollaborators}}
+          @initialCollabOptions={{this.initialCollabOptions}}
+          @customSubmissionIds={{this.customSubmissionIds}}
+          @isShowingCustomViewer={{this.isShowingCustomViewer}}
+          @toggleIsShowingCustomViewer={{this.toggleIsShowingCustomViewer}}
+        />
+      `);
+
+      assert
+        .dom('.collab-container')
+        .exists({ count: 2 }, 'Shows 2 collaborators');
+      const collabNames = this.element.textContent;
+      assert.ok(collabNames.includes('testuser1'), 'Shows first user');
+      assert.ok(collabNames.includes('testuser2'), 'Shows second user');
+    });
+
+    test('clicking edit opens edit mode for collaborator', async function (assert) {
+      await render(hbs`
+        <WorkspaceInfoCollaborators
+          @workspace={{this.workspace}}
+          @originalCollaborators={{this.originalCollaborators}}
+          @canEdit={{this.canEdit}}
+          @selectedCollaborators={{this.selectedCollaborators}}
+          @initialCollabOptions={{this.initialCollabOptions}}
+          @customSubmissionIds={{this.customSubmissionIds}}
+          @isShowingCustomViewer={{this.isShowingCustomViewer}}
+          @toggleIsShowingCustomViewer={{this.toggleIsShowingCustomViewer}}
+        />
+      `);
+
+      // Initially no radio groups visible
+      assert
+        .dom('.radio-group')
+        .doesNotExist('No radio group visible before edit');
+
+      // Click edit on first collaborator
+      const editIcons = findAll('.fa-edit');
+      assert.ok(editIcons.length >= 2, 'Has edit icons for collaborators');
+
+      await click(editIcons[0]);
+
+      // Edit mode should show radio group for global permissions
+      assert
+        .dom('.radio-group')
+        .exists('Radio group appears after clicking edit');
+
+      // Should show cancel button in edit mode
+      assert.dom('.cancel-button').exists('Cancel button appears in edit mode');
+    });
+
+    test('editing collaborator shows correct permission value in radio group', async function (assert) {
+      await render(hbs`
+        <WorkspaceInfoCollaborators
+          @workspace={{this.workspace}}
+          @originalCollaborators={{this.originalCollaborators}}
+          @canEdit={{this.canEdit}}
+          @selectedCollaborators={{this.selectedCollaborators}}
+          @initialCollabOptions={{this.initialCollabOptions}}
+          @customSubmissionIds={{this.customSubmissionIds}}
+          @isShowingCustomViewer={{this.isShowingCustomViewer}}
+          @toggleIsShowingCustomViewer={{this.toggleIsShowingCustomViewer}}
+        />
+      `);
+
+      // Click edit on first collaborator (editor permission)
+      const editIcons = findAll('.fa-edit');
+      await click(editIcons[0]);
+
+      // The radio group should be populated with the current permission value
+      assert
+        .dom('.radio-group')
+        .exists('Radio group is rendered with permission data');
+    });
+
+    test('clicking cancel exits edit mode', async function (assert) {
+      await render(hbs`
+        <WorkspaceInfoCollaborators
+          @workspace={{this.workspace}}
+          @originalCollaborators={{this.originalCollaborators}}
+          @canEdit={{this.canEdit}}
+          @selectedCollaborators={{this.selectedCollaborators}}
+          @initialCollabOptions={{this.initialCollabOptions}}
+          @customSubmissionIds={{this.customSubmissionIds}}
+          @isShowingCustomViewer={{this.isShowingCustomViewer}}
+          @toggleIsShowingCustomViewer={{this.toggleIsShowingCustomViewer}}
+        />
+      `);
+
+      // Enter edit mode
+      const editIcons = findAll('.fa-edit');
+      await click(editIcons[0]);
+      assert.dom('.radio-group').exists('Edit mode is active');
+
+      // Click cancel
+      await click('.cancel-button');
+
+      // Edit mode should close
+      assert.dom('.radio-group').doesNotExist('Edit mode closed after cancel');
+    });
+
+    test('clicking add collaborator opens new collaborator form', async function (assert) {
+      await render(hbs`
+        <WorkspaceInfoCollaborators
+          @workspace={{this.workspace}}
+          @originalCollaborators={{this.originalCollaborators}}
+          @canEdit={{this.canEdit}}
+          @selectedCollaborators={{this.selectedCollaborators}}
+          @initialCollabOptions={{this.initialCollabOptions}}
+          @customSubmissionIds={{this.customSubmissionIds}}
+          @isShowingCustomViewer={{this.isShowingCustomViewer}}
+          @toggleIsShowingCustomViewer={{this.toggleIsShowingCustomViewer}}
+        />
+      `);
+
+      // Click the add collaborator button
+      await click('.heading-icon');
+
+      // Should render the WorkspaceInfoCollaboratorsNew component
+      // (This will render when createNewCollaborator is true)
+      assert.ok(true, 'Add collaborator action triggered');
+    });
+
+    test('workspacePermissions getter adds userObj to permissions', async function (assert) {
+      await render(hbs`
+        <WorkspaceInfoCollaborators
+          @workspace={{this.workspace}}
+          @originalCollaborators={{this.originalCollaborators}}
+          @canEdit={{this.canEdit}}
+          @selectedCollaborators={{this.selectedCollaborators}}
+          @initialCollabOptions={{this.initialCollabOptions}}
+          @customSubmissionIds={{this.customSubmissionIds}}
+          @isShowingCustomViewer={{this.isShowingCustomViewer}}
+          @toggleIsShowingCustomViewer={{this.toggleIsShowingCustomViewer}}
+        />
+      `);
+
+      // Both collaborators should render with their usernames
+      const collabNames = this.element.querySelectorAll('.collab-name a');
+      assert.strictEqual(
+        collabNames.length,
+        2,
+        'Both collaborators have user links'
+      );
+
+      // The userObj should be accessible for rendering username
+      const textContent = this.element.textContent;
+      assert.ok(textContent.includes('testuser1'), 'Shows testuser1');
+      assert.ok(textContent.includes('testuser2'), 'Shows testuser2');
+    });
+
+    test('edit mode correctly sets globalPermissionValue without undefined errors', async function (assert) {
+      await render(hbs`
+        <WorkspaceInfoCollaborators
+          @workspace={{this.workspace}}
+          @originalCollaborators={{this.originalCollaborators}}
+          @canEdit={{this.canEdit}}
+          @selectedCollaborators={{this.selectedCollaborators}}
+          @initialCollabOptions={{this.initialCollabOptions}}
+          @customSubmissionIds={{this.customSubmissionIds}}
+          @isShowingCustomViewer={{this.isShowingCustomViewer}}
+          @toggleIsShowingCustomViewer={{this.toggleIsShowingCustomViewer}}
+        />
+      `);
+
+      // Click edit on first collaborator (has 'editor' permission)
+      const editIcons = findAll('.fa-edit');
+      await click(editIcons[0]);
+
+      // Should not throw "Cannot read properties of undefined (reading 'get')" error
+      // The radio group should render without errors
+      assert
+        .dom('.radio-group')
+        .exists('Radio group renders without undefined errors');
+
+      // Click edit on second collaborator (has 'viewOnly' permission)
+      await click('.cancel-button');
+      const editIcons2 = findAll('.fa-edit');
+      await click(editIcons2[1]);
+
+      assert
+        .dom('.radio-group')
+        .exists('Second edit also works without errors');
+    });
+
+    test('removes collaborator when clicking minus icon', async function (assert) {
+      // Mock the workspace save to prevent actual API call
+      this.workspace.save = function () {
+        return Promise.resolve();
+      };
+
+      await render(hbs`
+        <WorkspaceInfoCollaborators
+          @workspace={{this.workspace}}
+          @originalCollaborators={{this.originalCollaborators}}
+          @canEdit={{this.canEdit}}
+          @selectedCollaborators={{this.selectedCollaborators}}
+          @initialCollabOptions={{this.initialCollabOptions}}
+          @customSubmissionIds={{this.customSubmissionIds}}
+          @isShowingCustomViewer={{this.isShowingCustomViewer}}
+          @toggleIsShowingCustomViewer={{this.toggleIsShowingCustomViewer}}
+        />
+      `);
+
+      const originalPermissionsCount = this.workspace.get('permissions').length;
+
+      // Enter edit mode to see minus icon
+      const editIcons = findAll('.fa-edit');
+      await click(editIcons[0]);
+
+      // In edit mode, minus icon should appear
+      const minusIcon = this.element.querySelector('.fa-minus-circle');
+      assert.ok(minusIcon, 'Minus icon appears in edit mode');
+
+      // Click the minus icon (triggers confirmation modal which auto-confirms in test)
+      await click(minusIcon);
+
+      // Verify permissions array was updated (after async save completes)
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const newPermissionsCount = this.workspace.get('permissions').length;
+      assert.strictEqual(
+        newPermissionsCount,
+        originalPermissionsCount - 1,
+        'Collaborator was removed from permissions'
+      );
+    });
+
+    test('permission object structure maintains immutability', async function (assert) {
+      await render(hbs`
+        <WorkspaceInfoCollaborators
+          @workspace={{this.workspace}}
+          @originalCollaborators={{this.originalCollaborators}}
+          @canEdit={{this.canEdit}}
+          @selectedCollaborators={{this.selectedCollaborators}}
+          @initialCollabOptions={{this.initialCollabOptions}}
+          @customSubmissionIds={{this.customSubmissionIds}}
+          @isShowingCustomViewer={{this.isShowingCustomViewer}}
+          @toggleIsShowingCustomViewer={{this.toggleIsShowingCustomViewer}}
+        />
+      `);
+
+      const workspace = this.workspace;
+      const originalPermissions = workspace.get('permissions');
+      const firstPermission = originalPermissions[0];
+
+      // Click edit on first collaborator
+      const editIcons = findAll('.fa-edit');
+      await click(editIcons[0]);
+
+      // Original permission object should not have been mutated
+      // (userObj should be added to a new object, not the original)
+      assert.strictEqual(
+        firstPermission.user,
+        'user-1',
+        'Original permission still has user ID'
+      );
+      assert.notOk(
+        firstPermission.userObj,
+        'Original permission object was not mutated with userObj'
+      );
+    });
+
+    test('displays correct permission labels for different permission types', async function (assert) {
+      await render(hbs`
+        <WorkspaceInfoCollaborators
+          @workspace={{this.workspace}}
+          @originalCollaborators={{this.originalCollaborators}}
+          @canEdit={{this.canEdit}}
+          @selectedCollaborators={{this.selectedCollaborators}}
+          @initialCollabOptions={{this.initialCollabOptions}}
+          @customSubmissionIds={{this.customSubmissionIds}}
+          @isShowingCustomViewer={{this.isShowingCustomViewer}}
+          @toggleIsShowingCustomViewer={{this.toggleIsShowingCustomViewer}}
+        />
+      `);
+
+      // Should display permission type labels (via collab-permissions helper)
+      assert
+        .dom('.collab-settings')
+        .exists({ count: 2 }, 'Shows settings for both collaborators');
+    });
+  }
+);

--- a/tests/integration/components/workspace-info-settings-test.js
+++ b/tests/integration/components/workspace-info-settings-test.js
@@ -1,0 +1,376 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click, waitFor, find, settled } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import Service from '@ember/service';
+
+module('Integration | Component | workspace-info-settings', function (hooks) {
+  setupRenderingTest(hooks);
+
+  // Helper to find button by text
+  function findButtonByText(text) {
+    const buttons = Array.from(document.querySelectorAll('button'));
+    return buttons.find((btn) => btn.textContent.trim() === text);
+  }
+
+  hooks.beforeEach(function () {
+    const store = this.owner.lookup('service:store');
+
+    // Mock all required services
+    class UtilityMethodsService extends Service {
+      isNonEmptyObject(obj) {
+        return obj && typeof obj === 'object' && Object.keys(obj).length > 0;
+      }
+      isNonEmptyArray(arr) {
+        return Array.isArray(arr) && arr.length > 0;
+      }
+      getBelongsToId(record, key) {
+        return record.get ? record.get(key)?.get('id') : null;
+      }
+    }
+
+    class CurrentUserService extends Service {
+      user = {
+        id: 'current-user',
+        username: 'currentuser',
+        isAdmin: true,
+        isStudent: false,
+      };
+    }
+
+    class SweetAlertService extends Service {
+      lastToast = null;
+      showToast(type, message) {
+        this.lastToast = { type, message };
+        return Promise.resolve();
+      }
+      showModal() {
+        return Promise.resolve({ value: true });
+      }
+    }
+
+    class WorkspacePermissionsService extends Service {
+      hasOwnerPrivileges() {
+        return true;
+      }
+      isOwner() {
+        return true;
+      }
+      canEdit() {
+        return true;
+      }
+    }
+
+    this.owner.register('service:utility-methods', UtilityMethodsService);
+    this.owner.register('service:current-user', CurrentUserService);
+    this.owner.register('service:sweet-alert', SweetAlertService);
+    this.owner.register(
+      'service:workspace-permissions',
+      WorkspacePermissionsService
+    );
+
+    // Create test data
+    const assignment = store.createRecord('assignment', {
+      id: 'assignment-1',
+      name: 'Test Assignment',
+    });
+
+    const workspace = store.createRecord('workspace', {
+      id: 'ws-1',
+      name: 'Test Workspace',
+      workspaceType: 'individual',
+      owner: store.createRecord('user', { id: 'owner-1', username: 'owner' }),
+      permissions: [],
+    });
+
+    this.set('workspace', workspace);
+    this.set('assignment', assignment);
+    this.set('linkedAssignment', assignment);
+    this.set('canEdit', true);
+    this.set('childWorkspaces', []);
+  });
+
+  test('BEFORE FIX: passing belongsTo proxy to server causes "Invalid workspace" error', async function (assert) {
+    const store = this.owner.lookup('service:store');
+
+    let capturedLinkedAssignmentType = null;
+
+    // Mock createRecord to capture what it receives
+    const originalCreateRecord = store.createRecord.bind(store);
+    store.createRecord = function (modelName, properties) {
+      if (modelName === 'updateWorkspaceRequest') {
+        const linkedAssignment = properties.linkedAssignment;
+        capturedLinkedAssignmentType =
+          linkedAssignment && linkedAssignment._belongsToState
+            ? 'proxy'
+            : 'record';
+
+        // Simulate server error when receiving proxy
+        return {
+          save() {
+            return Promise.resolve({
+              get(key) {
+                if (key === 'updateErrors')
+                  return ['Invalid workspace or assignment.'];
+                return null;
+              },
+              updateErrors: ['Invalid workspace or assignment.'],
+            });
+          },
+        };
+      }
+      return originalCreateRecord(modelName, properties);
+    };
+
+    // Create a belongsTo proxy to simulate the bug
+    const proxyLinkedAssignment = {
+      content: this.assignment,
+      _belongsToState: {},
+      isFulfilled: true,
+    };
+    this.set('linkedAssignment', proxyLinkedAssignment);
+
+    await render(hbs`
+      <WorkspaceInfoSettings
+        @workspace={{this.workspace}}
+        @linkedAssignment={{this.linkedAssignment}}
+        @canEdit={{this.canEdit}}
+        @childWorkspaces={{this.childWorkspaces}}
+      />
+    `);
+
+    const updateButton = findButtonByText('Update Workspace');
+    await click(updateButton);
+    await waitFor('.update-results', { timeout: 2000 });
+
+    // Without the fix, a proxy would be passed
+    assert.strictEqual(
+      capturedLinkedAssignmentType,
+      'record',
+      'AFTER FIX: Should extract actual record from proxy, not pass proxy itself'
+    );
+
+    // Error should be visible in UI now that we added @tracked
+    assert.dom('.update-results').exists('Error results section is visible');
+  });
+
+  test('AFTER FIX: extracts actual record from belongsTo proxy', async function (assert) {
+    const store = this.owner.lookup('service:store');
+    let capturedLinkedAssignmentId = null;
+
+    store.createRecord = function (modelName, properties) {
+      if (modelName === 'updateWorkspaceRequest') {
+        capturedLinkedAssignmentId = properties.linkedAssignment?.id;
+        return {
+          save() {
+            return Promise.resolve({
+              get(key) {
+                if (key === 'wereNoAnswersToUpdate') return true;
+                return null;
+              },
+            });
+          },
+        };
+      }
+    };
+
+    await render(hbs`
+      <WorkspaceInfoSettings
+        @workspace={{this.workspace}}
+        @linkedAssignment={{this.linkedAssignment}}
+        @canEdit={{this.canEdit}}
+        @childWorkspaces={{this.childWorkspaces}}
+      />
+    `);
+
+    const updateButton = findButtonByText('Update Workspace');
+    await click(updateButton);
+
+    assert.strictEqual(
+      capturedLinkedAssignmentId,
+      'assignment-1',
+      'Extracted actual assignment record with correct ID'
+    );
+  });
+
+  test('displays error messages in UI when @tracked properties are set', async function (assert) {
+    const store = this.owner.lookup('service:store');
+
+    store.createRecord = function (modelName) {
+      if (modelName === 'updateWorkspaceRequest') {
+        return {
+          save() {
+            return Promise.resolve({
+              get(key) {
+                if (key === 'updateErrors')
+                  return ['Invalid workspace or assignment.'];
+                return null;
+              },
+              updateErrors: ['Invalid workspace or assignment.'],
+            });
+          },
+        };
+      }
+    };
+
+    await render(hbs`
+      <WorkspaceInfoSettings
+        @workspace={{this.workspace}}
+        @linkedAssignment={{this.linkedAssignment}}
+        @canEdit={{this.canEdit}}
+        @childWorkspaces={{this.childWorkspaces}}
+      />
+    `);
+
+    const updateButton = findButtonByText('Update Workspace');
+    await click(updateButton);
+    await waitFor('.update-results', { timeout: 2000 });
+
+    assert
+      .dom('.update-results')
+      .containsText(
+        'Invalid workspace',
+        'Error message appears in UI (requires @tracked)'
+      );
+  });
+
+  test('shows success toast when submissions are added', async function (assert) {
+    const store = this.owner.lookup('service:store');
+    const sweetAlert = this.owner.lookup('service:sweet-alert');
+
+    store.createRecord = function (modelName) {
+      if (modelName === 'updateWorkspaceRequest') {
+        return {
+          save() {
+            return Promise.resolve({
+              get(key) {
+                if (key === 'wereNoAnswersToUpdate') return false;
+                if (key === 'updateErrors') return null;
+                return null;
+              },
+              addedSubmissions: [{ id: 'sub-1' }, { id: 'sub-2' }],
+            });
+          },
+        };
+      }
+    };
+
+    await render(hbs`
+      <WorkspaceInfoSettings
+        @workspace={{this.workspace}}
+        @linkedAssignment={{this.linkedAssignment}}
+        @canEdit={{this.canEdit}}
+        @childWorkspaces={{this.childWorkspaces}}
+      />
+    `);
+
+    const updateButton = findButtonByText('Update Workspace');
+    await click(updateButton);
+
+    // Check toast was shown
+    assert.strictEqual(
+      sweetAlert.lastToast.type,
+      'success',
+      'Shows success toast'
+    );
+    assert.ok(
+      sweetAlert.lastToast.message.includes('2 new submissions'),
+      'Toast message mentions 2 submissions'
+    );
+  });
+
+  test('shows info toast when workspace is up to date', async function (assert) {
+    const store = this.owner.lookup('service:store');
+    const sweetAlert = this.owner.lookup('service:sweet-alert');
+
+    store.createRecord = function (modelName) {
+      if (modelName === 'updateWorkspaceRequest') {
+        return {
+          save() {
+            return Promise.resolve({
+              get(key) {
+                if (key === 'wereNoAnswersToUpdate') return true;
+                return null;
+              },
+            });
+          },
+        };
+      }
+    };
+
+    await render(hbs`
+      <WorkspaceInfoSettings
+        @workspace={{this.workspace}}
+        @linkedAssignment={{this.linkedAssignment}}
+        @canEdit={{this.canEdit}}
+        @childWorkspaces={{this.childWorkspaces}}
+      />
+    `);
+
+    const updateButton = findButtonByText('Update Workspace');
+    await click(updateButton);
+
+    assert.strictEqual(sweetAlert.lastToast.type, 'info', 'Shows info toast');
+    assert.strictEqual(
+      sweetAlert.lastToast.message,
+      'Workspace Up to Date',
+      'Toast says workspace is up to date'
+    );
+  });
+
+  test('handles Ember Data assertion error from embedded objects in response', async function (assert) {
+    const store = this.owner.lookup('service:store');
+    const sweetAlert = this.owner.lookup('service:sweet-alert');
+
+    // Track if workspace.reload() was called
+    let workspaceReloadCalled = false;
+    this.workspace.reload = function () {
+      workspaceReloadCalled = true;
+      return Promise.resolve(this);
+    };
+
+    store.createRecord = function (modelName) {
+      if (modelName === 'updateWorkspaceRequest') {
+        return {
+          save() {
+            // Simulate the Ember Data assertion error that occurs when
+            // server returns full user objects instead of relationship identifiers
+            const error = new Error(
+              "Assertion Failed: Encountered a relationship identifier without a type for the belongsTo relationship 'owner' on <workspace:123>, expected an identifier with type 'user' but found full object"
+            );
+            return Promise.reject(error);
+          },
+        };
+      }
+    };
+
+    await render(hbs`
+      <WorkspaceInfoSettings
+        @workspace={{this.workspace}}
+        @linkedAssignment={{this.linkedAssignment}}
+        @canEdit={{this.canEdit}}
+        @childWorkspaces={{this.childWorkspaces}}
+      />
+    `);
+
+    const updateButton = findButtonByText('Update Workspace');
+    await click(updateButton);
+
+    // Wait for all async operations (error catch, reload, toast)
+    await settled();
+
+    assert.ok(
+      workspaceReloadCalled,
+      'Workspace reload was called when embedded object error occurred'
+    );
+    assert.strictEqual(
+      sweetAlert.lastToast.type,
+      'success',
+      'Shows success toast despite serialization error'
+    );
+    assert.ok(
+      sweetAlert.lastToast.message.includes('updated'),
+      'Toast message indicates successful update'
+    );
+  });
+});

--- a/tests/integration/permissions-flow-test.js
+++ b/tests/integration/permissions-flow-test.js
@@ -1,0 +1,231 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+/**
+ * Integration tests for the complete permissions flow:
+ * Transform -> Model -> Service -> Component
+ *
+ * These tests verify that changing permissions through the transform,
+ * model getters, and service methods all work correctly together.
+ */
+module('Integration | Permissions Flow', function (hooks) {
+  setupTest(hooks);
+
+  test('permissions transform and model getters work together', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const transform = this.owner
+      .lookup('service:store')
+      ?.serializerFor?.('application')
+      ?._getOrCreateTransform?.('permissions');
+
+    // Simulate incoming API data with potentially problematic types
+    const apiData = [
+      {
+        user: 'user-1',
+        global: 'approver',
+        selections: 4,
+        comments: 4,
+        folders: 3,
+        feedback: 'approver',
+        submissions: { all: 1, userOnly: 0, submissionIds: ['sub-1'] }, // Truthy values
+        extraField: 'should be removed',
+      },
+      {
+        user: 'user-2',
+        global: 'viewOnly',
+        selections: 1,
+        comments: 1,
+        folders: 1,
+        feedback: 'none',
+        submissions: null,
+      },
+    ];
+
+    // Create workspace and set permissions as if from transform
+    const workspace = store.createRecord('workspace', {
+      permissions: apiData,
+    });
+
+    // Test collaborators getter
+    const collaborators = workspace.collaborators;
+    assert.deepEqual(collaborators, ['user-1', 'user-2']);
+
+    // Test feedbackAuthorizers getter
+    const authorizers = workspace.feedbackAuthorizers;
+    assert.deepEqual(authorizers, ['user-1']);
+
+    // Verify permissions were properly cleaned (if transform was applied)
+    if (transform) {
+      const cleaned = transform.deserialize(apiData);
+      assert.notOk(
+        cleaned[0].extraField,
+        'unwanted fields removed by transform'
+      );
+      assert.strictEqual(
+        cleaned[0].submissions.all,
+        true,
+        'truthy values normalized to boolean'
+      );
+      assert.strictEqual(
+        cleaned[0].submissions.userOnly,
+        false,
+        'falsy values normalized to boolean'
+      );
+    }
+  });
+
+  test('adding permission via spread operator maintains collaborators list', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const workspace = store.createRecord('workspace', {
+      permissions: [
+        { user: 'user-1', global: 'approver', feedback: 'approver' },
+        { user: 'user-2', global: 'viewOnly', feedback: 'none' },
+      ],
+    });
+
+    assert.deepEqual(workspace.collaborators, ['user-1', 'user-2']);
+
+    // Add new permission using spread operator (component pattern)
+    const newPermission = {
+      user: 'user-3',
+      global: 'editor',
+      feedback: 'approver',
+      selections: 1,
+      comments: 1,
+      folders: 1,
+      submissions: { all: false, userOnly: false, submissionIds: [] },
+    };
+
+    const newPermissions = [...workspace.permissions, newPermission];
+    workspace.set('permissions', newPermissions);
+
+    assert.deepEqual(workspace.collaborators, ['user-1', 'user-2', 'user-3']);
+    assert.deepEqual(workspace.feedbackAuthorizers, ['user-1', 'user-3']);
+  });
+
+  test('removing permission via filter maintains consistent lists', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const workspace = store.createRecord('workspace', {
+      permissions: [
+        { user: 'user-1', global: 'approver', feedback: 'approver' },
+        { user: 'user-2', global: 'viewOnly', feedback: 'none' },
+        { user: 'user-3', global: 'editor', feedback: 'approver' },
+      ],
+    });
+
+    assert.deepEqual(workspace.collaborators, ['user-1', 'user-2', 'user-3']);
+    assert.deepEqual(workspace.feedbackAuthorizers, ['user-1', 'user-3']);
+
+    // Remove permission using filter (component pattern)
+    const userToRemove = workspace.permissions[1]; // user-2
+    const newPermissions = workspace.permissions.filter(
+      (p) => p !== userToRemove
+    );
+    workspace.set('permissions', newPermissions);
+
+    assert.deepEqual(workspace.collaborators, ['user-1', 'user-3']);
+    assert.deepEqual(workspace.feedbackAuthorizers, ['user-1', 'user-3']);
+  });
+
+  test('updating permission in place via spread maintains lists', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const workspace = store.createRecord('workspace', {
+      permissions: [
+        { user: 'user-1', global: 'approver', feedback: 'none' },
+        { user: 'user-2', global: 'viewOnly', feedback: 'none' },
+        { user: 'user-3', global: 'editor', feedback: 'approver' },
+      ],
+    });
+
+    assert.deepEqual(workspace.feedbackAuthorizers, ['user-3']);
+
+    // Update user-1 to have approver feedback using immutable pattern
+    const updatedPermissions = workspace.permissions.map((p) =>
+      p.user === 'user-1' ? { ...p, feedback: 'approver' } : p
+    );
+    workspace.set('permissions', updatedPermissions);
+
+    assert.deepEqual(workspace.collaborators, ['user-1', 'user-2', 'user-3']);
+    assert.deepEqual(workspace.feedbackAuthorizers, ['user-1', 'user-3']);
+  });
+
+  test('empty permissions array handled gracefully', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const workspace = store.createRecord('workspace', {
+      permissions: [],
+    });
+
+    assert.deepEqual(workspace.collaborators, []);
+    assert.deepEqual(workspace.feedbackAuthorizers, []);
+
+    // Workspace permissions service should handle empty arrays
+    const permissionService = this.owner.lookup(
+      'service:workspace-permissions'
+    );
+    const currentUserService = this.owner.lookup('service:current-user');
+    currentUserService.user = { id: 'user-1', isAdmin: false };
+
+    const result = permissionService.isFeedbackApprover(workspace);
+    assert.false(result);
+  });
+
+  test('permissions with complex submissions object maintained through updates', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const workspace = store.createRecord('workspace', {
+      permissions: [
+        {
+          user: 'user-1',
+          global: 'approver',
+          feedback: 'approver',
+          selections: 4,
+          comments: 4,
+          folders: 3,
+          submissions: {
+            all: false,
+            userOnly: true,
+            submissionIds: ['sub-1', 'sub-2', 'sub-3'],
+          },
+        },
+      ],
+    });
+
+    // Verify structure is maintained
+    const perm = workspace.permissions[0];
+    assert.equal(perm.user, 'user-1');
+    assert.equal(perm.feedback, 'approver');
+    assert.false(perm.submissions.all);
+    assert.true(perm.submissions.userOnly);
+    assert.deepEqual(perm.submissions.submissionIds, [
+      'sub-1',
+      'sub-2',
+      'sub-3',
+    ]);
+
+    // Add another permission while maintaining submissions
+    const newPerm = {
+      user: 'user-2',
+      global: 'viewOnly',
+      feedback: 'none',
+      selections: 1,
+      comments: 1,
+      folders: 1,
+      submissions: {
+        all: true,
+        userOnly: false,
+        submissionIds: [],
+      },
+    };
+
+    const newPermissions = [...workspace.permissions, newPerm];
+    workspace.set('permissions', newPermissions);
+
+    // Verify both permissions exist and are intact
+    assert.equal(workspace.permissions.length, 2);
+    assert.deepEqual(workspace.permissions[0].submissions.submissionIds, [
+      'sub-1',
+      'sub-2',
+      'sub-3',
+    ]);
+    assert.deepEqual(workspace.permissions[1].submissions.submissionIds, []);
+  });
+});

--- a/tests/integration/real-world-collaborators-test.js
+++ b/tests/integration/real-world-collaborators-test.js
@@ -1,0 +1,535 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import Service from '@ember/service';
+
+/**
+ * Integration tests for workspace collaborators in real component/service/model scenarios
+ *
+ * Verifies that:
+ * 1. Adding collaborators works end-to-end
+ * 2. Removing collaborators works end-to-end
+ * 3. Editing collaborators maintains data integrity
+ * 4. Service methods work with modified permissions
+ * 5. Model getters compute correctly after changes
+ * 6. Routes can load and work with permissions
+ */
+module('Integration | Real-World Collaborators Workflows', function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    // Register a mock current-user service
+    const currentUserService = this.owner.lookup('service:current-user');
+    if (!currentUserService) {
+      class CurrentUserStub extends Service {
+        user = { id: 'admin-user', isAdmin: false, isPdAdmin: false };
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+    }
+  });
+
+  test('complete workflow: add collaborator → verify list → remove collaborator', function (assert) {
+    const store = this.owner.lookup('service:store');
+
+    // Create a workspace with initial collaborator
+    const workspace = store.createRecord('workspace', {
+      id: 'ws-1',
+      name: 'Test Workspace',
+      permissions: [
+        {
+          user: 'user-1',
+          global: 'owner',
+          selections: 4,
+          comments: 4,
+          folders: 3,
+          feedback: 'approver',
+          submissions: { all: true, userOnly: false, submissionIds: [] },
+        },
+      ],
+    });
+
+    // Initial state: 1 collaborator
+    assert.equal(workspace.collaborators.length, 1);
+    assert.equal(workspace.collaborators[0], 'user-1');
+
+    // Add a new collaborator
+    const newPermission = {
+      user: 'user-2',
+      global: 'editor',
+      selections: 4,
+      comments: 4,
+      folders: 3,
+      feedback: 'none',
+      submissions: { all: true, userOnly: false, submissionIds: [] },
+    };
+    const newPermissions = [...workspace.permissions, newPermission];
+    workspace.set('permissions', newPermissions);
+
+    // Verify new collaborator was added
+    assert.equal(workspace.collaborators.length, 2);
+    assert.deepEqual(workspace.collaborators, ['user-1', 'user-2']);
+
+    // Remove the first collaborator
+    const userToRemove = workspace.permissions[0];
+    const updatedPermissions = workspace.permissions.filter(
+      (p) => p !== userToRemove
+    );
+    workspace.set('permissions', updatedPermissions);
+
+    // Verify collaborator was removed
+    assert.equal(workspace.collaborators.length, 1);
+    assert.equal(workspace.collaborators[0], 'user-2');
+  });
+
+  test('adding collaborator with custom submissions permissions', function (assert) {
+    const store = this.owner.lookup('service:store');
+
+    const workspace = store.createRecord('workspace', {
+      id: 'ws-1',
+      permissions: [],
+    });
+
+    assert.equal(workspace.collaborators.length, 0);
+
+    const newPermission = {
+      user: 'user-1',
+      global: 'custom',
+      selections: 2,
+      comments: 2,
+      folders: 1,
+      feedback: 'none',
+      submissions: {
+        all: false,
+        userOnly: true,
+        submissionIds: ['sub-1', 'sub-2', 'sub-3'],
+      },
+    };
+
+    workspace.set('permissions', [newPermission]);
+
+    assert.equal(workspace.collaborators.length, 1);
+    const perms = workspace.permissions[0];
+    assert.false(perms.submissions.all);
+    assert.true(perms.submissions.userOnly);
+    assert.deepEqual(perms.submissions.submissionIds, [
+      'sub-1',
+      'sub-2',
+      'sub-3',
+    ]);
+  });
+
+  test('feedback authorizers correctly identified after permission changes', function (assert) {
+    const store = this.owner.lookup('service:store');
+
+    const workspace = store.createRecord('workspace', {
+      id: 'ws-1',
+      permissions: [
+        {
+          user: 'user-1',
+          global: 'editor',
+          feedback: 'none',
+          selections: 4,
+          comments: 4,
+          folders: 3,
+          submissions: { all: true },
+        },
+        {
+          user: 'user-2',
+          global: 'approver',
+          feedback: 'approver',
+          selections: 4,
+          comments: 4,
+          folders: 3,
+          submissions: { all: true },
+        },
+      ],
+    });
+
+    // Initial: only user-2 is feedback approver
+    assert.deepEqual(workspace.feedbackAuthorizers, ['user-2']);
+
+    // Update user-1 to be feedback approver
+    const updatedPerms = workspace.permissions.map((p) =>
+      p.user === 'user-1' ? { ...p, feedback: 'approver' } : p
+    );
+    workspace.set('permissions', updatedPerms);
+
+    // Now both should be feedback authorizers
+    assert.deepEqual(workspace.feedbackAuthorizers.sort(), [
+      'user-1',
+      'user-2',
+    ]);
+  });
+
+  test('workspace-permissions service canEdit method with permission updates', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const currentUserService = this.owner.lookup('service:current-user');
+    currentUserService.user = {
+      id: 'editor-user',
+      isAdmin: false,
+      isPdAdmin: false,
+    };
+
+    const workspace = store.createRecord('workspace', {
+      id: 'ws-1',
+      workspaceType: 'student',
+      permissions: [
+        {
+          user: 'editor-user',
+          global: 'editor',
+          selections: 4,
+          comments: 4,
+          folders: 3,
+          feedback: 'none',
+          submissions: { all: true },
+        },
+      ],
+    });
+
+    const permissionService = this.owner.lookup(
+      'service:workspace-permissions'
+    );
+
+    // Initially can edit
+    assert.true(permissionService.canEdit(workspace, 'selections', 4));
+
+    // Downgrade to viewOnly
+    const downgradedPerms = workspace.permissions.map((p) =>
+      p.user === 'editor-user' ? { ...p, global: 'viewOnly' } : p
+    );
+    workspace.set('permissions', downgradedPerms);
+
+    // Now cannot edit
+    assert.false(permissionService.canEdit(workspace, 'selections', 1));
+  });
+
+  test('permissions survive add-edit-edit-remove cycle', function (assert) {
+    const store = this.owner.lookup('service:store');
+
+    const workspace = store.createRecord('workspace', {
+      id: 'ws-1',
+      permissions: [
+        {
+          user: 'user-1',
+          global: 'owner',
+          selections: 4,
+          comments: 4,
+          folders: 3,
+          feedback: 'approver',
+          submissions: { all: true, userOnly: false, submissionIds: [] },
+        },
+      ],
+    });
+
+    // Add user-2
+    let perms = [
+      ...workspace.permissions,
+      {
+        user: 'user-2',
+        global: 'editor',
+        selections: 4,
+        comments: 4,
+        folders: 3,
+        feedback: 'none',
+        submissions: { all: true, userOnly: false, submissionIds: [] },
+      },
+    ];
+    workspace.set('permissions', perms);
+    assert.equal(workspace.collaborators.length, 2);
+
+    // Edit user-2 to have custom selections
+    perms = workspace.permissions.map((p) =>
+      p.user === 'user-2' ? { ...p, global: 'custom', selections: 2 } : p
+    );
+    workspace.set('permissions', perms);
+    assert.equal(workspace.permissions[1].selections, 2);
+    assert.equal(workspace.collaborators.length, 2);
+
+    // Edit user-1 to have different feedback
+    perms = workspace.permissions.map((p) =>
+      p.user === 'user-1' ? { ...p, feedback: 'none' } : p
+    );
+    workspace.set('permissions', perms);
+    assert.deepEqual(workspace.feedbackAuthorizers, []);
+
+    // Remove user-2
+    perms = workspace.permissions.filter((p) => p.user !== 'user-2');
+    workspace.set('permissions', perms);
+    assert.equal(workspace.collaborators.length, 1);
+    assert.equal(workspace.collaborators[0], 'user-1');
+  });
+
+  test('multiple collaborators with mixed submission permissions', function (assert) {
+    const store = this.owner.lookup('service:store');
+
+    const workspace = store.createRecord('workspace', {
+      id: 'ws-1',
+      permissions: [
+        {
+          user: 'user-1',
+          global: 'approver',
+          selections: 4,
+          comments: 4,
+          folders: 3,
+          feedback: 'approver',
+          submissions: { all: true, userOnly: false, submissionIds: [] },
+        },
+        {
+          user: 'user-2',
+          global: 'custom',
+          selections: 2,
+          comments: 2,
+          folders: 1,
+          feedback: 'none',
+          submissions: {
+            all: false,
+            userOnly: true,
+            submissionIds: ['sub-1', 'sub-2'],
+          },
+        },
+        {
+          user: 'user-3',
+          global: 'custom',
+          selections: 1,
+          comments: 1,
+          folders: 1,
+          feedback: 'none',
+          submissions: {
+            all: false,
+            userOnly: false,
+            submissionIds: ['sub-3', 'sub-4', 'sub-5'],
+          },
+        },
+      ],
+    });
+
+    // Verify all collaborators
+    assert.deepEqual(workspace.collaborators.sort(), [
+      'user-1',
+      'user-2',
+      'user-3',
+    ]);
+
+    // Verify only one feedback approver
+    assert.deepEqual(workspace.feedbackAuthorizers, ['user-1']);
+
+    // Verify submissions configuration per user
+    assert.true(workspace.permissions[0].submissions.all);
+    assert.true(workspace.permissions[1].submissions.userOnly);
+    assert.equal(workspace.permissions[2].submissions.submissionIds.length, 3);
+
+    // Update user-3 to have custom submissions
+    const updated = workspace.permissions.map((p) =>
+      p.user === 'user-3'
+        ? {
+            ...p,
+            submissions: { all: true, userOnly: false, submissionIds: [] },
+          }
+        : p
+    );
+    workspace.set('permissions', updated);
+
+    assert.true(workspace.permissions[2].submissions.all);
+  });
+
+  test('service isFeedbackApprover with dynamic permission updates', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const currentUserService = this.owner.lookup('service:current-user');
+    const permissionService = this.owner.lookup(
+      'service:workspace-permissions'
+    );
+
+    currentUserService.user = { id: 'mentor-user', isAdmin: false };
+
+    const workspace = store.createRecord('workspace', {
+      id: 'ws-1',
+      permissions: [
+        {
+          user: 'mentor-user',
+          global: 'custom',
+          feedback: 'none',
+          selections: 4,
+          comments: 4,
+          folders: 3,
+          submissions: { all: true },
+        },
+      ],
+    });
+
+    // Initially not an approver
+    assert.false(permissionService.isFeedbackApprover(workspace));
+
+    // Promote to approver
+    workspace.set('permissions', [
+      {
+        user: 'mentor-user',
+        global: 'custom',
+        feedback: 'approver',
+        selections: 4,
+        comments: 4,
+        folders: 3,
+        submissions: { all: true },
+      },
+    ]);
+
+    // Now should be approver
+    assert.true(permissionService.isFeedbackApprover(workspace));
+  });
+
+  test('large collaborator lists maintain data integrity', function (assert) {
+    const store = this.owner.lookup('service:store');
+
+    const permissions = [];
+    for (let i = 1; i <= 50; i++) {
+      permissions.push({
+        user: `user-${i}`,
+        global: i % 5 === 0 ? 'approver' : 'editor',
+        selections: 4,
+        comments: 4,
+        folders: 3,
+        feedback: i % 5 === 0 ? 'approver' : 'none',
+        submissions: { all: true, userOnly: false, submissionIds: [] },
+      });
+    }
+
+    const workspace = store.createRecord('workspace', {
+      id: 'ws-1',
+      permissions,
+    });
+
+    // Verify all 50 collaborators
+    assert.equal(workspace.collaborators.length, 50);
+
+    // Verify approvers (every 5th user)
+    const approverCount = workspace.feedbackAuthorizers.length;
+    assert.equal(approverCount, 10); // 50 / 5 = 10
+
+    // Remove user-25 (should be an approver)
+    const updated = workspace.permissions.filter((p) => p.user !== 'user-25');
+    workspace.set('permissions', updated);
+
+    assert.equal(workspace.collaborators.length, 49);
+    assert.equal(workspace.feedbackAuthorizers.length, 9);
+
+    // Add a new approver
+    updated.push({
+      user: 'user-new-approver',
+      global: 'approver',
+      selections: 4,
+      comments: 4,
+      folders: 3,
+      feedback: 'approver',
+      submissions: { all: true, userOnly: false, submissionIds: [] },
+    });
+    workspace.set('permissions', updated);
+
+    assert.equal(workspace.collaborators.length, 50);
+    assert.equal(workspace.feedbackAuthorizers.length, 10);
+  });
+
+  test('permissions update propagates through service permission checks', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const currentUserService = this.owner.lookup('service:current-user');
+    const permissionService = this.owner.lookup(
+      'service:workspace-permissions'
+    );
+
+    currentUserService.user = {
+      id: 'test-user',
+      isAdmin: false,
+      isPdAdmin: false,
+    };
+
+    const workspace = store.createRecord('workspace', {
+      id: 'ws-1',
+      workspaceType: 'student',
+      permissions: [],
+    });
+
+    // No permissions initially
+    assert.false(permissionService.canEdit(workspace, 'selections', 1));
+    assert.false(permissionService.isFeedbackApprover(workspace));
+
+    // Add permissions for test-user
+    workspace.set('permissions', [
+      {
+        user: 'test-user',
+        global: 'custom',
+        selections: 4,
+        comments: 4,
+        folders: 3,
+        feedback: 'approver',
+        submissions: { all: true },
+      },
+    ]);
+
+    // Now should have permissions
+    assert.true(permissionService.canEdit(workspace, 'selections', 4));
+    assert.true(permissionService.isFeedbackApprover(workspace));
+
+    // Downgrade feedback permissions
+    workspace.set('permissions', [
+      {
+        user: 'test-user',
+        global: 'custom',
+        selections: 4,
+        comments: 4,
+        folders: 3,
+        feedback: 'none',
+        submissions: { all: true },
+      },
+    ]);
+
+    // Edit still works but not feedback approver
+    assert.true(permissionService.canEdit(workspace, 'selections', 4));
+    assert.false(permissionService.isFeedbackApprover(workspace));
+  });
+
+  test('permissions with null/missing submissions are handled correctly', function (assert) {
+    const store = this.owner.lookup('service:store');
+
+    const workspace = store.createRecord('workspace', {
+      id: 'ws-1',
+      permissions: [
+        {
+          user: 'user-1',
+          global: 'approver',
+          selections: 4,
+          comments: 4,
+          folders: 3,
+          feedback: 'approver',
+          submissions: null,
+        },
+        {
+          user: 'user-2',
+          global: 'editor',
+          selections: 4,
+          comments: 4,
+          folders: 3,
+          feedback: 'none',
+          // Missing submissions property entirely
+        },
+      ],
+    });
+
+    // Both collaborators should still be accessible
+    assert.equal(workspace.collaborators.length, 2);
+    assert.deepEqual(workspace.collaborators, ['user-1', 'user-2']);
+
+    // Operations should not fail
+    const updated = [
+      ...workspace.permissions,
+      {
+        user: 'user-3',
+        global: 'viewOnly',
+        selections: 1,
+        comments: 1,
+        folders: 1,
+        feedback: 'none',
+        submissions: { all: true },
+      },
+    ];
+    workspace.set('permissions', updated);
+
+    assert.equal(workspace.collaborators.length, 3);
+  });
+});

--- a/tests/integration/routes/workspace-info-route-test.js
+++ b/tests/integration/routes/workspace-info-route-test.js
@@ -1,0 +1,271 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { settled } from '@ember/test-helpers';
+
+/**
+ * Integration tests for workspace/info route loading and handling permissions
+ *
+ * Tests that the route:
+ * 1. Loads workspace with permissions correctly
+ * 2. Loads collaborators based on permissions array
+ * 3. Handles empty/null permissions gracefully
+ * 4. Passes correct data to controller/template
+ */
+module('Integration | Route | workspace/info', function (hooks) {
+  setupTest(hooks);
+
+  test('route loads workspace and extracts collaborator IDs from permissions', async function (assert) {
+    const store = this.owner.lookup('service:store');
+
+    // Create a workspace with permissions
+    const workspace = store.createRecord('workspace', {
+      id: 'ws-1',
+      name: 'Test Workspace',
+      permissions: [
+        {
+          user: 'user-1',
+          global: 'approver',
+          feedback: 'approver',
+          selections: 4,
+          comments: 4,
+          folders: 3,
+          submissions: { all: true },
+        },
+        {
+          user: 'user-2',
+          global: 'editor',
+          feedback: 'none',
+          selections: 4,
+          comments: 4,
+          folders: 3,
+          submissions: { all: true },
+        },
+      ],
+    });
+
+    // Create user records
+    const user1 = store.createRecord('user', {
+      id: 'user-1',
+      username: 'collaborator1',
+    });
+    const user2 = store.createRecord('user', {
+      id: 'user-2',
+      username: 'collaborator2',
+    });
+
+    // Verify permissions extraction
+    const permissions = workspace.get('permissions');
+    assert.ok(Array.isArray(permissions), 'permissions is an array');
+    assert.equal(permissions.length, 2, 'has 2 permission objects');
+
+    const userIds = permissions.map((p) => p.user).filter((id) => id);
+    assert.deepEqual(
+      userIds,
+      ['user-1', 'user-2'],
+      'extracted user IDs correctly'
+    );
+
+    // Verify collaborators getter
+    assert.deepEqual(workspace.collaborators, ['user-1', 'user-2']);
+  });
+
+  test('route handles workspace with empty permissions array', async function (assert) {
+    const store = this.owner.lookup('service:store');
+
+    const workspace = store.createRecord('workspace', {
+      id: 'ws-empty',
+      name: 'Empty Workspace',
+      permissions: [],
+    });
+
+    const permissions = workspace.get('permissions');
+    assert.ok(Array.isArray(permissions), 'permissions is an array');
+    assert.equal(permissions.length, 0, 'permissions array is empty');
+
+    const userIds = permissions.map((p) => p.user).filter((id) => id);
+    assert.deepEqual(userIds, [], 'no user IDs extracted');
+
+    assert.deepEqual(workspace.collaborators, [], 'collaborators is empty');
+  });
+
+  test('route handles workspace with null permissions', async function (assert) {
+    const store = this.owner.lookup('service:store');
+
+    const workspace = store.createRecord('workspace', {
+      id: 'ws-null',
+      name: 'Null Permissions Workspace',
+      permissions: null,
+    });
+
+    const permissions = workspace.get('permissions');
+
+    // Permissions should be null or undefined
+    assert.notOk(
+      Array.isArray(permissions) && permissions.length > 0,
+      'permissions is not a valid array'
+    );
+
+    // Collaborators getter should handle this gracefully
+    const collaborators = workspace.collaborators;
+    assert.ok(Array.isArray(collaborators), 'collaborators returns an array');
+    assert.equal(collaborators.length, 0, 'empty array for null permissions');
+  });
+
+  test('route filters out permissions with null user IDs', async function (assert) {
+    const store = this.owner.lookup('service:store');
+
+    const workspace = store.createRecord('workspace', {
+      id: 'ws-mixed',
+      name: 'Mixed Workspace',
+      permissions: [
+        {
+          user: 'user-1',
+          global: 'approver',
+          feedback: 'approver',
+        },
+        {
+          user: null,
+          global: 'editor',
+          feedback: 'none',
+        },
+        {
+          user: 'user-2',
+          global: 'editor',
+          feedback: 'none',
+        },
+        {
+          user: undefined,
+          global: 'viewOnly',
+          feedback: 'none',
+        },
+      ],
+    });
+
+    const permissions = workspace.get('permissions');
+    const userIds = permissions.map((p) => p.user).filter((id) => id);
+
+    assert.equal(userIds.length, 2, 'filtered out null/undefined user IDs');
+    assert.deepEqual(userIds, ['user-1', 'user-2']);
+
+    const collaborators = workspace.collaborators;
+    assert.deepEqual(collaborators, ['user-1', 'user-2']);
+  });
+
+  test('route passes originalCollaborators as array to template', async function (assert) {
+    const store = this.owner.lookup('service:store');
+
+    const workspace = store.createRecord('workspace', {
+      id: 'ws-1',
+      permissions: [
+        { user: 'user-1', global: 'approver', feedback: 'approver' },
+        { user: 'user-2', global: 'editor', feedback: 'none' },
+      ],
+    });
+
+    const user1 = store.createRecord('user', {
+      id: 'user-1',
+      username: 'user1',
+    });
+    const user2 = store.createRecord('user', {
+      id: 'user-2',
+      username: 'user2',
+    });
+
+    // Simulate what the route does
+    const permissions = workspace.get('permissions');
+    let originalCollaborators = [];
+
+    if (Array.isArray(permissions) && permissions.length > 0) {
+      const userIds = permissions.map((p) => p.user).filter((id) => id);
+      // In the real route, this would be a store.query result
+      originalCollaborators = [user1, user2];
+    }
+
+    assert.ok(
+      Array.isArray(originalCollaborators),
+      'originalCollaborators is an array'
+    );
+    assert.equal(
+      originalCollaborators.length,
+      2,
+      'has correct number of collaborators'
+    );
+  });
+
+  test('permissions array maintains structure after workspace operations', async function (assert) {
+    const store = this.owner.lookup('service:store');
+
+    const workspace = store.createRecord('workspace', {
+      id: 'ws-1',
+      permissions: [
+        {
+          user: 'user-1',
+          global: 'approver',
+          selections: 4,
+          comments: 4,
+          folders: 3,
+          feedback: 'approver',
+          submissions: { all: true, userOnly: false, submissionIds: [] },
+        },
+      ],
+    });
+
+    // Simulate adding a collaborator (what components do)
+    const newPermission = {
+      user: 'user-2',
+      global: 'editor',
+      selections: 4,
+      comments: 4,
+      folders: 3,
+      feedback: 'none',
+      submissions: { all: true, userOnly: false, submissionIds: [] },
+    };
+
+    const updatedPermissions = [...workspace.permissions, newPermission];
+    workspace.set('permissions', updatedPermissions);
+
+    // Route should still be able to extract user IDs
+    const permissions = workspace.get('permissions');
+    const userIds = permissions.map((p) => p.user).filter((id) => id);
+
+    assert.equal(userIds.length, 2);
+    assert.deepEqual(userIds, ['user-1', 'user-2']);
+    assert.deepEqual(workspace.collaborators, ['user-1', 'user-2']);
+  });
+
+  test('permissions with complex submissions are accessible in route', async function (assert) {
+    const store = this.owner.lookup('service:store');
+
+    const workspace = store.createRecord('workspace', {
+      id: 'ws-custom',
+      permissions: [
+        {
+          user: 'user-custom',
+          global: 'custom',
+          selections: 2,
+          comments: 2,
+          folders: 1,
+          feedback: 'none',
+          submissions: {
+            all: false,
+            userOnly: true,
+            submissionIds: ['sub-1', 'sub-2', 'sub-3'],
+          },
+        },
+      ],
+    });
+
+    const permissions = workspace.get('permissions');
+    assert.equal(permissions.length, 1);
+
+    const customPerm = permissions[0];
+    assert.equal(customPerm.user, 'user-custom');
+    assert.equal(customPerm.global, 'custom');
+    assert.false(customPerm.submissions.all);
+    assert.true(customPerm.submissions.userOnly);
+    assert.equal(customPerm.submissions.submissionIds.length, 3);
+
+    const userIds = permissions.map((p) => p.user).filter((id) => id);
+    assert.deepEqual(userIds, ['user-custom']);
+  });
+});

--- a/tests/unit/models/workspace-test.js
+++ b/tests/unit/models/workspace-test.js
@@ -1,0 +1,212 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | workspace', function (hooks) {
+  setupTest(hooks);
+
+  test('collaborators getter returns array of user IDs', function (assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('workspace', {
+      permissions: [
+        { user: 'user-1', global: 'approver', feedback: 'approver' },
+        { user: 'user-2', global: 'viewOnly', feedback: 'none' },
+        { user: 'user-3', global: 'editor', feedback: 'approver' },
+      ],
+    });
+
+    const collaborators = model.collaborators;
+    assert.deepEqual(collaborators, ['user-1', 'user-2', 'user-3']);
+  });
+
+  test('collaborators getter returns empty array when permissions is null', function (assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('workspace', {
+      permissions: null,
+    });
+
+    const collaborators = model.collaborators;
+    assert.deepEqual(collaborators, []);
+  });
+
+  test('collaborators getter returns empty array when permissions is undefined', function (assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('workspace', {});
+
+    const collaborators = model.collaborators;
+    assert.deepEqual(collaborators, []);
+  });
+
+  test('collaborators getter filters out null/undefined user IDs', function (assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('workspace', {
+      permissions: [
+        { user: 'user-1', global: 'approver', feedback: 'approver' },
+        { user: null, global: 'viewOnly', feedback: 'none' },
+        { user: 'user-3', global: 'editor', feedback: 'approver' },
+        { user: undefined, global: 'editor', feedback: 'none' },
+      ],
+    });
+
+    const collaborators = model.collaborators;
+    assert.deepEqual(collaborators, ['user-1', 'user-3']);
+  });
+
+  test('collaborators getter returns empty array when permissions is empty array', function (assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('workspace', {
+      permissions: [],
+    });
+
+    const collaborators = model.collaborators;
+    assert.deepEqual(collaborators, []);
+  });
+
+  test('feedbackAuthorizers getter returns user IDs with feedback=approver', function (assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('workspace', {
+      permissions: [
+        { user: 'user-1', global: 'approver', feedback: 'approver' },
+        { user: 'user-2', global: 'viewOnly', feedback: 'none' },
+        { user: 'user-3', global: 'editor', feedback: 'approver' },
+      ],
+    });
+
+    const authorizers = model.feedbackAuthorizers;
+    assert.deepEqual(authorizers, ['user-1', 'user-3']);
+  });
+
+  test('feedbackAuthorizers getter returns empty array when no approvers', function (assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('workspace', {
+      permissions: [
+        { user: 'user-1', global: 'approver', feedback: 'none' },
+        { user: 'user-2', global: 'viewOnly', feedback: 'none' },
+      ],
+    });
+
+    const authorizers = model.feedbackAuthorizers;
+    assert.deepEqual(authorizers, []);
+  });
+
+  test('feedbackAuthorizers getter returns empty array when permissions is null', function (assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('workspace', {
+      permissions: null,
+    });
+
+    const authorizers = model.feedbackAuthorizers;
+    assert.deepEqual(authorizers, []);
+  });
+
+  test('feedbackAuthorizers getter returns empty array when permissions is undefined', function (assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('workspace', {});
+
+    const authorizers = model.feedbackAuthorizers;
+    assert.deepEqual(authorizers, []);
+  });
+
+  test('feedbackAuthorizers getter returns empty array when permissions is empty array', function (assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('workspace', {
+      permissions: [],
+    });
+
+    const authorizers = model.feedbackAuthorizers;
+    assert.deepEqual(authorizers, []);
+  });
+
+  test('feedbackAuthorizers getter filters out null/undefined user IDs', function (assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('workspace', {
+      permissions: [
+        { user: 'user-1', global: 'approver', feedback: 'approver' },
+        { user: null, global: 'viewOnly', feedback: 'approver' },
+        { user: 'user-3', global: 'editor', feedback: 'approver' },
+        { user: undefined, global: 'editor', feedback: 'approver' },
+      ],
+    });
+
+    const authorizers = model.feedbackAuthorizers;
+    assert.deepEqual(authorizers, ['user-1', 'user-3']);
+  });
+
+  test('feedback value is case-sensitive (must be exactly "approver")', function (assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('workspace', {
+      permissions: [
+        { user: 'user-1', global: 'approver', feedback: 'approver' },
+        { user: 'user-2', global: 'viewOnly', feedback: 'Approver' }, // Wrong case
+        { user: 'user-3', global: 'editor', feedback: 'APPROVER' }, // Wrong case
+      ],
+    });
+
+    const authorizers = model.feedbackAuthorizers;
+    assert.deepEqual(authorizers, ['user-1']);
+  });
+
+  test('collaborators is a live computed property', function (assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('workspace', {
+      permissions: [
+        { user: 'user-1', global: 'approver', feedback: 'approver' },
+      ],
+    });
+
+    let collaborators = model.collaborators;
+    assert.deepEqual(collaborators, ['user-1']);
+
+    // Modify permissions
+    model.permissions = [
+      { user: 'user-1', global: 'approver', feedback: 'approver' },
+      { user: 'user-2', global: 'viewOnly', feedback: 'none' },
+    ];
+
+    collaborators = model.collaborators;
+    assert.deepEqual(collaborators, ['user-1', 'user-2']);
+  });
+
+  test('feedbackAuthorizers is a live computed property', function (assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('workspace', {
+      permissions: [
+        { user: 'user-1', global: 'approver', feedback: 'approver' },
+      ],
+    });
+
+    let authorizers = model.feedbackAuthorizers;
+    assert.deepEqual(authorizers, ['user-1']);
+
+    // Modify permissions
+    model.permissions = [
+      { user: 'user-1', global: 'approver', feedback: 'none' },
+      { user: 'user-2', global: 'viewOnly', feedback: 'approver' },
+    ];
+
+    authorizers = model.feedbackAuthorizers;
+    assert.deepEqual(authorizers, ['user-2']);
+  });
+
+  test('collaborators and feedbackAuthorizers work with plain JS arrays', function (assert) {
+    let store = this.owner.lookup('service:store');
+
+    // Simulate what the transform returns - plain JS arrays, not Ember Arrays
+    const plainPermissions = [
+      { user: 'user-1', global: 'approver', feedback: 'approver' },
+      { user: 'user-2', global: 'viewOnly', feedback: 'none' },
+      { user: 'user-3', global: 'editor', feedback: 'approver' },
+    ];
+
+    let model = store.createRecord('workspace', {
+      permissions: plainPermissions,
+    });
+
+    const collaborators = model.collaborators;
+    const authorizers = model.feedbackAuthorizers;
+
+    assert.ok(Array.isArray(collaborators), 'collaborators is an array');
+    assert.ok(Array.isArray(authorizers), 'feedbackAuthorizers is an array');
+    assert.deepEqual(collaborators, ['user-1', 'user-2', 'user-3']);
+    assert.deepEqual(authorizers, ['user-1', 'user-3']);
+  });
+});

--- a/tests/unit/services/workspace-permissions-test.js
+++ b/tests/unit/services/workspace-permissions-test.js
@@ -1,0 +1,204 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | workspace-permissions', function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.service = this.owner.lookup('service:workspace-permissions');
+  });
+
+  test('isFeedbackApprover returns true when user is in feedbackAuthorizers', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const workspace = store.createRecord('workspace', {
+      permissions: [
+        { user: 'user-1', global: 'approver', feedback: 'approver' },
+        { user: 'user-2', global: 'viewOnly', feedback: 'none' },
+        { user: 'user-3', global: 'editor', feedback: 'approver' },
+      ],
+    });
+
+    // Stub current user to match one of the feedback authorizers
+    const currentUserService = this.owner.lookup('service:current-user');
+    currentUserService.user = { id: 'user-1', isAdmin: false };
+
+    const result = this.service.isFeedbackApprover(workspace);
+    assert.true(result);
+  });
+
+  test('isFeedbackApprover returns false when user is not in feedbackAuthorizers', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const workspace = store.createRecord('workspace', {
+      permissions: [
+        { user: 'user-1', global: 'approver', feedback: 'approver' },
+        { user: 'user-2', global: 'viewOnly', feedback: 'none' },
+      ],
+    });
+
+    const currentUserService = this.owner.lookup('service:current-user');
+    currentUserService.user = { id: 'user-99', isAdmin: false };
+
+    const result = this.service.isFeedbackApprover(workspace);
+    assert.false(result);
+  });
+
+  test('isFeedbackApprover returns false when workspace is null', function (assert) {
+    const currentUserService = this.owner.lookup('service:current-user');
+    currentUserService.user = { id: 'user-1', isAdmin: false };
+
+    const result = this.service.isFeedbackApprover(null);
+    assert.false(result);
+  });
+
+  test('isFeedbackApprover returns false when workspace has no approvers', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const workspace = store.createRecord('workspace', {
+      permissions: [
+        { user: 'user-1', global: 'approver', feedback: 'none' },
+        { user: 'user-2', global: 'viewOnly', feedback: 'none' },
+      ],
+    });
+
+    const currentUserService = this.owner.lookup('service:current-user');
+    currentUserService.user = { id: 'user-1', isAdmin: false };
+
+    const result = this.service.isFeedbackApprover(workspace);
+    assert.false(result);
+  });
+
+  test('isFeedbackApprover works with plain JS arrays from transform', function (assert) {
+    const store = this.owner.lookup('service:store');
+
+    // Create workspace with plain JS permissions array (no mapBy method)
+    const workspace = store.createRecord('workspace', {
+      permissions: [
+        { user: 'user-1', global: 'approver', feedback: 'approver' },
+        { user: 'user-2', global: 'viewOnly', feedback: 'none' },
+        { user: 'user-3', global: 'editor', feedback: 'approver' },
+      ],
+    });
+
+    // Can't test if mapBy exists because Ember Data may wrap it,
+    // but we CAN verify the service works correctly with it
+    const authorizers = workspace.feedbackAuthorizers;
+    assert.ok(
+      Array.isArray(authorizers),
+      'feedbackAuthorizers returns an array'
+    );
+
+    const currentUserService = this.owner.lookup('service:current-user');
+    currentUserService.user = { id: 'user-3', isAdmin: false };
+
+    const result = this.service.isFeedbackApprover(workspace);
+    assert.true(result);
+  });
+
+  test('canEdit finds user permissions with plain JS arrays', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const currentUserService = this.owner.lookup('service:current-user');
+    currentUserService.user = {
+      id: 'user-1',
+      isAdmin: false,
+      isPdAdmin: false,
+    };
+
+    const workspace = store.createRecord('workspace', {
+      workspaceType: 'student',
+      permissions: [
+        {
+          user: 'user-1',
+          global: 'editor',
+          selections: 4,
+          comments: 4,
+          folders: 3,
+          feedback: 'approver',
+          submissions: { all: true },
+        },
+        {
+          user: 'user-2',
+          global: 'viewOnly',
+          selections: 1,
+          comments: 1,
+          folders: 1,
+          feedback: 'none',
+          submissions: { all: false },
+        },
+      ],
+    });
+
+    // User-1 has editor privileges
+    assert.true(this.service.canEdit(workspace, 'selections', 4));
+    assert.true(this.service.canEdit(workspace, 'comments', 4));
+    assert.true(this.service.canEdit(workspace, 'folders', 3));
+  });
+
+  test('canEdit returns false when user not in permissions', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const currentUserService = this.owner.lookup('service:current-user');
+    currentUserService.user = {
+      id: 'user-99',
+      isAdmin: false,
+      isPdAdmin: false,
+    };
+
+    const workspace = store.createRecord('workspace', {
+      workspaceType: 'student',
+      permissions: [
+        {
+          user: 'user-1',
+          global: 'editor',
+          selections: 4,
+          comments: 4,
+          folders: 3,
+          feedback: 'approver',
+        },
+      ],
+    });
+
+    assert.false(this.service.canEdit(workspace, 'selections', 1));
+  });
+
+  test('canEdit handles null permissions array', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const currentUserService = this.owner.lookup('service:current-user');
+    currentUserService.user = {
+      id: 'user-1',
+      isAdmin: false,
+      isPdAdmin: false,
+    };
+
+    const workspace = store.createRecord('workspace', {
+      workspaceType: 'student',
+      permissions: null,
+    });
+
+    assert.false(this.service.canEdit(workspace, 'selections', 1));
+  });
+
+  test('canEdit respects global permission levels', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const currentUserService = this.owner.lookup('service:current-user');
+    currentUserService.user = {
+      id: 'user-1',
+      isAdmin: false,
+      isPdAdmin: false,
+    };
+
+    const viewOnlyWorkspace = store.createRecord('workspace', {
+      workspaceType: 'student',
+      permissions: [
+        {
+          user: 'user-1',
+          global: 'viewOnly',
+          selections: 4,
+          comments: 4,
+          folders: 3,
+          feedback: 'approver',
+        },
+      ],
+    });
+
+    // Even with custom permissions set, viewOnly global prevents editing
+    assert.false(this.service.canEdit(viewOnlyWorkspace, 'selections', 1));
+  });
+});

--- a/tests/unit/transforms/permissions-test.js
+++ b/tests/unit/transforms/permissions-test.js
@@ -1,0 +1,194 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import PermissionsTransform from 'encompass/transforms/permissions';
+
+module('Unit | Transform | permissions', function (hooks) {
+  setupTest(hooks);
+
+  let transform;
+
+  hooks.beforeEach(function () {
+    transform = new PermissionsTransform();
+  });
+
+  module('deserialize', function () {
+    test('returns empty array for null', function (assert) {
+      const result = transform.deserialize(null);
+      assert.deepEqual(result, [], 'returns empty array for null');
+    });
+
+    test('returns empty array for non-array', function (assert) {
+      const result = transform.deserialize({});
+      assert.deepEqual(result, [], 'returns empty array for object');
+    });
+
+    test('cleans permission objects', function (assert) {
+      const input = [
+        {
+          user: 'user-1',
+          global: 'approver',
+          selections: 4,
+          comments: 4,
+          folders: 3,
+          feedback: 'approver',
+          submissions: { all: true, userOnly: false, submissionIds: [] },
+          unwantedProp: 'should be removed',
+        },
+      ];
+
+      const result = transform.deserialize(input);
+
+      assert.equal(result.length, 1, 'returns array with one object');
+      assert.deepEqual(result[0], {
+        user: 'user-1',
+        global: 'approver',
+        selections: 4,
+        comments: 4,
+        folders: 3,
+        feedback: 'approver',
+        submissions: { all: true, userOnly: false, submissionIds: [] },
+      });
+      assert.notOk(result[0].unwantedProp, 'unwanted properties removed');
+    });
+
+    test('cleans submissions sub-objects', function (assert) {
+      const input = [
+        {
+          user: 'user-1',
+          global: 'viewOnly',
+          selections: 1,
+          comments: 1,
+          folders: 1,
+          feedback: 'none',
+          submissions: {
+            all: false,
+            userOnly: true,
+            submissionIds: ['sub-1', 'sub-2'],
+            embeddedStore: {}, // Should be removed
+          },
+        },
+      ];
+
+      const result = transform.deserialize(input);
+
+      assert.deepEqual(result[0].submissions, {
+        all: false,
+        userOnly: true,
+        submissionIds: ['sub-1', 'sub-2'],
+      });
+      assert.notOk(
+        result[0].submissions.embeddedStore,
+        'embedded store removed'
+      );
+    });
+
+    test('handles missing submissions object', function (assert) {
+      const input = [
+        {
+          user: 'user-1',
+          global: 'viewOnly',
+          selections: 1,
+          comments: 1,
+          folders: 1,
+          feedback: 'none',
+        },
+      ];
+
+      const result = transform.deserialize(input);
+
+      assert.deepEqual(result[0].submissions, {
+        all: false,
+        userOnly: false,
+        submissionIds: [],
+      });
+    });
+
+    test('converts array submission IDs to plain array', function (assert) {
+      // Simulate an Ember Array
+      const emberArray = ['sub-1', 'sub-2'];
+      emberArray.isArray = true; // Ember Array marker
+
+      const input = [
+        {
+          user: 'user-1',
+          global: 'viewOnly',
+          selections: 1,
+          comments: 1,
+          folders: 1,
+          feedback: 'none',
+          submissions: {
+            all: false,
+            userOnly: false,
+            submissionIds: emberArray,
+          },
+        },
+      ];
+
+      const result = transform.deserialize(input);
+
+      assert.deepEqual(result[0].submissions.submissionIds, ['sub-1', 'sub-2']);
+      assert.notOk(
+        result[0].submissions.submissionIds.isArray,
+        'isArray marker removed'
+      );
+    });
+  });
+
+  module('serialize', function () {
+    test('returns empty array for null', function (assert) {
+      const result = transform.serialize(null);
+      assert.deepEqual(result, [], 'returns empty array for null');
+    });
+
+    test('cleans permission objects same as deserialize', function (assert) {
+      const input = [
+        {
+          user: 'user-1',
+          global: 'editor',
+          selections: 4,
+          comments: 4,
+          folders: 3,
+          feedback: 'none',
+          submissions: { all: true, userOnly: false, submissionIds: [] },
+          emberInternalProp: { circular: 'reference' },
+        },
+      ];
+
+      const result = transform.serialize(input);
+
+      assert.equal(result.length, 1);
+      assert.notOk(result[0].emberInternalProp, 'internal props removed');
+    });
+
+    test('boolean values are normalized', function (assert) {
+      const input = [
+        {
+          user: 'user-1',
+          global: 'viewOnly',
+          selections: 1,
+          comments: 1,
+          folders: 1,
+          feedback: 'none',
+          submissions: {
+            all: 1, // Truthy but not boolean
+            userOnly: 0, // Falsy but not boolean
+            submissionIds: [],
+          },
+        },
+      ];
+
+      const result = transform.serialize(input);
+
+      assert.strictEqual(
+        result[0].submissions.all,
+        true,
+        'converts truthy to boolean'
+      );
+      assert.strictEqual(
+        result[0].submissions.userOnly,
+        false,
+        'converts falsy to boolean'
+      );
+    });
+  });
+});


### PR DESCRIPTION
Main problem with collaborators was that workspace permissions is a stored embedded object (rather than having its own DB table) and so Ember Data wrapped it. Changed permissions to regular object, added a specialized serializer/deserializer, and made sure that other areas didn't treat permissions as an Ember Array.

Note that the workspace settings subsystem (info, collaborators, etc) still needs to be upgraded. These changes were applied to un-upgraded components for now.