### PR TITLE
Simplify AI variants to two modes (A + B),  reduce stack comparison cards, and map FE 'B' to BE 'D'

### DIFF
--- a/app/components/ai-variant-comparison.hbs
+++ b/app/components/ai-variant-comparison.hbs
@@ -8,7 +8,7 @@
     </div>
     <div class="ab-test-message">
       <p><strong>What's being tested:</strong> Different combinations of student work + teacher annotations (comments, selections) to determine the most effective AI input for generating helpful responses.</p>
-      <p><strong>What to focus on:</strong> Compare the quality and helpfulness of AI-generated responses across the four variant combinations below.</p>
+      <p><strong>What to focus on:</strong> Compare the quality and helpfulness of AI-generated responses across the two active variants below.</p>
     </div>
   </div>
   
@@ -18,12 +18,12 @@
   </div>
   
   <button type="button" class="primary-button" {{on "click" (fn this.generateAllVariants @submission)}} disabled={{this.isLoading}}>
-    {{if this.isLoading "Generating..." "Generate All Variants"}}
+    {{if this.isLoading "Generating..." "Generate Both Variants"}}
   </button>
   {{#if this.error}}
     <div class="error-message">{{this.error}}</div>
   {{/if}}
-  <div class="variant-grid-2x2">
+  <div class="variant-stack">
     <div class="variant-cell-simple">
       <div class="variant-title">Variant A: Student Work Only</div>
       <button type="button" class="variant-generate-btn" {{on "click" (fn this.generateSingleVariant @submission 'A')}} disabled={{this.isVariantADisabled}}>
@@ -32,25 +32,11 @@
       <div class="ai-draft-text">{{if this.draftA this.draftA "EMPTY - Click Generate to populate"}}</div>
     </div>
     <div class="variant-cell-simple">
-      <div class="variant-title">Variant B: Student Work + Selections</div>
-      <button type="button" class="variant-generate-btn" {{on "click" (fn this.generateSingleVariant @submission 'B')}} disabled={{this.isVariantBDisabled}}>
+      <div class="variant-title">Variant B: Student Work + Selections + Comments (All)</div>
+      <button type="button" class="variant-generate-btn" {{on "click" (fn this.generateSingleVariant @submission 'D')}} disabled={{this.isVariantBDisabled}}>
         {{this.variantBButtonText}}
       </button>
       <div class="ai-draft-text">{{if this.draftB this.draftB "EMPTY - Click Generate to populate"}}</div>
-    </div>
-    <div class="variant-cell-simple">
-      <div class="variant-title">Variant C: Student Work + Comments (notice, wonder, feedback)</div>
-      <button type="button" class="variant-generate-btn" {{on "click" (fn this.generateSingleVariant @submission 'C')}} disabled={{this.isVariantCDisabled}}>
-        {{this.variantCButtonText}}
-      </button>
-      <div class="ai-draft-text">{{if this.draftC this.draftC "EMPTY - Click Generate to populate"}}</div>
-    </div>
-    <div class="variant-cell-simple">
-      <div class="variant-title">Variant D: Student Work + Selections + Comments (All)</div>
-      <button type="button" class="variant-generate-btn" {{on "click" (fn this.generateSingleVariant @submission 'D')}} disabled={{this.isVariantDDisabled}}>
-        {{this.variantDButtonText}}
-      </button>
-      <div class="ai-draft-text">{{if this.draftD this.draftD "EMPTY - Click Generate to populate"}}</div>
     </div>
   </div>
   

--- a/app/components/ai-variant-comparison.js
+++ b/app/components/ai-variant-comparison.js
@@ -14,16 +14,16 @@ export default class AiVariantComparisonComponent extends Component {
 
   @tracked draftA = null;
   @tracked draftB = null;
-  @tracked draftC = null;
-  @tracked draftD = null;
 
   @tracked loadingVariant = null; // Track which variant is currently loading
 
   variants = [
-    { code: 'A', label: 'Student work only' },
-    { code: 'B', label: 'Student work + teacher selections' },
-    { code: 'C', label: 'Student work + teacher comments' },
-    { code: 'D', label: 'Student work + selections + comments' },
+    { code: 'A', displayLabel: 'A', label: 'Student work only' },
+    {
+      code: 'D',
+      displayLabel: 'B',
+      label: 'Student work + selections + comments',
+    },
   ];
 
   get isVariantADisabled() {
@@ -31,14 +31,6 @@ export default class AiVariantComparisonComponent extends Component {
   }
 
   get isVariantBDisabled() {
-    return this.isLoading || this.loadingVariant === 'B';
-  }
-
-  get isVariantCDisabled() {
-    return this.isLoading || this.loadingVariant === 'C';
-  }
-
-  get isVariantDDisabled() {
     return this.isLoading || this.loadingVariant === 'D';
   }
 
@@ -47,15 +39,7 @@ export default class AiVariantComparisonComponent extends Component {
   }
 
   get variantBButtonText() {
-    return this.loadingVariant === 'B' ? 'Generating...' : 'Generate B';
-  }
-
-  get variantCButtonText() {
-    return this.loadingVariant === 'C' ? 'Generating...' : 'Generate C';
-  }
-
-  get variantDButtonText() {
-    return this.loadingVariant === 'D' ? 'Generating...' : 'Generate D';
+    return this.loadingVariant === 'D' ? 'Generating...' : 'Generate B';
   }
 
   @action
@@ -76,14 +60,8 @@ export default class AiVariantComparisonComponent extends Component {
         case 'A':
           this.draftA = result;
           break;
-        case 'B':
-          this.draftB = result;
-          break;
-        case 'C':
-          this.draftC = result;
-          break;
         case 'D':
-          this.draftD = result;
+          this.draftB = result;
           break;
       }
     } catch (error) {
@@ -117,8 +95,6 @@ export default class AiVariantComparisonComponent extends Component {
       );
       this.draftA = results[0];
       this.draftB = results[1];
-      this.draftC = results[2];
-      this.draftD = results[3];
     } catch (e) {
       console.error('Overall error:', e);
       this.error = e.message || 'Failed to generate drafts';
@@ -137,11 +113,8 @@ export default class AiVariantComparisonComponent extends Component {
       case 'B':
         draftText = this.draftB;
         break;
-      case 'C':
-        draftText = this.draftC;
-        break;
       case 'D':
-        draftText = this.draftD;
+        draftText = this.draftB;
         break;
     }
     if (this.args.onDraftSelected && draftText) {

--- a/app/components/response-mentor-reply.hbs
+++ b/app/components/response-mentor-reply.hbs
@@ -12,6 +12,8 @@
     {{!-- END TEMPORARY A/B TEST CODE --}}
     {{!-- END TEMPORARY A/B TEST CODE --}}
     {{!-- END TEMPORARY A/B TEST CODE --}}
+    {{!-- Temporarily hidden: new response area below A/B testing --}}
+    {{!--
     <ResponseNew
       @isCreating={{@isCreating}}
       @submission={{@submission}}
@@ -25,6 +27,7 @@
       @handleResponseThread={{this.handleNewMentorReply}}
       @aiGeneratedText={{this.aiGeneratedText}}
     />
+    --}}
   {{/if}}
 {{/unless}}
 

--- a/app/services/ai-draft.js
+++ b/app/services/ai-draft.js
@@ -53,7 +53,7 @@ export default class AiDraftService extends Service {
    * and generates appropriate feedback.
    *
    * @param {String} submissionId - The ID of the submission to generate feedback for
-   * @param {String} variant - A/B TEST VARIANT: The variant type ('A', 'B', 'C', 'D')
+   * @param {String} variant - Variant key ('A' or 'D')
    * @returns {Promise<String>} HTML string containing the generated draft
    * @throws {Error} If API call fails or no content is received
    */

--- a/app/services/workspace-reports.js
+++ b/app/services/workspace-reports.js
@@ -31,7 +31,7 @@ export default class WorkspaceReportsService extends Service {
     // Variants will be fetched separately and passed in
     // This is just a placeholder that returns empty columns
     const variantData = {};
-    ['A', 'B', 'C', 'D'].forEach((key) => {
+    ['A', 'B'].forEach((key) => {
       variantData[`AI Variant ${key}`] = '';
     });
     return variantData;
@@ -210,14 +210,8 @@ export default class WorkspaceReportsService extends Service {
         'AI Variant A (Student Work Only)': this.stripHtml(
           submissionVariants['A'] || ''
         ),
-        'AI Variant B (Work + Selections)': this.stripHtml(
-          submissionVariants['B'] || ''
-        ),
-        'AI Variant C (Work + Comments)': this.stripHtml(
-          submissionVariants['C'] || ''
-        ),
-        'AI Variant D (Work + Selections + Comments)': this.stripHtml(
-          submissionVariants['D'] || ''
+        'AI Variant B (Work + Selections + Comments)': this.stripHtml(
+          submissionVariants['D'] || submissionVariants['B'] || ''
         ),
       };
 

--- a/app/styles/_ai-variant-comparison.scss
+++ b/app/styles/_ai-variant-comparison.scss
@@ -4,10 +4,10 @@
 .ai-variant-comparison {
   margin-bottom: 2em;
 }
-.variant-grid-2x2 {
+.variant-grid-2x2,
+.variant-stack {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-template-rows: 1fr 1fr;
+  grid-template-columns: 1fr;
   gap: 1em;
   margin-top: 1em;
   width: 100%;
@@ -18,9 +18,9 @@
 
 // Responsive design for smaller screens
 @media (max-width: 768px) {
-  .variant-grid-2x2 {
+  .variant-grid-2x2,
+  .variant-stack {
     grid-template-columns: 1fr;
-    grid-template-rows: auto auto auto auto;
     gap: 0.75em;
     padding: 0 0.5em;
   }

--- a/app_server/config/aiVariants.js
+++ b/app_server/config/aiVariants.js
@@ -8,30 +8,20 @@
  */
 
 module.exports = {
-  // Current A/B Testing Mode: 4 variants
+  // Current A/B Testing Mode: 2 active variants
+  // Variant mapping:
+  // - A -> Student Work Only
+  // - D -> Student Work + Selections + Comments (shown as "Variant B" in UI)
   activeVariants: [
     {
       key: 'A',
-      label: 'Student Work Only',
+      label: 'Variant A: Student Work Only',
       inputType: 'work_only',
       description: 'AI analyzes only student submission text',
     },
     {
-      key: 'B',
-      label: 'Work + Selections',
-      inputType: 'work_selections',
-      description: 'AI analyzes student work + teacher text selections',
-    },
-    {
-      key: 'C',
-      label: 'Work + Comments',
-      inputType: 'work_comments',
-      description:
-        'AI analyzes student work + teacher comments (notice/wonder/feedback)',
-    },
-    {
       key: 'D',
-      label: 'Work + Selections + Comments',
+      label: 'Variant B: Work + Selections + Comments',
       inputType: 'work_all',
       description: 'AI analyzes student work + all teacher annotations',
     },

--- a/app_server/datasource/api/aiApi.js
+++ b/app_server/datasource/api/aiApi.js
@@ -23,7 +23,7 @@ async function aiDraft(req, res, next) {
 
   const target = req.query.target;
   const workspace = req.query.workspace;
-  const variant = req.query.variant || 'A'; // A/B TEST: Default to variant A
+  const variant = req.query.variant || 'A'; // Default to variant A
 
   if (!target) {
     return utils.sendError.InvalidArgumentError(
@@ -32,8 +32,8 @@ async function aiDraft(req, res, next) {
     );
   }
 
-  // A/B TEST: Validate variant (A/B/C/D input combinations)
-  const validVariants = ['A', 'B', 'C', 'D'];
+  // Validate variant using active server configuration
+  const validVariants = variantConfig.activeVariants.map((v) => v.key);
   if (!validVariants.includes(variant)) {
     return utils.sendError.InvalidArgumentError(
       `Invalid variant. Must be one of: ${validVariants.join(', ')}`,
@@ -42,7 +42,7 @@ async function aiDraft(req, res, next) {
   }
 
   try {
-    // A/B TEST: Generate AI draft using the AI service with variant
+    // Generate AI draft using the AI service with selected variant
     const draftResult = await aiService.generateDraft(
       target,
       variant,
@@ -56,10 +56,6 @@ async function aiDraft(req, res, next) {
         (v) => v.key === variant
       );
 
-      if (!variantConfigData) {
-        return;
-      }
-
       const existingVariant = await models.AIVariant.findOne({
         submission: target,
         variantKey: variant,
@@ -70,7 +66,11 @@ async function aiDraft(req, res, next) {
         typeof draftResult === 'object' && draftResult?.draft
           ? draftResult.draft
           : draftResult;
-      if (!existingVariant) {
+      if (!variantConfigData) {
+        console.warn(
+          `[AI Variant] No active config found for variant ${variant}; skipping save`
+        );
+      } else if (!existingVariant) {
         await models.AIVariant.create({
           submission: target,
           workspace: workspace,
@@ -96,7 +96,7 @@ async function aiDraft(req, res, next) {
         : draftResult;
     const response = {
       target: target,
-      variant: variant, // A/B TEST: Include variant in response
+      variant: variant,
       message: `AI draft generated for target submission: ${target}`,
       draft: draftText,
     };

--- a/app_server/services/ai.js
+++ b/app_server/services/ai.js
@@ -53,15 +53,13 @@ const { resolveProblemText } = require('./problemText');
 /**
  * Generate an AI draft response based on submission
  * @param {string} targetSubmissionId - The ID of the target submission
- * @param {string} variant - A/B TEST VARIANT: Input variant ('A', 'B', 'C', or 'D')
+ * @param {string} variant - Input variant ('A' or 'D')
  * @param {string} workspaceId - Optional workspace ID to filter selections/comments
  * @param {string} teacherId - Teacher user ID to scope selections/comments
  * @returns {Promise<string>} The generated AI draft text
  *
- * A/B TEST VARIANTS - WILL BE SIMPLIFIED ONCE PREFERRED COMBINATION IS CHOSEN:
+ * Active variants:
  * A: Student work only
- * B: Student work + teacher selections
- * C: Student work + teacher comments (noticings, wonderings, feedback)
  * D: Student work + teacher selections + teacher comments
  */
 const generateDraft = async (
@@ -150,7 +148,7 @@ const generateDraft = async (
 };
 
 /**
- * A/B TEST HELPER: Get teacher selections for a submission
+ * Helper: Get teacher selections for a submission
  * @param {string} submissionId - The submission ID
  * @param {string} workspaceId - The workspace ID to filter selections
  * @param {string} teacherId - The teacher user ID to filter selections
@@ -184,7 +182,7 @@ const getTeacherSelections = async (submissionId, workspaceId, teacherId) => {
 };
 
 /**
- * A/B TEST HELPER: Get teacher comments for a submission
+ * Helper: Get teacher comments for a submission
  * @param {string} submissionId - The submission ID
  * @param {string} workspaceId - The workspace ID to filter comments
  * @param {string} teacherId - The teacher user ID to filter comments
@@ -233,8 +231,8 @@ const buildSelectionsAndObservations = async (
   workspaceId,
   teacherId
 ) => {
-  const includeSelections = variant === 'B' || variant === 'D';
-  const includeComments = variant === 'C' || variant === 'D';
+  const includeSelections = variant === 'D';
+  const includeComments = variant === 'D';
 
   const [selections, comments] = await Promise.all([
     includeSelections


### PR DESCRIPTION
## Description
This PR simplifies AI variant behavior by keeping only two active options in product flow:
- Variant A: student work only
- Variant B: student work + selections + comments

Implementation keeps backend key `D` for the all-context mode and maps it to visible Variant B in UI and reports.

## Changes

### Backend / API
- Reduced active variant config to `A` and `D`
- Removed original active `B` and `C` from server configuration
- Updated aiDraft validation to use config-driven active keys
- Kept draft generation/persistence behavior stable with safe handling when config is missing
- Updated AI service logic so mentor context is attached only for variant `D`

### Frontend Comparison UI
- Removed old C/D comparison cards and related state
- Kept two visible options only:
  - A -> key `A`
  - B -> key `D`
- Updated bulk action to generate only both active variants
- Updated explanatory copy to match two-variant flow

### Layout / Styling
- Stacked Variant A and Variant B vertically (A above B)
- Updated comparison SCSS to single-column layout across breakpoints

### WP Report
- Updated workspace report variant columns to only A and B
- Mapped report Variant B column to backend key `D`
- Added fallback to legacy `B` values for historical data continuity

## Additional UI Scope
- Temporarily commented out inline `ResponseNew` under A/B comparison in `app/components/response-mentor-reply.hbs` to keep this pass focused on variant comparison behavior.

## Manual Testing
- Generated Variant A and Variant B from comparison UI and verified expected draft responses
- Verified no generation path for old B/C variants from UI
- Verified request validation accepts active variants only
- Downloaded workspace report and confirmed only A/B columns are exported
- Confirmed Variant B report values resolve from key D
