### PR TITLE
fix(ai-api): return variantLogId even when variant create hits duplic…

### DIFF
--- a/app_server/datasource/api/aiApi.js
+++ b/app_server/datasource/api/aiApi.js
@@ -53,17 +53,16 @@ async function aiDraft(req, res, next) {
       .toString(36)
       .slice(2, 8)}`;
     let variantLogId = null;
+    const draftText =
+      typeof draftResult === 'object' && draftResult?.draft
+        ? draftResult.draft
+        : draftResult;
+    const variantConfigData = variantConfig.activeVariants.find(
+      (v) => v.key === variant
+    );
 
     // Save variant to database for export/analysis
     try {
-      const variantConfigData = variantConfig.activeVariants.find(
-        (v) => v.key === variant
-      );
-
-      const draftText =
-        typeof draftResult === 'object' && draftResult?.draft
-          ? draftResult.draft
-          : draftResult;
       if (!variantConfigData) {
         console.warn(
           `[AI Variant] No active config found for variant ${variant}; skipping save`
@@ -82,13 +81,63 @@ async function aiDraft(req, res, next) {
         variantLogId = variantRow?._id?.toString() || null;
       }
     } catch (saveError) {
-      console.error('[AI Variant] Failed to save variant:', saveError);
-    }
+      const isDuplicateKey =
+        saveError?.code === 11000 ||
+        (typeof saveError?.message === 'string' &&
+          saveError.message.includes('E11000 duplicate key error'));
 
-    const draftText =
-      typeof draftResult === 'object' && draftResult?.draft
-        ? draftResult.draft
-        : draftResult;
+      if (isDuplicateKey && variantConfigData) {
+        // Compatibility fallback for environments that still enforce one row per
+        // (submission, variantKey). We reuse that row so review logging can proceed.
+        try {
+          const fallbackRow = await models.AIVariant.findOneAndUpdate(
+            {
+              submission: target,
+              variantKey: variant,
+              isTrashed: false,
+            },
+            {
+              $set: {
+                workspace,
+                variantLabel: variantConfigData.label,
+                inputType: variantConfigData.inputType,
+                draftText,
+                requestId,
+                lastModifiedBy: user._id,
+                lastModifiedDate: new Date(),
+              },
+              $setOnInsert: {
+                createdBy: user._id,
+              },
+            },
+            {
+              new: true,
+              upsert: true,
+              setDefaultsOnInsert: true,
+            }
+          )
+            .select('_id')
+            .exec();
+
+          variantLogId = fallbackRow?._id?.toString() || null;
+
+          if (variantLogId) {
+            console.warn(
+              `[AI Variant] Reused existing row for ${target}/${variant} after duplicate-key save error`
+            );
+          }
+        } catch (fallbackError) {
+          console.error(
+            '[AI Variant] Duplicate-key fallback failed while saving variant:',
+            fallbackError
+          );
+        }
+      }
+
+      if (!variantLogId) {
+        console.error('[AI Variant] Failed to save variant:', saveError);
+      }
+    }
     const response = {
       target: target,
       variant: variant,


### PR DESCRIPTION
## Description
Quick Fix for `test-env` where `Log Review` was not firing because `/api/aiDraft` sometimes returned `variantLogId: null`.

## Problem
In environments with legacy duplicate-key behavior on `aivariants` create, the AI draft response was still returned, but variant persistence failed before an id could be returned.  
Without `variantLogId`, frontend review logging exits early and no `PUT /api/aiVariants/:id` call is made.

## What Changed
- Updated `app_server/datasource/api/aiApi.js` draft-save flow.
- Added duplicate-key fallback logic:
  - detect `E11000` on `AIVariant.create`
  - recover by `findOneAndUpdate` / upsert on `{ submission, variantKey }`
  - return recovered `_id` as `variantLogId`
- Kept existing error logging for non-recoverable save failures.

## Impact
- Restores `Log Review` flow in `enc-test` without DB/index changes.
- Keeps behavior backward-compatible for production-like environments.

## Testing
1. Generate variant A or B in `enc-test`.
2. Confirm `/api/aiDraft` response includes non-null `variantLogId`.
3. Click `Log Review`.
4. Confirm `PUT /api/aiVariants/:id` is sent and review data persists.
5. Download and Verify the report