### PR TITLE
Feat/ab draft formatting and metadata

### DIFF
--- a/app/components/ai-variant-comparison.hbs
+++ b/app/components/ai-variant-comparison.hbs
@@ -1,6 +1,4 @@
 {{!-- TEMPORARY A/B TEST CODE - REMOVE AFTER TESTING PERIOD --}}
-{{!-- TEMPORARY A/B TEST CODE - REMOVE AFTER TESTING PERIOD --}}
-{{!-- TEMPORARY A/B TEST CODE - REMOVE AFTER TESTING PERIOD --}}
 <div class="ai-variant-comparison">
   <div class="ab-test-notice">
     <div class="ab-test-header">

--- a/app/components/ai-variant-comparison.hbs
+++ b/app/components/ai-variant-comparison.hbs
@@ -10,7 +10,7 @@
     </div>
   </div>
   
-  <!-- A/B TEST BOUNDARY MARKERS -->
+  {{!-- A/B TEST BOUNDARY MARKERS --}}
   <div class="ab-test-boundary">
     <div class="ab-test-begin-marker">▶▶▶ BEGIN A/B TEST ◀◀◀</div>
   </div>
@@ -56,6 +56,12 @@
         </div>
         <button
           type="button"
+          class="ai-log-review-btn"
+          disabled={{not this.canLogReviewA}}
+          {{on "click" (fn this.logVariantReview 'A')}}
+        >{{this.logReviewButtonTextA}}</button>
+        <button
+          type="button"
           class="ai-bring-down-btn"
           disabled={{not this.canBringDownA}}
           title={{this.bringDownTooltipA}}
@@ -97,6 +103,12 @@
         </div>
         <button
           type="button"
+          class="ai-log-review-btn"
+          disabled={{not this.canLogReviewD}}
+          {{on "click" (fn this.logVariantReview 'D')}}
+        >{{this.logReviewButtonTextB}}</button>
+        <button
+          type="button"
           class="ai-bring-down-btn"
           disabled={{not this.canBringDownD}}
           title={{this.bringDownTooltipB}}
@@ -106,7 +118,7 @@
     </div>
   </div>
   
-  <!-- A/B TEST BOUNDARY MARKERS -->
+  {{!-- A/B TEST BOUNDARY MARKERS --}}
   <div class="ab-test-boundary">
     <div class="ab-test-end-marker">▶▶▶ END A/B TEST ◀◀◀</div>
   </div>

--- a/app/components/ai-variant-comparison.js
+++ b/app/components/ai-variant-comparison.js
@@ -1,6 +1,4 @@
 // TEMPORARY A/B TEST CODE - REMOVE AFTER TESTING PERIOD
-// TEMPORARY A/B TEST CODE - REMOVE AFTER TESTING PERIOD
-// TEMPORARY A/B TEST CODE - REMOVE AFTER TESTING PERIOD
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
@@ -14,6 +12,10 @@ export default class AiVariantComparisonComponent extends Component {
 
   @tracked draftA = null;
   @tracked draftB = null;
+  @tracked variantLogIdA = null;
+  @tracked variantLogIdD = null;
+  @tracked requestIdA = null;
+  @tracked requestIdD = null;
   @tracked ratingA = 0;
   @tracked ratingD = 0;
   @tracked feedbackA = '';
@@ -113,18 +115,23 @@ export default class AiVariantComparisonComponent extends Component {
       const result = await this.aiDraft.generateDraft(
         submission.id,
         variantCode,
-        workspaceId
+        workspaceId,
+        { includeMeta: true }
       );
 
       // Set the appropriate tracked property
       switch (variantCode) {
         case 'A':
-          this.draftA = result;
+          this.draftA = result.draft;
+          this.variantLogIdA = result.variantLogId;
+          this.requestIdA = result.requestId;
           this.ratingA = 0;
           this.feedbackA = '';
           break;
         case 'D':
-          this.draftB = result;
+          this.draftB = result.draft;
+          this.variantLogIdD = result.variantLogId;
+          this.requestIdD = result.requestId;
           this.ratingD = 0;
           this.feedbackD = '';
           break;
@@ -149,17 +156,33 @@ export default class AiVariantComparisonComponent extends Component {
             const result = await this.aiDraft.generateDraft(
               submission.id,
               v.code,
-              workspaceId
+              workspaceId,
+              { includeMeta: true }
             );
-            return result;
+            return { variantCode: v.code, result };
           } catch (error) {
             console.error(`Error generating variant ${v.code}:`, error);
-            return `Error: ${error.message}`;
+            return { variantCode: v.code, error: error.message };
           }
         })
       );
-      this.draftA = results[0];
-      this.draftB = results[1];
+
+      results.forEach(({ variantCode, result, error }) => {
+        const draftText = error ? `Error: ${error}` : result?.draft;
+        const variantLogId = result?.variantLogId || null;
+        const requestId = result?.requestId || null;
+
+        if (variantCode === 'A') {
+          this.draftA = draftText;
+          this.variantLogIdA = variantLogId;
+          this.requestIdA = requestId;
+        } else if (variantCode === 'D') {
+          this.draftB = draftText;
+          this.variantLogIdD = variantLogId;
+          this.requestIdD = requestId;
+        }
+      });
+
       this.ratingA = 0;
       this.ratingD = 0;
       this.feedbackA = '';
@@ -214,6 +237,9 @@ export default class AiVariantComparisonComponent extends Component {
         variantKey: variantCode,
         rating: variantCode === 'A' ? this.ratingA : this.ratingD,
         writtenFeedback: variantCode === 'A' ? this.feedbackA : this.feedbackD,
+        variantLogId:
+          variantCode === 'A' ? this.variantLogIdA : this.variantLogIdD,
+        requestId: variantCode === 'A' ? this.requestIdA : this.requestIdD,
       });
     }
   }

--- a/app/components/ai-variant-comparison.js
+++ b/app/components/ai-variant-comparison.js
@@ -16,6 +16,10 @@ export default class AiVariantComparisonComponent extends Component {
   @tracked variantLogIdD = null;
   @tracked requestIdA = null;
   @tracked requestIdD = null;
+  @tracked isReviewLoggedA = false;
+  @tracked isReviewLoggedD = false;
+  @tracked isLoggingReviewA = false;
+  @tracked isLoggingReviewD = false;
   @tracked ratingA = 0;
   @tracked ratingD = 0;
   @tracked feedbackA = '';
@@ -57,36 +61,107 @@ export default class AiVariantComparisonComponent extends Component {
     { value: 5, tooltip: 'Excellent: Very useful, clear, and actionable' },
   ];
 
-  get canBringDownA() {
+  _forVariant(variantCode, valueA, valueD) {
+    return variantCode === 'A' ? valueA : valueD;
+  }
+
+  _setReviewLogged(variantCode, value) {
+    if (variantCode === 'A') {
+      this.isReviewLoggedA = value;
+      return;
+    }
+    this.isReviewLoggedD = value;
+  }
+
+  _setLoggingReview(variantCode, value) {
+    if (variantCode === 'A') {
+      this.isLoggingReviewA = value;
+      return;
+    }
+    this.isLoggingReviewD = value;
+  }
+
+  _resetReviewInputs(variantCode) {
+    this._setReviewLogged(variantCode, false);
+    if (variantCode === 'A') {
+      this.ratingA = 0;
+      this.feedbackA = '';
+      return;
+    }
+    this.ratingD = 0;
+    this.feedbackD = '';
+  }
+
+  _applyGeneratedVariant(variantCode, draftText, variantLogId, requestId) {
+    if (variantCode === 'A') {
+      this.draftA = draftText;
+      this.variantLogIdA = variantLogId;
+      this.requestIdA = requestId;
+    } else {
+      this.draftB = draftText;
+      this.variantLogIdD = variantLogId;
+      this.requestIdD = requestId;
+    }
+    this._resetReviewInputs(variantCode);
+  }
+
+  _canLogReview(variantCode) {
+    const draft = this._forVariant(variantCode, this.draftA, this.draftB);
+    const rating = this._forVariant(variantCode, this.ratingA, this.ratingD);
+    const feedback = this._forVariant(
+      variantCode,
+      this.feedbackA,
+      this.feedbackD
+    );
+    const isLogging = this._forVariant(
+      variantCode,
+      this.isLoggingReviewA,
+      this.isLoggingReviewD
+    );
     return (
-      Boolean(this.draftA) &&
-      this.ratingA > 0 &&
-      this.feedbackA.trim().length >= this.minFeedbackLength
+      Boolean(draft) &&
+      rating > 0 &&
+      feedback.trim().length >= this.minFeedbackLength &&
+      !isLogging
     );
   }
 
+  get canBringDownA() {
+    return Boolean(this.draftA) && this.isReviewLoggedA;
+  }
+
   get canBringDownD() {
-    return (
-      Boolean(this.draftB) &&
-      this.ratingD > 0 &&
-      this.feedbackD.trim().length >= this.minFeedbackLength
-    );
+    return Boolean(this.draftB) && this.isReviewLoggedD;
+  }
+
+  get canLogReviewA() {
+    return this._canLogReview('A');
+  }
+
+  get canLogReviewD() {
+    return this._canLogReview('D');
   }
 
   get bringDownTooltipA() {
     if (!this.draftA) return 'Generate Variant A first';
-    if (this.ratingA <= 0) return 'Rate Variant A before bringing it down';
+    if (this.ratingA <= 0) return 'Rate Variant A before logging review';
     if (this.feedbackA.trim().length < this.minFeedbackLength) {
       return `Add at least ${this.minFeedbackLength} characters of written feedback for Variant A`;
+    }
+    if (!this.isReviewLoggedA) {
+      return 'Log review for Variant A before bringing it down';
     }
     return 'Bring Variant A into the editor';
   }
 
   get bringDownTooltipB() {
     if (!this.draftB) return 'Generate Variant B first';
-    if (this.ratingD <= 0) return 'Rate Variant B before bringing it down';
+    if (this.ratingD <= 0) return 'Rate Variant B before logging review';
     if (this.feedbackD.trim().length < this.minFeedbackLength) {
       return `Add at least ${this.minFeedbackLength} characters of written feedback for Variant B`;
+    }
+    if (!this.isReviewLoggedD) {
+      return 'Log review for Variant B before bringing it down';
     }
     return 'Bring Variant B into the editor';
   }
@@ -97,6 +172,14 @@ export default class AiVariantComparisonComponent extends Component {
 
   get ratingLabelB() {
     return this.ratingD > 0 ? `${this.ratingD} / 5` : 'No rating yet';
+  }
+
+  get logReviewButtonTextA() {
+    return this.isLoggingReviewA ? 'Logging...' : 'Log Review';
+  }
+
+  get logReviewButtonTextB() {
+    return this.isLoggingReviewD ? 'Logging...' : 'Log Review';
   }
 
   @action
@@ -120,22 +203,12 @@ export default class AiVariantComparisonComponent extends Component {
       );
 
       // Set the appropriate tracked property
-      switch (variantCode) {
-        case 'A':
-          this.draftA = result.draft;
-          this.variantLogIdA = result.variantLogId;
-          this.requestIdA = result.requestId;
-          this.ratingA = 0;
-          this.feedbackA = '';
-          break;
-        case 'D':
-          this.draftB = result.draft;
-          this.variantLogIdD = result.variantLogId;
-          this.requestIdD = result.requestId;
-          this.ratingD = 0;
-          this.feedbackD = '';
-          break;
-      }
+      this._applyGeneratedVariant(
+        variantCode,
+        result.draft,
+        result.variantLogId || null,
+        result.requestId || null
+      );
     } catch (error) {
       console.error(`Error generating variant ${variantCode}:`, error);
       this.error = `Failed to generate variant ${variantCode}: ${error.message}`;
@@ -171,22 +244,13 @@ export default class AiVariantComparisonComponent extends Component {
         const draftText = error ? `Error: ${error}` : result?.draft;
         const variantLogId = result?.variantLogId || null;
         const requestId = result?.requestId || null;
-
-        if (variantCode === 'A') {
-          this.draftA = draftText;
-          this.variantLogIdA = variantLogId;
-          this.requestIdA = requestId;
-        } else if (variantCode === 'D') {
-          this.draftB = draftText;
-          this.variantLogIdD = variantLogId;
-          this.requestIdD = requestId;
-        }
+        this._applyGeneratedVariant(
+          variantCode,
+          draftText,
+          variantLogId,
+          requestId
+        );
       });
-
-      this.ratingA = 0;
-      this.ratingD = 0;
-      this.feedbackA = '';
-      this.feedbackD = '';
     } catch (e) {
       console.error('Overall error:', e);
       this.error = e.message || 'Failed to generate drafts';
@@ -199,10 +263,12 @@ export default class AiVariantComparisonComponent extends Component {
   setVariantRating(variantCode, rating) {
     if (variantCode === 'A') {
       this.ratingA = rating;
+      this._setReviewLogged(variantCode, false);
       return;
     }
     if (variantCode === 'D') {
       this.ratingD = rating;
+      this._setReviewLogged(variantCode, false);
     }
   }
 
@@ -211,10 +277,71 @@ export default class AiVariantComparisonComponent extends Component {
     const value = event.target.value || '';
     if (variantCode === 'A') {
       this.feedbackA = value;
+      this._setReviewLogged(variantCode, false);
       return;
     }
     if (variantCode === 'D') {
       this.feedbackD = value;
+      this._setReviewLogged(variantCode, false);
+    }
+  }
+
+  @action
+  async logVariantReview(variantCode) {
+    const rating = this._forVariant(variantCode, this.ratingA, this.ratingD);
+    const feedback = this._forVariant(
+      variantCode,
+      this.feedbackA,
+      this.feedbackD
+    );
+    const variantLogId = this._forVariant(
+      variantCode,
+      this.variantLogIdA,
+      this.variantLogIdD
+    );
+
+    if (rating <= 0 || feedback.trim().length < this.minFeedbackLength) {
+      return;
+    }
+
+    if (!variantLogId) {
+      this.error = `Variant ${variantCode} review could not be logged because variantLogId is missing. Generate the variant again and retry.`;
+      return;
+    }
+
+    this._setLoggingReview(variantCode, true);
+    this.error = null;
+    try {
+      const response = await fetch(`/api/aiVariants/${variantLogId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({
+          aiVariant: {
+            rating,
+            teacherNotes: feedback,
+          },
+        }),
+      });
+
+      if (!response.ok) {
+        let errMessage = `Failed to log review for variant ${variantCode}`;
+        try {
+          const parsed = await response.json();
+          errMessage = parsed.message || parsed.error || errMessage;
+        } catch (e) {
+          // Best-effort parse only; keep default message.
+        }
+        throw new Error(errMessage);
+      }
+
+      this._setReviewLogged(variantCode, true);
+    } catch (error) {
+      console.error(`Error logging review for variant ${variantCode}:`, error);
+      this.error =
+        error.message || `Failed to log review for variant ${variantCode}`;
+    } finally {
+      this._setLoggingReview(variantCode, false);
     }
   }
 
@@ -235,11 +362,16 @@ export default class AiVariantComparisonComponent extends Component {
       this.args.onDraftSelected({
         draftText,
         variantKey: variantCode,
-        rating: variantCode === 'A' ? this.ratingA : this.ratingD,
-        writtenFeedback: variantCode === 'A' ? this.feedbackA : this.feedbackD,
-        variantLogId:
-          variantCode === 'A' ? this.variantLogIdA : this.variantLogIdD,
-        requestId: variantCode === 'A' ? this.requestIdA : this.requestIdD,
+        variantLogId: this._forVariant(
+          variantCode,
+          this.variantLogIdA,
+          this.variantLogIdD
+        ),
+        requestId: this._forVariant(
+          variantCode,
+          this.requestIdA,
+          this.requestIdD
+        ),
       });
     }
   }

--- a/app/components/response-mentor-reply.hbs
+++ b/app/components/response-mentor-reply.hbs
@@ -2,8 +2,6 @@
 {{#unless @isOlderRevision}}
   {{#if @isCreating}}
     {{!-- TEMPORARY A/B TEST CODE - REMOVE AFTER TESTING PERIOD --}}
-    {{!-- TEMPORARY A/B TEST CODE - REMOVE AFTER TESTING PERIOD --}}
-    {{!-- TEMPORARY A/B TEST CODE - REMOVE AFTER TESTING PERIOD --}}
     <AiVariantComparison
       @submission={{@submission}}
       @workspace={{@workspace}}
@@ -29,8 +27,6 @@
         </button>
       </div>
     </div>
-    {{!-- END TEMPORARY A/B TEST CODE --}}
-    {{!-- END TEMPORARY A/B TEST CODE --}}
     {{!-- END TEMPORARY A/B TEST CODE --}}
     {{!-- Temporarily hidden: new response area below A/B testing --}}
     {{!--

--- a/app/components/response-mentor-reply.js
+++ b/app/components/response-mentor-reply.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import DOMPurify from 'dompurify';
 
 export default class ResponseMentorReplyComponent extends Component {
   @service('sweet-alert') alert;
@@ -297,12 +298,56 @@ export default class ResponseMentorReplyComponent extends Component {
     );
   }
 
-  _mergeDraftIntoEditor(existingContent, draftText) {
+  _headlineForVariant(variantKey) {
+    if (variantKey === 'A') return 'Variant A';
+    if (variantKey === 'D') return 'Variant B';
+    return 'AI Draft';
+  }
+
+  _withDraftHeadline(draftText, variantKey = null) {
+    const headline = this._headlineForVariant(variantKey);
+    return `<p><strong>${headline}</strong></p><p><br></p>${draftText}`;
+  }
+
+  _mergeDraftIntoEditor(existingContent, draftText, variantKey = null) {
+    const block = this._withDraftHeadline(draftText, variantKey);
     if (this._isEmptyEditorContent(existingContent)) {
-      return draftText;
+      return block;
     }
 
-    return `${existingContent}<p><br></p>${draftText}`;
+    return `${existingContent}<p><br></p>${block}`;
+  }
+
+  _escapeDraftLine(text) {
+    return String(text)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/ {2,}/g, (spaces) => '&nbsp;'.repeat(spaces.length));
+  }
+
+  _prepareDraftForEditor(draftText) {
+    if (!draftText) return '';
+    const raw = String(draftText);
+
+    // Preserve existing HTML drafts, but sanitize before inserting.
+    if (/<\/?[a-z][\s\S]*>/i.test(raw)) {
+      return DOMPurify.sanitize(raw);
+    }
+
+    // Plain text path: preserve each input line as its own paragraph so Quill
+    // does not collapse lines or drop metadata/list lines on append.
+    const lines = raw.replace(/\r\n/g, '\n').split('\n');
+    const html = lines
+      .map((line) => {
+        if (line.trim() === '') {
+          return '<p><br></p>';
+        }
+        return `<p>${this._escapeDraftLine(line)}</p>`;
+      })
+      .join('');
+
+    return html;
   }
 
   _startLoading() {
@@ -755,8 +800,6 @@ export default class ResponseMentorReplyComponent extends Component {
   }
 
   // TEMPORARY A/B TEST CODE - REMOVE AFTER TESTING PERIOD
-  // TEMPORARY A/B TEST CODE - REMOVE AFTER TESTING PERIOD
-  // TEMPORARY A/B TEST CODE - REMOVE AFTER TESTING PERIOD
   @action
   handleVariantDraftSelected(draftSelection) {
     // TEMPORARY A/B TEST CODE: Set the selected draft for the in-place editor
@@ -774,13 +817,16 @@ export default class ResponseMentorReplyComponent extends Component {
       this.finalEditFeedback = draftSelection.writtenFeedback || '';
     }
 
-    this.aiGeneratedText = draftText;
+    const preparedDraft = this._prepareDraftForEditor(draftText);
+    this.aiGeneratedText = preparedDraft;
     const existingContent = this.quillText || this.variantComposeText;
-    const mergedText = this._mergeDraftIntoEditor(existingContent, draftText);
+    const mergedText = this._mergeDraftIntoEditor(
+      existingContent,
+      preparedDraft,
+      draftSelection?.variantKey
+    );
     this.variantComposeText = mergedText;
     this.quillText = mergedText;
   }
-  // END TEMPORARY A/B TEST CODE
-  // END TEMPORARY A/B TEST CODE
   // END TEMPORARY A/B TEST CODE
 }

--- a/app/components/response-mentor-reply.js
+++ b/app/components/response-mentor-reply.js
@@ -29,9 +29,9 @@ export default class ResponseMentorReplyComponent extends Component {
   @tracked quillKey = 0;
   @tracked variantComposeText = '';
   @tracked isSavingFinalEdit = false;
-  @tracked finalEditSourceVariant = null;
-  @tracked finalEditRating = null;
-  @tracked finalEditFeedback = '';
+  @tracked latestBroughtDownVariantLogId = null;
+  @tracked latestBroughtDownRequestId = null;
+  @tracked latestBroughtDownVariantKey = null;
 
   maxResponseLength = 14680064;
 
@@ -728,13 +728,20 @@ export default class ResponseMentorReplyComponent extends Component {
 
     const submissionId = this.args.submission?.id;
     const savedAt = new Date();
+    const savedBy = this.currentUser.user?.id || null;
+    const appendedVersion = {
+      text: this.quillText,
+      savedAt,
+      savedBy,
+      sourceVariantLogId: this.latestBroughtDownVariantLogId,
+      sourceRequestId: this.latestBroughtDownRequestId,
+      sourceVariantKey: this.latestBroughtDownVariantKey,
+    };
     const payload = {
       aiFinalEditText: this.quillText,
       aiFinalEditAt: savedAt,
-      aiFinalEditBy: this.currentUser.user?.id,
-      aiFinalEditSourceVariant: this.finalEditSourceVariant,
-      aiFinalEditRating: this.finalEditRating,
-      aiFinalEditFeedback: this.finalEditFeedback,
+      aiFinalEditBy: savedBy,
+      appendAiFinalEditVersion: appendedVersion,
     };
 
     this.isSavingFinalEdit = true;
@@ -753,8 +760,13 @@ export default class ResponseMentorReplyComponent extends Component {
 
       this.args.submission.aiFinalEditText = payload.aiFinalEditText;
       this.args.submission.aiFinalEditAt = payload.aiFinalEditAt;
-      this.args.submission.aiFinalEditSourceVariant =
-        payload.aiFinalEditSourceVariant;
+      this.args.submission.aiFinalEditBy = payload.aiFinalEditBy;
+      const existingRawVersions = this.args.submission.aiFinalEditVersions;
+      const existingVersions = Array.isArray(existingRawVersions)
+        ? existingRawVersions
+        : existingRawVersions?.toArray?.() || [];
+      this.args.submission.aiFinalEditVersions =
+        existingVersions.concat(appendedVersion);
 
       this.alert.showToast(
         'success',
@@ -812,9 +824,9 @@ export default class ResponseMentorReplyComponent extends Component {
     }
 
     if (typeof draftSelection === 'object' && draftSelection !== null) {
-      this.finalEditSourceVariant = draftSelection.variantKey || null;
-      this.finalEditRating = draftSelection.rating ?? null;
-      this.finalEditFeedback = draftSelection.writtenFeedback || '';
+      this.latestBroughtDownVariantLogId = draftSelection.variantLogId || null;
+      this.latestBroughtDownRequestId = draftSelection.requestId || null;
+      this.latestBroughtDownVariantKey = draftSelection.variantKey || null;
     }
 
     const preparedDraft = this._prepareDraftForEditor(draftText);

--- a/app/models/submission.js
+++ b/app/models/submission.js
@@ -1,5 +1,4 @@
 import { attr, belongsTo, hasMany } from '@ember-data/model';
-import { format } from 'date-fns';
 import AuditableModel from './auditable';
 
 export default class SubmissionModel extends AuditableModel {
@@ -27,9 +26,8 @@ export default class SubmissionModel extends AuditableModel {
   @attr() vmtRoomInfo;
   @attr('string') aiFinalEditText;
   @attr('date') aiFinalEditAt;
-  @attr('string') aiFinalEditSourceVariant;
-  @attr('number') aiFinalEditRating;
-  @attr('string') aiFinalEditFeedback;
+  @attr() aiFinalEditBy;
+  @attr() aiFinalEditVersions;
 
   get folders() {
     let folders = [];

--- a/app/services/ai-draft.js
+++ b/app/services/ai-draft.js
@@ -57,7 +57,13 @@ export default class AiDraftService extends Service {
    * @returns {Promise<String>} HTML string containing the generated draft
    * @throws {Error} If API call fails or no content is received
    */
-  async generateDraft(submissionId, variant = 'A', workspaceId = null) {
+  async generateDraft(
+    submissionId,
+    variant = 'A',
+    workspaceId = null,
+    options = {}
+  ) {
+    const includeMeta = Boolean(options.includeMeta);
     const params = new URLSearchParams({
       target: submissionId,
       variant,
@@ -94,6 +100,15 @@ export default class AiDraftService extends Service {
     }
     if (!data || !data.draft) {
       throw new Error('No content received');
+    }
+
+    if (includeMeta) {
+      return {
+        draft: data.draft,
+        requestId: data.requestId || null,
+        variantLogId: data.variantLogId || null,
+        variant: data.variant || variant,
+      };
     }
 
     return data.draft;

--- a/app/services/workspace-reports.js
+++ b/app/services/workspace-reports.js
@@ -27,14 +27,22 @@ export default class WorkspaceReportsService extends Service {
     return Array.from(folderNames);
   }
 
-  getAiVariantData(submission) {
-    // Variants will be fetched separately and passed in
-    // This is just a placeholder that returns empty columns
-    const variantData = {};
-    ['A', 'B'].forEach((key) => {
-      variantData[`AI Variant ${key}`] = '';
-    });
-    return variantData;
+  toArray(value) {
+    if (Array.isArray(value)) return value;
+    return value?.toArray?.() || [];
+  }
+
+  normalizeObjectId(value) {
+    if (!value) return '';
+    if (typeof value === 'string') return value;
+    if (typeof value === 'object') {
+      if (value._id) return this.normalizeObjectId(value._id);
+      if (value.id) return String(value.id);
+      if (value.toString && value.toString !== Object.prototype.toString) {
+        return String(value.toString());
+      }
+    }
+    return String(value);
   }
 
   async fetchVariantsForSubmissions(submissions) {
@@ -55,18 +63,17 @@ export default class WorkspaceReportsService extends Service {
 
       const data = await response.json();
 
-      // Group variants by submission ID
+      // Group variants by submission ID and variant key (newest -> oldest).
       const variantsBySubmission = {};
       (data.variants || []).forEach((variant) => {
         const submissionId = variant.submission._id || variant.submission;
         if (!variantsBySubmission[submissionId]) {
           variantsBySubmission[submissionId] = {};
         }
-        // API returns newest-first; keep the first seen value per variant key.
         if (variantsBySubmission[submissionId][variant.variantKey] == null) {
-          variantsBySubmission[submissionId][variant.variantKey] =
-            variant.draftText;
+          variantsBySubmission[submissionId][variant.variantKey] = [];
         }
+        variantsBySubmission[submissionId][variant.variantKey].push(variant);
       });
 
       return variantsBySubmission;
@@ -208,17 +215,132 @@ export default class WorkspaceReportsService extends Service {
     // Generate CSV data with dynamic columns for selections
     const data = labeledSubmissions.flatMap((submission) => {
       const submissionVariants = variantsBySubmission[submission.id] || {};
+      const variantARows = this.toArray(submissionVariants['A']);
+      const variantDRows = this.toArray(submissionVariants['D']);
+      const legacyVariantBRows = this.toArray(submissionVariants['B']);
+      const variantBRows = variantDRows.length
+        ? variantDRows
+        : legacyVariantBRows;
 
-      const variantData = {
-        'AI Variant A (Student Work Only)': this.stripHtml(
-          submissionVariants['A'] || ''
-        ),
-        'AI Variant B (Work + Selections + Comments)': this.stripHtml(
-          submissionVariants['D'] || submissionVariants['B'] || ''
-        ),
+      const finalEditVersions = this.toArray(submission.aiFinalEditVersions);
+      const finalEditRows = finalEditVersions.length
+        ? finalEditVersions.slice().reverse()
+        : submission.aiFinalEditText || submission.aiFinalEditAt
+        ? [
+            {
+              text: submission.aiFinalEditText,
+              savedAt: submission.aiFinalEditAt,
+            },
+          ]
+        : [];
+
+      const emptyAiData = {
+        'AI Variant A (Student Work Only)': '',
+        'AI Variant A Rating': '',
+        'AI Variant A Feedback': '',
+        'AI Variant B (Work + Selections + Comments)': '',
+        'AI Variant B Rating': '',
+        'AI Variant B Feedback': '',
+        'AI Final Edit Version': '',
+        'AI Final Edit Saved At': '',
       };
 
-      const baseData = {
+      const variantAiRows = Array.from(
+        { length: Math.max(variantARows.length, variantBRows.length, 1) },
+        (_, index) => {
+          const variantA = variantARows[index] || null;
+          const variantB = variantBRows[index] || null;
+
+          return {
+            'AI Variant A (Student Work Only)': this.stripHtml(
+              variantA?.draftText || ''
+            ),
+            'AI Variant A Rating': variantA?.rating ?? '',
+            'AI Variant A Feedback': this.stripHtml(
+              variantA?.teacherNotes || ''
+            ),
+            'AI Variant B (Work + Selections + Comments)': this.stripHtml(
+              variantB?.draftText || ''
+            ),
+            'AI Variant B Rating': variantB?.rating ?? '',
+            'AI Variant B Feedback': this.stripHtml(
+              variantB?.teacherNotes || ''
+            ),
+            'AI Final Edit Version': '',
+            'AI Final Edit Saved At': '',
+          };
+        }
+      );
+
+      const aiRows = variantAiRows.map((row) => ({ ...row }));
+      const variantRowIndexByLogId = new Map();
+      variantARows.forEach((row, index) => {
+        const key = this.normalizeObjectId(row?._id);
+        if (key) {
+          variantRowIndexByLogId.set(key, index);
+        }
+      });
+      variantBRows.forEach((row, index) => {
+        const key = this.normalizeObjectId(row?._id);
+        if (key && !variantRowIndexByLogId.has(key)) {
+          variantRowIndexByLogId.set(key, index);
+        }
+      });
+
+      const overflowAiRows = [];
+      finalEditRows.forEach((finalEdit) => {
+        const finalEditData = {
+          'AI Final Edit Version': this.stripHtml(finalEdit?.text || ''),
+          'AI Final Edit Saved At': this.formatDateOrEmpty(finalEdit?.savedAt),
+        };
+        if (
+          !finalEditData['AI Final Edit Version'] &&
+          !finalEditData['AI Final Edit Saved At']
+        ) {
+          return;
+        }
+
+        const sourceVariantLogId = this.normalizeObjectId(
+          finalEdit?.sourceVariantLogId
+        );
+        const associatedIndex =
+          sourceVariantLogId && variantRowIndexByLogId.has(sourceVariantLogId)
+            ? variantRowIndexByLogId.get(sourceVariantLogId)
+            : null;
+
+        if (
+          associatedIndex != null &&
+          !aiRows[associatedIndex]['AI Final Edit Version'] &&
+          !aiRows[associatedIndex]['AI Final Edit Saved At']
+        ) {
+          aiRows[associatedIndex] = {
+            ...aiRows[associatedIndex],
+            ...finalEditData,
+          };
+          return;
+        }
+
+        if (associatedIndex != null) {
+          overflowAiRows.push({
+            ...variantAiRows[associatedIndex],
+            ...finalEditData,
+          });
+          return;
+        }
+
+        overflowAiRows.push({
+          ...emptyAiData,
+          ...finalEditData,
+        });
+      });
+
+      if (!aiRows.length && !overflowAiRows.length) {
+        aiRows.push({ ...emptyAiData });
+      }
+
+      const combinedAiRows = aiRows.concat(overflowAiRows);
+
+      const staticData = {
         'Name of workspace': submission.get('workspaces.firstObject.name'),
         'Workspace URL': window.location.href,
         'Workspace Owner': model.workspace.get('owner.username'),
@@ -243,64 +365,71 @@ export default class WorkspaceReportsService extends Service {
         'Number of Workspace Folders': model.workspace.foldersLength,
         'Number of Notice/Wonder/Feedback': model.workspace.commentsLength,
         'EnCoMPASS templated response': '',
-        ...variantData, // Add AI variant columns
-        'AI Final Edit Version': this.stripHtml(submission.aiFinalEditText),
-        'AI Final Edit Source Variant': submission.aiFinalEditSourceVariant,
-        'AI Final Edit Rating': submission.aiFinalEditRating,
-        'AI Final Edit Feedback': this.stripHtml(submission.aiFinalEditFeedback),
-        'AI Final Edit Saved At': this.formatDateOrEmpty(submission.aiFinalEditAt),
       };
       const selections = submission
         .get('selections')
         .filterBy('isTrashed', false)
         .slice();
-      if (selections.length === 0) {
-        // For submissions without selections, return the base data only
-        return [baseData];
-      } else {
-        // For submissions with selections, add one row per annotation/comment.
-        return selections.flatMap((selection) => {
-          const selectorInfo = this.createSelectorInfo(selection);
-          const folders = this.getUniqueFolderNames(selection).join('; ');
-          const comments = (selection.get('comments') || []).filterBy(
-            'isTrashed',
-            false
-          );
+      const selectionRows =
+        selections.length === 0
+          ? [{}]
+          : selections.flatMap((selection) => {
+              const selectorInfo = this.createSelectorInfo(selection);
+              const folders = this.getUniqueFolderNames(selection).join('; ');
+              const comments = (selection.get('comments') || []).filterBy(
+                'isTrashed',
+                false
+              );
 
-          if (comments.length === 0) {
-            const selectionData = {
-              [`Selector of Text`]: selectorInfo.username,
-              [`Text of Selection`]: selectorInfo.text,
-              [`Selector Date`]: selectorInfo.selectionCreateDate,
-              [`Annotator`]: '',
-              [`Text of Annotator`]: '',
-              [`Annotator Date`]: '',
-              [`Folder(s) for Selection`]: folders,
-            };
-            return [{ ...baseData, ...selectionData }];
-          }
+              if (comments.length === 0) {
+                return [
+                  {
+                    [`Selector of Text`]: selectorInfo.username,
+                    [`Text of Selection`]: selectorInfo.text,
+                    [`Selector Date`]: selectorInfo.selectionCreateDate,
+                    [`Annotator`]: '',
+                    [`Text of Annotator`]: '',
+                    [`Annotator Date`]: '',
+                    [`Folder(s) for Selection`]: folders,
+                  },
+                ];
+              }
 
-          return comments.map((comment) => {
-            const annotatorText = this.stripHtml(comment.get('text'));
-            const annotatorUsername = comment.get('createdBy.username');
-            const commentDate = new Date(comment.get('createDate'));
-            const annotatorCreateDate = isValid(commentDate)
-              ? format(commentDate, 'MM/dd/yyyy')
-              : '';
-            const selectionData = {
-              [`Selector of Text`]: selectorInfo.username,
-              [`Text of Selection`]: selectorInfo.text,
-              [`Selector Date`]: selectorInfo.selectionCreateDate,
-              [`Annotator`]: annotatorUsername,
-              [`Text of Annotator`]: annotatorText,
-              [`Annotation Label`]: comment.get('label') || '',
-              [`Annotator Date`]: annotatorCreateDate,
-              [`Folder(s) for Selection`]: folders,
-            };
-            return { ...baseData, ...selectionData };
-          });
-        });
+              return comments.map((comment) => {
+                const annotatorText = this.stripHtml(comment.get('text'));
+                const annotatorUsername = comment.get('createdBy.username');
+                const commentDate = new Date(comment.get('createDate'));
+                const annotatorCreateDate = isValid(commentDate)
+                  ? format(commentDate, 'MM/dd/yyyy')
+                  : '';
+                return {
+                  [`Selector of Text`]: selectorInfo.username,
+                  [`Text of Selection`]: selectorInfo.text,
+                  [`Selector Date`]: selectorInfo.selectionCreateDate,
+                  [`Annotator`]: annotatorUsername,
+                  [`Text of Annotator`]: annotatorText,
+                  [`Annotation Label`]: comment.get('label') || '',
+                  [`Annotator Date`]: annotatorCreateDate,
+                  [`Folder(s) for Selection`]: folders,
+                };
+              });
+            });
+
+      const baseRows = selectionRows.map((selectionData, index) => ({
+        ...staticData,
+        ...(index === 0 ? combinedAiRows[0] || emptyAiData : emptyAiData),
+        ...selectionData,
+      }));
+
+      if (combinedAiRows.length <= 1) {
+        return baseRows;
       }
+
+      const extraAiRows = combinedAiRows.slice(1).map((aiData) => ({
+        ...staticData,
+        ...aiData,
+      }));
+      return baseRows.concat(extraAiRows);
     });
 
     const headers = [...new Set(data.flatMap((row) => Object.keys(row)))];

--- a/app/styles/_ai-feedback-controls.scss
+++ b/app/styles/_ai-feedback-controls.scss
@@ -95,6 +95,18 @@
   box-sizing: border-box;
 }
 
+.ai-feedback-controls .ai-log-review-btn {
+  @extend .primary-button;
+  width: auto;
+  white-space: nowrap;
+}
+
+.ai-feedback-controls .ai-log-review-btn:disabled {
+  background-color: #cccccc;
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
 .ai-feedback-controls .ai-bring-down-btn {
   @extend .primary-button;
   width: auto;

--- a/app_server/datasource/api/aiApi.js
+++ b/app_server/datasource/api/aiApi.js
@@ -52,6 +52,7 @@ async function aiDraft(req, res, next) {
     const requestId = `aiVariant_${Date.now()}_${Math.random()
       .toString(36)
       .slice(2, 8)}`;
+    let variantLogId = null;
 
     // Save variant to database for export/analysis
     try {
@@ -68,7 +69,7 @@ async function aiDraft(req, res, next) {
           `[AI Variant] No active config found for variant ${variant}; skipping save`
         );
       } else {
-        await models.AIVariant.create({
+        const variantRow = await models.AIVariant.create({
           submission: target,
           workspace: workspace,
           variantKey: variant,
@@ -78,6 +79,7 @@ async function aiDraft(req, res, next) {
           requestId,
           createdBy: user._id,
         });
+        variantLogId = variantRow?._id?.toString() || null;
       }
     } catch (saveError) {
       console.error('[AI Variant] Failed to save variant:', saveError);
@@ -93,6 +95,7 @@ async function aiDraft(req, res, next) {
       message: `AI draft generated for target submission: ${target}`,
       draft: draftText,
       requestId,
+      variantLogId,
     };
 
     return utils.sendResponse(res, response);

--- a/app_server/datasource/api/aiVariantApi.js
+++ b/app_server/datasource/api/aiVariantApi.js
@@ -1,9 +1,11 @@
 const models = require('../schemas');
 const utils = require('../../middleware/requestHandler');
+const userAuth = require('../../middleware/userAuth');
 
 module.exports.get = {};
+module.exports.put = {};
 
-async function getVariants(req, res, next) {
+async function getVariants(req, res) {
   try {
     const query = { isTrashed: false };
 
@@ -31,3 +33,53 @@ async function getVariants(req, res, next) {
 }
 
 module.exports.get.aiVariants = getVariants;
+
+async function putVariant(req, res) {
+  try {
+    const user = userAuth.requireUser(req);
+    if (!user) {
+      return utils.sendError.InvalidCredentialsError(
+        'You must be logged in to update AI variant reviews.',
+        res
+      );
+    }
+
+    const payload =
+      req?.body?.aiVariant || req?.body?.variant || req?.body || {};
+    const rating = Number(payload.rating);
+    const teacherNotes =
+      typeof payload.teacherNotes === 'string' ? payload.teacherNotes : '';
+
+    if (!Number.isFinite(rating) || rating < 1 || rating > 5) {
+      return utils.sendError.InvalidArgumentError(
+        'rating is required and must be a number between 1 and 5.',
+        res
+      );
+    }
+
+    if (teacherNotes.trim().length < 10) {
+      return utils.sendError.InvalidArgumentError(
+        'teacherNotes is required and must be at least 10 characters.',
+        res
+      );
+    }
+
+    const variant = await models.AIVariant.findById(req.params.id).exec();
+    if (!variant || variant.isTrashed) {
+      return utils.sendResponse(res, null);
+    }
+
+    variant.rating = rating;
+    variant.teacherNotes = teacherNotes;
+    variant.lastModifiedBy = user._id;
+    variant.lastModifiedDate = new Date();
+    await variant.save();
+
+    return utils.sendResponse(res, { variant });
+  } catch (error) {
+    console.error('Error updating variant review:', error);
+    return utils.sendError.InternalError(error.message, res);
+  }
+}
+
+module.exports.put.aiVariant = putVariant;

--- a/app_server/datasource/api/submissionApi.js
+++ b/app_server/datasource/api/submissionApi.js
@@ -52,7 +52,7 @@ function toSubmission(obj, index, arr) {
     delete json.Id;
 
     for (var property in json) {
-      if (json.hasOwnProperty(property)) {
+      if (Object.prototype.hasOwnProperty.call(json, property)) {
         model.set(property, json[property]);
       }
     }
@@ -86,7 +86,7 @@ function toPDSubmission(obj, index, arr) {
     delete json.Id;
 
     for (var property in json) {
-      if (json.hasOwnProperty(property)) {
+      if (Object.prototype.hasOwnProperty.call(json, property)) {
         model.set(property, json[property]);
       }
     }
@@ -396,10 +396,29 @@ function putSubmission(req, res, next) {
       return utils.sendError.InternalError(err, res);
     }
 
-    for (var field in req.body.submission) {
-      if (field !== '_id' && field !== undefined) {
-        doc[field] = req.body.submission[field];
+    const submissionPayload = req.body.submission || {};
+    for (var field in submissionPayload) {
+      if (field === 'appendAiFinalEditVersion') {
+        continue;
       }
+      if (field !== '_id' && field !== undefined) {
+        doc[field] = submissionPayload[field];
+      }
+    }
+
+    const appendAiFinalEditVersion = submissionPayload.appendAiFinalEditVersion;
+    if (appendAiFinalEditVersion) {
+      if (!Array.isArray(doc.aiFinalEditVersions)) {
+        doc.aiFinalEditVersions = [];
+      }
+      doc.aiFinalEditVersions.push({
+        text: appendAiFinalEditVersion.text || '',
+        savedAt: appendAiFinalEditVersion.savedAt || new Date(),
+        savedBy: appendAiFinalEditVersion.savedBy || null,
+        sourceVariantLogId: appendAiFinalEditVersion.sourceVariantLogId || null,
+        sourceRequestId: appendAiFinalEditVersion.sourceRequestId || null,
+        sourceVariantKey: appendAiFinalEditVersion.sourceVariantKey || null,
+      });
     }
 
     doc.save(function (err, submission) {

--- a/app_server/datasource/schemas/submission.js
+++ b/app_server/datasource/schemas/submission.js
@@ -50,9 +50,16 @@ var baseSubmission = {
   aiFinalEditText: { type: String },
   aiFinalEditAt: { type: Date },
   aiFinalEditBy: { type: ObjectId, ref: 'User' },
-  aiFinalEditSourceVariant: { type: String },
-  aiFinalEditRating: { type: Number, min: 1, max: 5 },
-  aiFinalEditFeedback: { type: String },
+  aiFinalEditVersions: [
+    {
+      text: { type: String },
+      savedAt: { type: Date },
+      savedBy: { type: ObjectId, ref: 'User' },
+      sourceVariantLogId: { type: ObjectId, ref: 'AIVariant' },
+      sourceRequestId: { type: String },
+      sourceVariantKey: { type: String },
+    },
+  ],
 };
 
 /**

--- a/app_server/server.js
+++ b/app_server/server.js
@@ -312,6 +312,7 @@ server.put('/api/comments/:id', pathMw.validateId(), api.put.comment);
 server.put('/api/responses/:id', pathMw.validateId(), api.put.response);
 server.put('/api/taggings/:id', pathMw.validateId(), api.put.tagging);
 server.put('/api/users/:id', pathMw.validateId(), api.put.user);
+server.put('/api/aiVariants/:id', pathMw.validateId(), api.put.aiVariant);
 server.put(
   '/api/users/addSection/:id',
   pathMw.validateId(),


### PR DESCRIPTION
## Description
This PR finishes the A/B review logging + final edit export flow end to end.

Main goals:
- Make variant review logging explicit (per generated row)
- Make final edit saves append-only(not overwrite)
- Make ratings and written comments persistent
- Stop report export from collapsing repeated AI/final-edit data

## Problem
While testing A/B + export:
- we had no dedicated API path for logging review onto a specific variant row
- final edit history could be clobbered by full-payload updates
- CSV shaping was effectively flattening/deduping AI rows, so later entries were easy to lose

## What Changed

### Frontend
- `app/components/ai-variant-comparison.hbs`
  - Added `Log Review` button on both variant cards.

- `app/components/ai-variant-comparison.js`
  - Added `isReviewLoggedA/D` + `isLoggingReviewA/D` state.
  - `Bring It Down` now unlocks only after review is logged successfully.
  - Editing rating/feedback resets logged state.
  - Bring-down payload now includes `variantLogId` and `requestId` so downstream save can be associated correctly.

- `app/components/response-mentor-reply.js`
  - Tracks latest brought-down source metadata (`variantLogId`, `requestId`, `variantKey`).
  - `Save Final Edit Version` sends append payload (`appendAiFinalEditVersion`) instead of replacing full history.

- `app/styles/_ai-feedback-controls.scss`
  - Added styles for `Log Review` button.

### Backend
- `app_server/datasource/api/aiVariantApi.js`
  - Added authenticated `PUT` handler for updating variant review fields (`rating`, `teacherNotes`) with validation.

- `app_server/server.js`
  - Registered `PUT /api/aiVariants/:id`.

- `app_server/datasource/api/submissionApi.js`
  - Added append-only handling for `appendAiFinalEditVersion`.
  - Continues to process other submission fields normally.

- `app_server/datasource/schemas/submission.js`
  - Replaced old final-edit metadata fields with `aiFinalEditVersions[]`.
  - Added source linkage on each version item:
    - `sourceVariantLogId`
    - `sourceRequestId`
    - `sourceVariantKey`

- `app/models/submission.js`
  - Updated Ember model fields to match schema changes (`aiFinalEditBy`, `aiFinalEditVersions`).

### Reporting
- `app/services/workspace-reports.js`
  - Removed dedup/flatten behavior that kept only one variant row.
  - Keeps all variant rows per submission for export shaping.
  - Emits additional rows for additional AI/final-edit entries using existing columns.
  - Associates final edit rows to matching variant row when `sourceVariantLogId` exists.
  - Uses safe fallback when association metadata is missing.

## Testing

### Manual flow verification
1. Generate Variant A and B.
2. Add rating + feedback, click `Log Review`.
3. Verify `Bring It Down` stays disabled until log succeeds.
4. Bring one variant down into Draft Editor.
5. Click `Save Final Edit Version` multiple times.
6. Export workspace report and verify:
   - same base columns
   - extra AI/final-edit entries show as additional rows
   - no dedup collapse of repeated entries
