### PR TITLE
Feat/ai variants rating

### DIFF
--- a/app/components/ai-variant-comparison.hbs
+++ b/app/components/ai-variant-comparison.hbs
@@ -30,6 +30,39 @@
         {{this.variantAButtonText}}
       </button>
       <div class="ai-draft-text">{{if this.draftA this.draftA "EMPTY - Click Generate to populate"}}</div>
+      <div class="ai-feedback-controls">
+        <div class="star-rating-container">
+          <label class="star-rating-label">Rate AI Draft <span class="required-asterisk">*</span></label>
+          <div class="star-rating-stars">
+            {{#each this.starDefinitions as |star|}}
+              <i
+                class="fas fa-star star-icon {{if (this.isStarActive 'A' star.value) 'star-filled' 'star-empty'}}"
+                role="button"
+                tabindex="0"
+                title={{star.tooltip}}
+                {{on "click" (fn this.setVariantRating 'A' star.value)}}
+              ></i>
+            {{/each}}
+          </div>
+          <span class="rating-value">{{this.ratingLabelA}}</span>
+        </div>
+        <div class="ai-feedback-container">
+          <label for="variant-a-feedback" class="ai-feedback-label">Written Feedback <span class="required-asterisk">*</span></label>
+          <Textarea
+            id="variant-a-feedback"
+            class="variant-feedback-textarea"
+            @value={{this.feedbackA}}
+            placeholder="Write your feedback for Variant A(at least 10 characters long)"
+            {{on "input" (fn this.setVariantFeedback 'A')}}
+          />
+        </div>
+        <button
+          type="button"
+          class="ai-bring-down-btn"
+          disabled={{not this.canBringDownA}}
+          {{on "click" (fn this.bringDownVariant 'A')}}
+        >Bring It Down</button>
+      </div>
     </div>
     <div class="variant-cell-simple">
       <div class="variant-title">Variant B: Student Work + Selections + Comments (All)</div>
@@ -37,6 +70,39 @@
         {{this.variantBButtonText}}
       </button>
       <div class="ai-draft-text">{{if this.draftB this.draftB "EMPTY - Click Generate to populate"}}</div>
+      <div class="ai-feedback-controls">
+        <div class="star-rating-container">
+          <label class="star-rating-label">Rate AI Draft <span class="required-asterisk">*</span></label>
+          <div class="star-rating-stars">
+            {{#each this.starDefinitions as |star|}}
+              <i
+                class="fas fa-star star-icon {{if (this.isStarActive 'D' star.value) 'star-filled' 'star-empty'}}"
+                role="button"
+                tabindex="0"
+                title={{star.tooltip}}
+                {{on "click" (fn this.setVariantRating 'D' star.value)}}
+              ></i>
+            {{/each}}
+          </div>
+          <span class="rating-value">{{this.ratingLabelB}}</span>
+        </div>
+        <div class="ai-feedback-container">
+          <label for="variant-b-feedback" class="ai-feedback-label">Written Feedback <span class="required-asterisk">*</span></label>
+          <Textarea
+            id="variant-b-feedback"
+            class="variant-feedback-textarea"
+            @value={{this.feedbackD}}
+            placeholder="Write your feedback for Variant B(at least 10 characters long)"
+            {{on "input" (fn this.setVariantFeedback 'D')}}
+          />
+        </div>
+        <button
+          type="button"
+          class="ai-bring-down-btn"
+          disabled={{not this.canBringDownD}}
+          {{on "click" (fn this.bringDownVariant 'D')}}
+        >Bring It Down</button>
+      </div>
     </div>
   </div>
   

--- a/app/components/ai-variant-comparison.hbs
+++ b/app/components/ai-variant-comparison.hbs
@@ -60,6 +60,7 @@
           type="button"
           class="ai-bring-down-btn"
           disabled={{not this.canBringDownA}}
+          title={{this.bringDownTooltipA}}
           {{on "click" (fn this.bringDownVariant 'A')}}
         >Bring It Down</button>
       </div>
@@ -100,6 +101,7 @@
           type="button"
           class="ai-bring-down-btn"
           disabled={{not this.canBringDownD}}
+          title={{this.bringDownTooltipB}}
           {{on "click" (fn this.bringDownVariant 'D')}}
         >Bring It Down</button>
       </div>

--- a/app/components/ai-variant-comparison.js
+++ b/app/components/ai-variant-comparison.js
@@ -14,6 +14,10 @@ export default class AiVariantComparisonComponent extends Component {
 
   @tracked draftA = null;
   @tracked draftB = null;
+  @tracked ratingA = 0;
+  @tracked ratingD = 0;
+  @tracked feedbackA = '';
+  @tracked feedbackD = '';
 
   @tracked loadingVariant = null; // Track which variant is currently loading
 
@@ -42,6 +46,36 @@ export default class AiVariantComparisonComponent extends Component {
     return this.loadingVariant === 'D' ? 'Generating...' : 'Generate B';
   }
 
+  starDefinitions = [
+    { value: 1, tooltip: 'Poor: Not useful, needs major changes' },
+    { value: 2, tooltip: 'Fair: Somewhat useful but significant issues' },
+    { value: 3, tooltip: 'Good: Moderately helpful with minor issues' },
+    { value: 4, tooltip: 'Very Good: Helpful and well-formed' },
+    { value: 5, tooltip: 'Excellent: Very useful, clear, and actionable' },
+  ];
+
+  get canBringDownA() {
+    return Boolean(this.draftA);
+  }
+
+  get canBringDownD() {
+    return Boolean(this.draftB);
+  }
+
+  get ratingLabelA() {
+    return this.ratingA > 0 ? `${this.ratingA} / 5` : 'No rating yet';
+  }
+
+  get ratingLabelB() {
+    return this.ratingD > 0 ? `${this.ratingD} / 5` : 'No rating yet';
+  }
+
+  @action
+  isStarActive(variantCode, starNumber) {
+    const rating = variantCode === 'A' ? this.ratingA : this.ratingD;
+    return rating >= starNumber;
+  }
+
   @action
   async generateSingleVariant(submission, variantCode) {
     this.loadingVariant = variantCode;
@@ -59,9 +93,13 @@ export default class AiVariantComparisonComponent extends Component {
       switch (variantCode) {
         case 'A':
           this.draftA = result;
+          this.ratingA = 0;
+          this.feedbackA = '';
           break;
         case 'D':
           this.draftB = result;
+          this.ratingD = 0;
+          this.feedbackD = '';
           break;
       }
     } catch (error) {
@@ -95,6 +133,10 @@ export default class AiVariantComparisonComponent extends Component {
       );
       this.draftA = results[0];
       this.draftB = results[1];
+      this.ratingA = 0;
+      this.ratingD = 0;
+      this.feedbackA = '';
+      this.feedbackD = '';
     } catch (e) {
       console.error('Overall error:', e);
       this.error = e.message || 'Failed to generate drafts';
@@ -104,19 +146,35 @@ export default class AiVariantComparisonComponent extends Component {
   }
 
   @action
-  useDraft(variant) {
-    let draftText;
-    switch (variant) {
-      case 'A':
-        draftText = this.draftA;
-        break;
-      case 'B':
-        draftText = this.draftB;
-        break;
-      case 'D':
-        draftText = this.draftB;
-        break;
+  setVariantRating(variantCode, rating) {
+    if (variantCode === 'A') {
+      this.ratingA = rating;
+      return;
     }
+    if (variantCode === 'D') {
+      this.ratingD = rating;
+    }
+  }
+
+  @action
+  setVariantFeedback(variantCode, event) {
+    const value = event.target.value || '';
+    if (variantCode === 'A') {
+      this.feedbackA = value;
+      return;
+    }
+    if (variantCode === 'D') {
+      this.feedbackD = value;
+    }
+  }
+
+  @action
+  bringDownVariant(variantCode) {
+    const draftText = variantCode === 'A' ? this.draftA : this.draftB;
+    if (!draftText) {
+      return;
+    }
+
     if (this.args.onDraftSelected && draftText) {
       this.args.onDraftSelected(draftText);
     }

--- a/app/components/ai-variant-comparison.js
+++ b/app/components/ai-variant-comparison.js
@@ -20,6 +20,7 @@ export default class AiVariantComparisonComponent extends Component {
   @tracked feedbackD = '';
 
   @tracked loadingVariant = null; // Track which variant is currently loading
+  minFeedbackLength = 10;
 
   variants = [
     { code: 'A', displayLabel: 'A', label: 'Student work only' },
@@ -55,11 +56,37 @@ export default class AiVariantComparisonComponent extends Component {
   ];
 
   get canBringDownA() {
-    return Boolean(this.draftA);
+    return (
+      Boolean(this.draftA) &&
+      this.ratingA > 0 &&
+      this.feedbackA.trim().length >= this.minFeedbackLength
+    );
   }
 
   get canBringDownD() {
-    return Boolean(this.draftB);
+    return (
+      Boolean(this.draftB) &&
+      this.ratingD > 0 &&
+      this.feedbackD.trim().length >= this.minFeedbackLength
+    );
+  }
+
+  get bringDownTooltipA() {
+    if (!this.draftA) return 'Generate Variant A first';
+    if (this.ratingA <= 0) return 'Rate Variant A before bringing it down';
+    if (this.feedbackA.trim().length < this.minFeedbackLength) {
+      return `Add at least ${this.minFeedbackLength} characters of written feedback for Variant A`;
+    }
+    return 'Bring Variant A into the editor';
+  }
+
+  get bringDownTooltipB() {
+    if (!this.draftB) return 'Generate Variant B first';
+    if (this.ratingD <= 0) return 'Rate Variant B before bringing it down';
+    if (this.feedbackD.trim().length < this.minFeedbackLength) {
+      return `Add at least ${this.minFeedbackLength} characters of written feedback for Variant B`;
+    }
+    return 'Bring Variant B into the editor';
   }
 
   get ratingLabelA() {
@@ -170,13 +197,24 @@ export default class AiVariantComparisonComponent extends Component {
 
   @action
   bringDownVariant(variantCode) {
+    const canBringDown =
+      variantCode === 'A' ? this.canBringDownA : this.canBringDownD;
+    if (!canBringDown) {
+      return;
+    }
+
     const draftText = variantCode === 'A' ? this.draftA : this.draftB;
     if (!draftText) {
       return;
     }
 
     if (this.args.onDraftSelected && draftText) {
-      this.args.onDraftSelected(draftText);
+      this.args.onDraftSelected({
+        draftText,
+        variantKey: variantCode,
+        rating: variantCode === 'A' ? this.ratingA : this.ratingD,
+        writtenFeedback: variantCode === 'A' ? this.feedbackA : this.feedbackD,
+      });
     }
   }
 }

--- a/app/components/response-mentor-reply.hbs
+++ b/app/components/response-mentor-reply.hbs
@@ -9,6 +9,26 @@
       @workspace={{@workspace}}
       @onDraftSelected={{this.handleVariantDraftSelected}}
     />
+    <div class='ab-draft-editor-section'>
+      <p class='response-header'>Draft Editor</p>
+      <Ui::QuillContainer
+        @onEditorChange={{this.updateVariantComposeText}}
+        @startingText={{this.variantComposeText}}
+        @maxLength={{10000}}
+        @showErrors={{true}}
+        @emptyErrorMessage='Message body cannot be blank'
+      />
+      <div class='ab-draft-editor-actions'>
+        <button
+          type='button'
+          class='primary-button'
+          disabled={{not this.canSaveFinalEditVersion}}
+          {{on 'click' this.saveFinalEditVersion}}
+        >
+          {{this.saveFinalEditButtonText}}
+        </button>
+      </div>
+    </div>
     {{!-- END TEMPORARY A/B TEST CODE --}}
     {{!-- END TEMPORARY A/B TEST CODE --}}
     {{!-- END TEMPORARY A/B TEST CODE --}}

--- a/app/components/response-mentor-reply.js
+++ b/app/components/response-mentor-reply.js
@@ -26,6 +26,11 @@ export default class ResponseMentorReplyComponent extends Component {
   @tracked editingReplyId = null;
   @tracked aiGeneratedText = null;
   @tracked quillKey = 0;
+  @tracked variantComposeText = '';
+  @tracked isSavingFinalEdit = false;
+  @tracked finalEditSourceVariant = null;
+  @tracked finalEditRating = null;
+  @tracked finalEditFeedback = '';
 
   maxResponseLength = 14680064;
 
@@ -263,8 +268,41 @@ export default class ResponseMentorReplyComponent extends Component {
     );
   }
 
+  get canSaveFinalEditVersion() {
+    return (
+      Boolean(this.args.submission?.id) &&
+      !this.isSavingFinalEdit &&
+      !this._isEmptyEditorContent(this.quillText) &&
+      this.isValidQuillContent
+    );
+  }
+
+  get saveFinalEditButtonText() {
+    return this.isSavingFinalEdit ? 'Saving...' : 'Save Final Edit Version';
+  }
+
   _hasContentChanged(oldText, newText, oldNote, newNote) {
     return oldText !== newText || oldNote !== newNote;
+  }
+
+  _isEmptyEditorContent(content) {
+    if (!content) return true;
+
+    const normalized = content.replace(/\s+/g, '').toLowerCase();
+    return (
+      normalized === '' ||
+      normalized === '<p><br></p>' ||
+      normalized === '<div><br></div>' ||
+      normalized === '<p></p>'
+    );
+  }
+
+  _mergeDraftIntoEditor(existingContent, draftText) {
+    if (this._isEmptyEditorContent(existingContent)) {
+      return draftText;
+    }
+
+    return `${existingContent}<p><br></p>${draftText}`;
   }
 
   _startLoading() {
@@ -630,6 +668,72 @@ export default class ResponseMentorReplyComponent extends Component {
   }
 
   @action
+  updateVariantComposeText(content, isEmpty, isOverLengthLimit) {
+    // Keep variantComposeText as the seed value for Quill only.
+    // Quill emits onEditorChange during setup (did-insert); updating the same
+    // tracked field here triggers Ember's "updated after use" assertion.
+    this.updateQuillText(content, isEmpty, isOverLengthLimit);
+  }
+
+  @action
+  async saveFinalEditVersion() {
+    if (!this.canSaveFinalEditVersion) {
+      return;
+    }
+
+    const submissionId = this.args.submission?.id;
+    const savedAt = new Date();
+    const payload = {
+      aiFinalEditText: this.quillText,
+      aiFinalEditAt: savedAt,
+      aiFinalEditBy: this.currentUser.user?.id,
+      aiFinalEditSourceVariant: this.finalEditSourceVariant,
+      aiFinalEditRating: this.finalEditRating,
+      aiFinalEditFeedback: this.finalEditFeedback,
+    };
+
+    this.isSavingFinalEdit = true;
+    try {
+      const response = await fetch(`/api/submissions/${submissionId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({ submission: payload }),
+      });
+
+      if (!response.ok) {
+        const raw = await response.text();
+        throw new Error(raw || 'Failed to save final edit version');
+      }
+
+      this.args.submission.aiFinalEditText = payload.aiFinalEditText;
+      this.args.submission.aiFinalEditAt = payload.aiFinalEditAt;
+      this.args.submission.aiFinalEditSourceVariant =
+        payload.aiFinalEditSourceVariant;
+
+      this.alert.showToast(
+        'success',
+        'Final edit version saved',
+        'bottom-end',
+        2500,
+        false,
+        null
+      );
+    } catch (error) {
+      this.alert.showToast(
+        'error',
+        error.message || 'Failed to save final edit version',
+        'bottom-end',
+        5000,
+        false,
+        null
+      );
+    } finally {
+      this.isSavingFinalEdit = false;
+    }
+  }
+
+  @action
   cancelCompose() {
     this.editRevisionText = '';
     this.editRevisionNote = '';
@@ -654,9 +758,27 @@ export default class ResponseMentorReplyComponent extends Component {
   // TEMPORARY A/B TEST CODE - REMOVE AFTER TESTING PERIOD
   // TEMPORARY A/B TEST CODE - REMOVE AFTER TESTING PERIOD
   @action
-  handleVariantDraftSelected(draftText) {
-    // TEMPORARY A/B TEST CODE: Set the selected draft for the response-new editor
+  handleVariantDraftSelected(draftSelection) {
+    // TEMPORARY A/B TEST CODE: Set the selected draft for the in-place editor
+    const draftText =
+      typeof draftSelection === 'string'
+        ? draftSelection
+        : draftSelection?.draftText;
+    if (!draftText) {
+      return;
+    }
+
+    if (typeof draftSelection === 'object' && draftSelection !== null) {
+      this.finalEditSourceVariant = draftSelection.variantKey || null;
+      this.finalEditRating = draftSelection.rating ?? null;
+      this.finalEditFeedback = draftSelection.writtenFeedback || '';
+    }
+
     this.aiGeneratedText = draftText;
+    const existingContent = this.quillText || this.variantComposeText;
+    const mergedText = this._mergeDraftIntoEditor(existingContent, draftText);
+    this.variantComposeText = mergedText;
+    this.quillText = mergedText;
   }
   // END TEMPORARY A/B TEST CODE
   // END TEMPORARY A/B TEST CODE

--- a/app/models/submission.js
+++ b/app/models/submission.js
@@ -25,6 +25,11 @@ export default class SubmissionModel extends AuditableModel {
   @hasMany('response', { async: true }) responses;
   @hasMany('ai-variant', { async: true }) aiVariants;
   @attr() vmtRoomInfo;
+  @attr('string') aiFinalEditText;
+  @attr('date') aiFinalEditAt;
+  @attr('string') aiFinalEditSourceVariant;
+  @attr('number') aiFinalEditRating;
+  @attr('string') aiFinalEditFeedback;
 
   get folders() {
     let folders = [];

--- a/app/services/workspace-reports.js
+++ b/app/services/workspace-reports.js
@@ -62,8 +62,11 @@ export default class WorkspaceReportsService extends Service {
         if (!variantsBySubmission[submissionId]) {
           variantsBySubmission[submissionId] = {};
         }
-        variantsBySubmission[submissionId][variant.variantKey] =
-          variant.draftText;
+        // API returns newest-first; keep the first seen value per variant key.
+        if (variantsBySubmission[submissionId][variant.variantKey] == null) {
+          variantsBySubmission[submissionId][variant.variantKey] =
+            variant.draftText;
+        }
       });
 
       return variantsBySubmission;
@@ -241,6 +244,11 @@ export default class WorkspaceReportsService extends Service {
         'Number of Notice/Wonder/Feedback': model.workspace.commentsLength,
         'EnCoMPASS templated response': '',
         ...variantData, // Add AI variant columns
+        'AI Final Edit Version': this.stripHtml(submission.aiFinalEditText),
+        'AI Final Edit Source Variant': submission.aiFinalEditSourceVariant,
+        'AI Final Edit Rating': submission.aiFinalEditRating,
+        'AI Final Edit Feedback': this.stripHtml(submission.aiFinalEditFeedback),
+        'AI Final Edit Saved At': this.formatDateOrEmpty(submission.aiFinalEditAt),
       };
       const selections = submission
         .get('selections')
@@ -338,6 +346,12 @@ export default class WorkspaceReportsService extends Service {
       annotatorCreateDate,
     };
     return Object.assign({}, defaultSelection, selectorInfo);
+  }
+
+  formatDateOrEmpty(value) {
+    if (!value) return '';
+    const dateValue = value instanceof Date ? value : new Date(value);
+    return isValid(dateValue) ? format(dateValue, 'MM/dd/yyyy HH:mm') : '';
   }
 
   generateRevisionFields(submissionLabel, maxRevisions) {

--- a/app/styles/_ai-feedback-controls.scss
+++ b/app/styles/_ai-feedback-controls.scss
@@ -1,0 +1,133 @@
+.ai-feedback-controls {
+  margin-top: 0.75em;
+  padding-top: 0.75em;
+  border-top: 1px solid #90caf9;
+  display: flex;
+  align-items: center;
+  gap: 1em;
+}
+
+.ai-feedback-controls .star-rating-container {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5em;
+  margin-bottom: 0;
+}
+
+.ai-feedback-controls .star-rating-label {
+  font-weight: 500;
+  margin: 0;
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+.ai-feedback-controls .required-asterisk {
+  color: #d9534f;
+}
+
+.ai-feedback-controls .star-rating-stars {
+  display: flex;
+  gap: 0.3em;
+}
+
+.ai-feedback-controls .star-icon {
+  font-size: 24px;
+  cursor: pointer;
+  position: relative;
+}
+
+.ai-feedback-controls .star-icon.star-filled {
+  color: #f5af4e;
+}
+
+.ai-feedback-controls .star-icon.star-empty {
+  color: #ddd;
+}
+
+.ai-feedback-controls .star-icon:hover {
+  color: #f5af4e;
+}
+
+.ai-feedback-controls .star-icon:hover::after {
+  content: attr(title);
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 8px 12px;
+  background-color: #8bc34a;
+  color: white;
+  font-size: 13px;
+  white-space: nowrap;
+  border-radius: 4px;
+  margin-bottom: 5px;
+  z-index: 1000;
+  pointer-events: none;
+}
+
+.ai-feedback-controls .ai-feedback-container {
+  flex: 2 1 0;
+  max-width: none;
+  min-width: 0;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5em;
+  margin-bottom: 0;
+}
+
+.ai-feedback-controls .ai-feedback-label {
+  font-weight: 500;
+  margin: 0;
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+.ai-feedback-controls .variant-feedback-textarea {
+  min-height: 54px;
+  height: auto;
+  padding: 4px 8px;
+  font-size: 13px;
+  resize: vertical;
+  width: 100%;
+  max-width: none;
+  box-sizing: border-box;
+}
+
+.ai-feedback-controls .ai-bring-down-btn {
+  @extend .primary-button;
+  width: auto;
+  white-space: nowrap;
+}
+
+.ai-feedback-controls .ai-bring-down-btn:disabled {
+  background-color: #cccccc;
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.ai-feedback-controls .rating-value {
+  font-size: 12px;
+  color: #37474f;
+}
+
+@media (max-width: 768px) {
+  .ai-feedback-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .ai-feedback-controls .ai-feedback-container {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .ai-feedback-controls .ai-feedback-label {
+    white-space: normal;
+  }
+
+  .ai-feedback-controls .ai-bring-down-btn {
+    width: 100%;
+  }
+}

--- a/app/styles/_response-mentor-thread.scss
+++ b/app/styles/_response-mentor-thread.scss
@@ -171,6 +171,22 @@
     }
   }
 
+  .ab-draft-editor-section {
+    margin: 1em 0 1.5em 5em;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    padding: 1em;
+    background-color: #f8f8f8;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    max-width: calc(100% - 5em);
+  }
+
+  .ab-draft-editor-actions {
+    margin-top: 0.75em;
+    display: flex;
+    justify-content: flex-end;
+  }
+
   // AI Draft Section Styles(Read_Only)
   .ai-draft-section {
     margin-bottom: 1.5em;

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -75,6 +75,7 @@
 @import 'landing-page';
 @import 'terms';
 @import 'summary';
+@import 'ai-feedback-controls';
 // TEMPORARY A/B TEST STYLES - REMOVE AFTER TESTING PERIOD
 // TEMPORARY A/B TEST STYLES - REMOVE AFTER TESTING PERIOD
 // TEMPORARY A/B TEST STYLES - REMOVE AFTER TESTING PERIOD

--- a/app_server/datasource/api/aiApi.js
+++ b/app_server/datasource/api/aiApi.js
@@ -49,18 +49,15 @@ async function aiDraft(req, res, next) {
       workspace,
       user._id
     );
+    const requestId = `aiVariant_${Date.now()}_${Math.random()
+      .toString(36)
+      .slice(2, 8)}`;
 
     // Save variant to database for export/analysis
     try {
       const variantConfigData = variantConfig.activeVariants.find(
         (v) => v.key === variant
       );
-
-      const existingVariant = await models.AIVariant.findOne({
-        submission: target,
-        variantKey: variant,
-        isTrashed: false,
-      });
 
       const draftText =
         typeof draftResult === 'object' && draftResult?.draft
@@ -70,7 +67,7 @@ async function aiDraft(req, res, next) {
         console.warn(
           `[AI Variant] No active config found for variant ${variant}; skipping save`
         );
-      } else if (!existingVariant) {
+      } else {
         await models.AIVariant.create({
           submission: target,
           workspace: workspace,
@@ -78,13 +75,9 @@ async function aiDraft(req, res, next) {
           variantLabel: variantConfigData.label,
           inputType: variantConfigData.inputType,
           draftText: draftText,
+          requestId,
           createdBy: user._id,
         });
-      } else {
-        existingVariant.draftText = draftText;
-        existingVariant.lastModifiedDate = new Date();
-        existingVariant.lastModifiedBy = user._id;
-        await existingVariant.save();
       }
     } catch (saveError) {
       console.error('[AI Variant] Failed to save variant:', saveError);
@@ -99,6 +92,7 @@ async function aiDraft(req, res, next) {
       variant: variant,
       message: `AI draft generated for target submission: ${target}`,
       draft: draftText,
+      requestId,
     };
 
     return utils.sendResponse(res, response);

--- a/app_server/datasource/schemas/aiVariant.js
+++ b/app_server/datasource/schemas/aiVariant.js
@@ -37,6 +37,7 @@ var AIVariantSchema = new Schema(
     teacherNotes: { type: String }, // Teacher's notes about this variant
 
     // Technical metadata
+    requestId: { type: String },
     modelUsed: { type: String }, // e.g., 'claude-3-5-sonnet', 'gpt-4'
     tokensUsed: { type: Number },
     responseTime: { type: Number }, // milliseconds
@@ -46,7 +47,8 @@ var AIVariantSchema = new Schema(
 );
 
 // Indexes for efficient querying
-AIVariantSchema.index({ submission: 1, variantKey: 1 }, { unique: true }); // One variant per submission
+AIVariantSchema.index({ submission: 1, variantKey: 1, createDate: -1 }); // Keep full generation history
+AIVariantSchema.index({ requestId: 1 }); // Lookup by request id when debugging logs
 AIVariantSchema.index({ workspace: 1, createDate: -1 }); // For workspace reports
 AIVariantSchema.index({ createdBy: 1, createDate: -1 }); // For user analytics
 AIVariantSchema.index({ isSelected: 1 }); // For analyzing chosen variants

--- a/app_server/datasource/schemas/submission.js
+++ b/app_server/datasource/schemas/submission.js
@@ -47,6 +47,12 @@ var baseSubmission = {
   status: { type: String },
   pdSet: { type: String, default: 'default' },
   uploadedFile: { uploadedFileId: Number, savedFileName: String }, // This is from PoWs
+  aiFinalEditText: { type: String },
+  aiFinalEditAt: { type: Date },
+  aiFinalEditBy: { type: ObjectId, ref: 'User' },
+  aiFinalEditSourceVariant: { type: String },
+  aiFinalEditRating: { type: Number, min: 1, max: 5 },
+  aiFinalEditFeedback: { type: String },
 };
 
 /**


### PR DESCRIPTION
## Description
This PR improves the temporary A/B draft workflow by:
1. Preserving full A/B generation history (append-only, no overwrite).
2. Adding a shared Draft Editor save path (`Final Edit Version`) after bring-down.
3. Including final edited output fields in workspace report exports.

The final edit is stored once per submission (shared), regardless of whether the teacher used Variant A or Variant B.

---

## Changes

### Backend: A/B generation logging (append-only)
- `app_server/datasource/api/aiApi.js`
  - removed overwrite behavior for existing variant rows
  - now creates a new `AIVariant` row on each generate request
  - returns a `requestId` in `/api/aiDraft` response
- `app_server/datasource/schemas/aiVariant.js`
  - added `requestId` field
  - changed indexing to support history rows per submission+variant
  - added `requestId` index for trace/debug use

### Frontend: A/B bring-down gating + metadata handoff
- `app/components/ai-variant-comparison.js`
  - require draft + rating + min feedback before enabling Bring It Down
  - pass metadata payload on bring-down (`variantKey`, `rating`, `writtenFeedback`)
- `app/components/ai-variant-comparison.hbs`
  - tooltip guidance for disabled bring-down states

### Shared Draft Editor + final save action
- `app/components/response-mentor-reply.hbs`
  - added Draft Editor below A/B section
  - added **Save Final Edit Version** button
- `app/components/response-mentor-reply.js`
  - append brought-down draft into existing editor content (preserve existing text)
  - implemented `saveFinalEditVersion()` to persist final edited content to submission
  - stores source metadata from selected variant

### Submission model/schema for final edited output
- `app_server/datasource/schemas/submission.js`
  - added:
    - `aiFinalEditText`
    - `aiFinalEditAt`
    - `aiFinalEditBy`
    - `aiFinalEditSourceVariant`
    - `aiFinalEditRating`
    - `aiFinalEditFeedback`
- `app/models/submission.js`
  - added matching attrs for client/report access

### Workspace report export updates
- `app/services/workspace-reports.js`
  - added export columns:
    - `AI Final Edit Version`
    - `AI Final Edit Source Variant`
    - `AI Final Edit Rating`
    - `AI Final Edit Feedback`
    - `AI Final Edit Saved At`
  - adjusted variant aggregation for append-only rows (latest-per-variant handling)
  - added safe date formatting helper for export values

### Styling
- `app/styles/_response-mentor-thread.scss`
  - added styles for Draft Editor action row (`.ab-draft-editor-actions`)

---

## Behavior After This PR
- Repeated A/B generation creates multiple rows in `aivariants` (history kept).
- Bring It Down requires rating + feedback first.
- Bring It Down appends into shared editor (does not replace existing content).
- Teacher can save one shared final edited version per submission.
- Workspace report includes both A/B draft columns and final edited output columns.

---

## Test
Manual:
    1. Open mentor reply create flow with A/B section.
    2. Generate A and B multiple times.
    3. Confirm multiple `aivariants` rows are created (no overwrite).
    4. Try Bring It Down without rating/feedback (should stay disabled).
    5. Add rating + feedback, then Bring It Down.
    6. Edit text in Draft Editor and click **Save Final Edit Version**.
    7. Verify submission now has `aiFinalEdit*` fields(Mongo)
    8. Export workspace report and verify new final edit columns are populated.