### PR TITLE
Fix/variant log

### DIFF
--- a/app/components/response-mentor-reply.hbs
+++ b/app/components/response-mentor-reply.hbs
@@ -47,7 +47,7 @@
   {{/if}}
 {{/unless}}
 
-  {{#if this.sortedMentorReplies.length}}
+  {{#if this.hasPreviousConversation}}
     {{#unless @isOlderRevision}}
       {{#if @isCreating}}
         <h3 class='previous-responses-header'>Previous Conversation</h3>
@@ -188,6 +188,39 @@
       {{/if}}
     {{/each}}
 
+    {{#if this.finalEditHistoryEntries.length}}
+      <div class='final-edit-history-section'>
+        <h4 class='response-header'>Final Edit History</h4>
+        {{#each this.finalEditHistoryEntries as |entry|}}
+          <div class='response-mentor-container final-edit-history-item'>
+            <div class='response-mentor-info'>
+              <div class='response-users'>
+                <p class='response-time final-edit-history-saved-at'>
+                  {{#if entry.savedAt}}
+                    {{format-date entry.savedAt 'MMMM Do, YYYY'}}
+                    {{format-date entry.savedAt 'h:mm a'}}
+                  {{else}}
+                    Saved time unavailable
+                  {{/if}}
+                </p>
+                {{#if entry.savedBy}}
+                  <p>
+                    <span class='response-label'>Saved By:</span>
+                    <span class='response-value final-edit-history-saved-by'>{{entry.savedBy}}</span>
+                  </p>
+                {{/if}}
+              </div>
+              <div class='response-text-container'>
+                <div class='response-text final-edit-history-text'>
+                  {{{entry.html}}}
+                </div>
+              </div>
+            </div>
+          </div>
+        {{/each}}
+      </div>
+    {{/if}}
+
     {{! Show "New Response" button after responses when no drafts exist }}
     {{! Removed @isOlderRevision check - allow responding to any revision }}
       {{#unless this.hasDrafts}}
@@ -210,21 +243,22 @@
       {{/unless}}
 
   {{else}}
-    {{! Removed @isOlderRevision check - allow responding to any revision }}
-    <p class='info'>No Mentor Feedback for this revision yet.</p>
-    <img src='/assets/images/no-message.svg' alt='No Replies' />
-    {{#if this.canSendNew}}
-      Click 'New Response' to begin composing a new Mentor Reply.
-      <div class="submit-buttons button-row">
-        <LinkTo
-          @route="responses.new.submission"
-          @model={{@submission.id}}
-          class="primary-button"
-        >
-          New Response
-        </LinkTo>
-      </div>
-    {{/if}}
+    {{#unless @isOlderRevision}}
+      <p class='info'>No Mentor Feedback for this revision yet.</p>
+      <img src='/assets/images/no-message.svg' alt='No Replies' />
+      {{#if this.canSendNew}}
+        Click 'New Response' to begin composing a new Mentor Reply.
+        <div class="submit-buttons button-row">
+          <LinkTo
+            @route="responses.new.submission"
+            @model={{@submission.id}}
+            class="primary-button"
+          >
+            New Response
+          </LinkTo>
+        </div>
+      {{/if}}
+    {{/unless}}
   {{/if}}
   {{! page pagination for mentor replies }}
   {{!-- <div class="mentor-replies">

--- a/app/components/response-mentor-reply.js
+++ b/app/components/response-mentor-reply.js
@@ -149,15 +149,109 @@ export default class ResponseMentorReplyComponent extends Component {
     return this.isComposing && this.newReplyStatus !== 'approved';
   }
   get sortedMentorReplies() {
-    const mentorReplies = this.args.submissionResponses?.filter(
-      (reply) => reply.responseType === 'mentor' && !reply.isTrashed
+    const rawResponses = this.args.submissionResponses;
+    const responses = Array.isArray(rawResponses)
+      ? rawResponses
+      : rawResponses?.toArray?.() || [];
+    const mentorReplies = responses.filter(
+      (reply) => reply?.responseType === 'mentor' && !reply?.isTrashed
     );
 
     if (!mentorReplies || mentorReplies.length === 0) {
-      return null;
+      return [];
     }
 
-    return mentorReplies.sortBy('createDate');
+    if (typeof mentorReplies.sortBy === 'function') {
+      return mentorReplies.sortBy('createDate');
+    }
+
+    return mentorReplies
+      .slice()
+      .sort(
+        (a, b) => new Date(a?.createDate || 0) - new Date(b?.createDate || 0)
+      );
+  }
+
+  get finalEditHistoryEntries() {
+    const submission = this.args.submission;
+    if (!submission) {
+      return [];
+    }
+    const currentUserId = this._normalizeObjectId(this.currentUser.user);
+    if (!currentUserId) {
+      return [];
+    }
+    const userNameById = this._buildUserNameByIdMap();
+
+    const rawVersions = submission.aiFinalEditVersions;
+    const versions = Array.isArray(rawVersions)
+      ? rawVersions
+      : rawVersions?.toArray?.() || [];
+    const ownVersions = versions.filter(
+      (version) => this._normalizeObjectId(version?.savedBy) === currentUserId
+    );
+
+    let normalized = ownVersions
+      .map((version, index) => {
+        const html = this._toSafeHistoryHtml(version?.text || '');
+        const { savedBy, savedById } = this._resolveSavedByDisplay(
+          version?.savedBy,
+          userNameById
+        );
+        const savedAtRaw = version?.savedAt || null;
+        const savedAtDate = savedAtRaw ? new Date(savedAtRaw) : null;
+        const savedAt =
+          savedAtDate && !Number.isNaN(savedAtDate.getTime())
+            ? savedAtDate
+            : null;
+
+        return {
+          id: `${savedAt?.getTime() || 'no-date'}-${index}`,
+          html,
+          savedAt,
+          savedBy,
+          savedById,
+        };
+      })
+      .filter((entry) => entry.html || entry.savedAt);
+
+    const legacySavedById = this._normalizeObjectId(submission.aiFinalEditBy);
+    if (
+      normalized.length === 0 &&
+      legacySavedById === currentUserId &&
+      (submission.aiFinalEditText || submission.aiFinalEditAt)
+    ) {
+      const fallbackSavedAt = submission.aiFinalEditAt
+        ? new Date(submission.aiFinalEditAt)
+        : null;
+      normalized = [
+        {
+          id: 'legacy-final-edit',
+          html: this._toSafeHistoryHtml(submission.aiFinalEditText || ''),
+          ...this._resolveSavedByDisplay(
+            submission.aiFinalEditBy,
+            userNameById
+          ),
+          savedAt:
+            fallbackSavedAt && !Number.isNaN(fallbackSavedAt.getTime())
+              ? fallbackSavedAt
+              : null,
+        },
+      ];
+    }
+
+    return normalized.sort((a, b) => {
+      const aMs = a.savedAt ? a.savedAt.getTime() : Number.POSITIVE_INFINITY;
+      const bMs = b.savedAt ? b.savedAt.getTime() : Number.POSITIVE_INFINITY;
+      return aMs - bMs;
+    });
+  }
+
+  get hasPreviousConversation() {
+    return (
+      this.sortedMentorReplies.length > 0 ||
+      this.finalEditHistoryEntries.length > 0
+    );
   }
 
   get showNoteHeader() {
@@ -201,7 +295,7 @@ export default class ResponseMentorReplyComponent extends Component {
     if (this.args.isParentWorkspace) return false;
     const isOwnReply =
       this.utils.getBelongsToId(reply, 'createdBy') ===
-      this.currentUser.user?.id;
+      this._normalizeObjectId(this.currentUser.user);
     const status = reply.status;
     const isBeingEdited =
       this.isFinishingDraft && this.editingReplyId === reply.id;
@@ -280,6 +374,114 @@ export default class ResponseMentorReplyComponent extends Component {
 
   get saveFinalEditButtonText() {
     return this.isSavingFinalEdit ? 'Saving...' : 'Save Final Edit Version';
+  }
+
+  _toSafeHistoryHtml(content) {
+    if (!content) return '';
+
+    const raw = String(content);
+
+    if (/<\/?[a-z][\s\S]*>/i.test(raw)) {
+      return DOMPurify.sanitize(raw);
+    }
+
+    return raw
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/\r?\n/g, '<br>');
+  }
+
+  _buildUserNameByIdMap() {
+    const names = new Map();
+    const add = (id, name) => {
+      if (!id || !name || names.has(id)) return;
+      names.set(id, name);
+    };
+
+    const currentUserId = this._normalizeObjectId(this.currentUser.user);
+    add(currentUserId, this._getUserDisplayName(this.currentUser.user));
+
+    const rawReplies = this.sortedMentorReplies;
+    const replies = Array.isArray(rawReplies)
+      ? rawReplies
+      : rawReplies?.toArray?.() || [];
+
+    for (const reply of replies) {
+      const createdById =
+        this.utils.getBelongsToId(reply, 'createdBy') ||
+        this._normalizeObjectId(reply?.createdBy);
+      add(createdById, this._getUserDisplayName(reply?.createdBy));
+    }
+
+    return names;
+  }
+
+  _resolveSavedByDisplay(savedByValue, userNameById) {
+    const directName = this._getUserDisplayName(savedByValue);
+    const savedById = this._normalizeObjectId(savedByValue);
+    const currentUserId = this._normalizeObjectId(this.currentUser.user);
+
+    // Show saver identity only for rows saved by the current logged-in user.
+    if (savedById && currentUserId && savedById !== currentUserId) {
+      return { savedBy: null, savedById };
+    }
+
+    if (directName) {
+      return { savedBy: directName, savedById };
+    }
+
+    if (savedById && userNameById?.has(savedById)) {
+      return { savedBy: userNameById.get(savedById), savedById };
+    }
+
+    if (savedById) {
+      const userRecord = this.store.peekRecord('user', savedById);
+      const recordName = this._getUserDisplayName(userRecord);
+      if (recordName) {
+        return { savedBy: recordName, savedById };
+      }
+    }
+
+    return { savedBy: savedById || null, savedById };
+  }
+
+  _normalizeObjectId(value) {
+    if (!value) return null;
+    if (typeof value === 'string') return value;
+
+    if (typeof value === 'object') {
+      const id = typeof value.get === 'function' ? value.get('id') : value.id;
+      if (typeof id === 'string') return id;
+
+      const rawId =
+        typeof value.get === 'function' ? value.get('_id') : value._id;
+      if (typeof rawId === 'string') return rawId;
+      if (rawId && typeof rawId.toString === 'function') {
+        return rawId.toString();
+      }
+    }
+
+    return null;
+  }
+
+  _getUserDisplayName(userLike) {
+    if (!userLike || typeof userLike === 'string') return null;
+
+    const read = (key) => {
+      if (typeof userLike.get === 'function') {
+        return userLike.get(key);
+      }
+      return userLike[key];
+    };
+
+    return (
+      read('safeName') ||
+      read('fullName') ||
+      read('displayName') ||
+      read('username') ||
+      null
+    );
   }
 
   _hasContentChanged(oldText, newText, oldNote, newNote) {
@@ -728,7 +930,7 @@ export default class ResponseMentorReplyComponent extends Component {
 
     const submissionId = this.args.submission?.id;
     const savedAt = new Date();
-    const savedBy = this.currentUser.user?.id || null;
+    const savedBy = this._normalizeObjectId(this.currentUser.user);
     const appendedVersion = {
       text: this.quillText,
       savedAt,

--- a/app/components/response-mentor-reply.js
+++ b/app/components/response-mentor-reply.js
@@ -157,12 +157,8 @@ export default class ResponseMentorReplyComponent extends Component {
       (reply) => reply?.responseType === 'mentor' && !reply?.isTrashed
     );
 
-    if (!mentorReplies || mentorReplies.length === 0) {
+    if (mentorReplies.length === 0) {
       return [];
-    }
-
-    if (typeof mentorReplies.sortBy === 'function') {
-      return mentorReplies.sortBy('createDate');
     }
 
     return mentorReplies

--- a/app/components/response-new.js
+++ b/app/components/response-new.js
@@ -192,7 +192,7 @@ export default class ResponseNewComponent extends Component {
       return 'Submit';
     }
     if (this.args.canDirectSend) {
-      return 'Submit';
+      return 'Send';
     }
     return 'Submit for Approval';
   }

--- a/tests/integration/components/response-mentor-reply-test.js
+++ b/tests/integration/components/response-mentor-reply-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, findAll } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 
@@ -45,7 +45,9 @@ module('Integration | Component | response-mentor-reply', function (hooks) {
     if (response.isTrashed === undefined) response.isTrashed = false;
     if (submission) {
       // Handle Ember proxy objects - use get() if available
-      const responses = submission.get ? submission.get('responses') : submission.responses;
+      const responses = submission.get
+        ? submission.get('responses')
+        : submission.responses;
       if (!responses) {
         submission.responses = [response];
       } else if (!responses.includes(response)) {
@@ -91,7 +93,7 @@ module('Integration | Component | response-mentor-reply', function (hooks) {
 
     // Auto-setup all responses with required properties
     const responses = context.submissionResponses || [];
-    responses.forEach(r => {
+    responses.forEach((r) => {
       if (r && r.submission) {
         setupResponse(r, r.submission);
       }
@@ -270,6 +272,299 @@ module('Integration | Component | response-mentor-reply', function (hooks) {
     });
 
     assert.dom('.response-mentor-container').exists();
+  });
+
+  test('renders final edit history in ascending order by savedAt', async function (assert) {
+    const store = this.owner.lookup('service:store');
+    const submission = store.createRecord('submission', {
+      id: 'sub-final-history',
+      creator: { username: 'Test Student', safeName: 'Test Student' },
+    });
+
+    submission.aiFinalEditVersions = [
+      {
+        text: '<p>Newest final edit</p>',
+        savedAt: new Date('2026-03-06T10:00:00.000Z'),
+        savedBy: 'user1',
+      },
+      {
+        text: '<p>Oldest final edit</p>',
+        savedAt: new Date('2026-03-06T09:00:00.000Z'),
+        savedBy: 'user1',
+      },
+    ];
+
+    this.set('submission', submission);
+
+    await renderMentorReply(this, {
+      submission,
+      submissionResponses: [],
+      canSend: false,
+    });
+
+    assert
+      .dom('.final-edit-history-section')
+      .exists('Final edit history section renders');
+    assert
+      .dom('.final-edit-history-item')
+      .exists({ count: 2 }, 'Two final edit history entries render');
+
+    const renderedTexts = findAll('.final-edit-history-text').map((el) =>
+      el.textContent.replace(/\s+/g, ' ').trim()
+    );
+    assert.strictEqual(
+      renderedTexts[0],
+      'Oldest final edit',
+      'Oldest entry appears first'
+    );
+    assert.strictEqual(
+      renderedTexts[1],
+      'Newest final edit',
+      'Newest entry appears second'
+    );
+  });
+
+  test('shows only current user final edit history entries', async function (assert) {
+    const store = this.owner.lookup('service:store');
+    const submission = store.createRecord('submission', {
+      id: 'sub-final-history-current-user',
+      creator: { username: 'Test Student', safeName: 'Test Student' },
+    });
+
+    submission.aiFinalEditVersions = [
+      {
+        text: '<p>Other user edit</p>',
+        savedAt: new Date('2026-03-06T08:00:00.000Z'),
+        savedBy: 'user2',
+      },
+      {
+        text: '<p>My older edit</p>',
+        savedAt: new Date('2026-03-06T09:00:00.000Z'),
+        savedBy: 'user1',
+      },
+      {
+        text: '<p>My newer edit</p>',
+        savedAt: new Date('2026-03-06T10:00:00.000Z'),
+        savedBy: 'user1',
+      },
+    ];
+
+    this.set('submission', submission);
+
+    await renderMentorReply(this, {
+      submission,
+      submissionResponses: [],
+      canSend: false,
+    });
+
+    assert
+      .dom('.final-edit-history-item')
+      .exists({ count: 2 }, 'Only current user entries are shown');
+
+    const renderedTexts = findAll('.final-edit-history-text').map((el) =>
+      el.textContent.replace(/\s+/g, ' ').trim()
+    );
+    assert.deepEqual(
+      renderedTexts,
+      ['My older edit', 'My newer edit'],
+      'Only current user history is rendered in ascending order'
+    );
+  });
+
+  test('does not render final edit history when only other users entries exist', async function (assert) {
+    const store = this.owner.lookup('service:store');
+    const submission = store.createRecord('submission', {
+      id: 'sub-final-history-other-user-only',
+      creator: { username: 'Test Student', safeName: 'Test Student' },
+    });
+
+    submission.aiFinalEditVersions = [
+      {
+        text: '<p>Other user only edit</p>',
+        savedAt: new Date('2026-03-06T08:00:00.000Z'),
+        savedBy: 'user2',
+      },
+    ];
+
+    this.set('submission', submission);
+
+    await renderMentorReply(this, {
+      submission,
+      submissionResponses: [],
+      canSend: false,
+    });
+
+    assert
+      .dom('.final-edit-history-section')
+      .doesNotExist('History section is hidden for non-owner entries');
+    assert
+      .dom('.final-edit-history-item')
+      .doesNotExist('No final edit rows render');
+  });
+
+  test('renders legacy final edit snapshot when versions array is empty', async function (assert) {
+    const store = this.owner.lookup('service:store');
+    const submission = store.createRecord('submission', {
+      id: 'sub-final-legacy',
+      creator: { username: 'Test Student', safeName: 'Test Student' },
+    });
+
+    submission.aiFinalEditVersions = [];
+    submission.aiFinalEditText = '<p>Legacy final edit snapshot</p>';
+    submission.aiFinalEditAt = new Date('2026-03-06T08:30:00.000Z');
+    submission.aiFinalEditBy = 'user1';
+
+    this.set('submission', submission);
+
+    await renderMentorReply(this, {
+      submission,
+      submissionResponses: [],
+      canSend: false,
+    });
+
+    assert
+      .dom('.final-edit-history-item')
+      .exists({ count: 1 }, 'One legacy fallback entry renders');
+    assert
+      .dom('.final-edit-history-text')
+      .includesText(
+        'Legacy final edit snapshot',
+        'Legacy final edit text is displayed'
+      );
+  });
+
+  test('does not render legacy final edit snapshot for other user', async function (assert) {
+    const store = this.owner.lookup('service:store');
+    const submission = store.createRecord('submission', {
+      id: 'sub-final-legacy-other-user',
+      creator: { username: 'Test Student', safeName: 'Test Student' },
+    });
+
+    submission.aiFinalEditVersions = [];
+    submission.aiFinalEditText = '<p>Other user legacy snapshot</p>';
+    submission.aiFinalEditAt = new Date('2026-03-06T08:30:00.000Z');
+    submission.aiFinalEditBy = 'user2';
+
+    this.set('submission', submission);
+
+    await renderMentorReply(this, {
+      submission,
+      submissionResponses: [],
+      canSend: false,
+    });
+
+    assert
+      .dom('.final-edit-history-item')
+      .doesNotExist('Legacy fallback is hidden for other users');
+  });
+
+  test('renders Saved By as username for current user history entries', async function (assert) {
+    const store = this.owner.lookup('service:store');
+    const submission = store.createRecord('submission', {
+      id: 'sub-final-history-saved-by-name',
+      creator: { username: 'Test Student', safeName: 'Test Student' },
+    });
+
+    submission.aiFinalEditVersions = [
+      {
+        text: '<p>Named saver edit</p>',
+        savedAt: new Date('2026-03-06T10:00:00.000Z'),
+        savedBy: 'user1',
+      },
+    ];
+
+    this.set('submission', submission);
+
+    await renderMentorReply(this, {
+      submission,
+      submissionResponses: [],
+      canSend: false,
+    });
+
+    assert
+      .dom('.final-edit-history-saved-by')
+      .includesText('testuser', 'Saved By shows resolved username');
+  });
+
+  test('sanitizes final edit history html while preserving safe formatting', async function (assert) {
+    const store = this.owner.lookup('service:store');
+    const submission = store.createRecord('submission', {
+      id: 'sub-final-history-sanitize',
+      creator: { username: 'Test Student', safeName: 'Test Student' },
+    });
+
+    submission.aiFinalEditVersions = [
+      {
+        text: '<p>Safe <strong>format</strong></p><script>alert("x")</script><img src="x" onerror="alert(1)">',
+        savedAt: new Date('2026-03-06T10:00:00.000Z'),
+        savedBy: 'user1',
+      },
+    ];
+
+    this.set('submission', submission);
+
+    await renderMentorReply(this, {
+      submission,
+      submissionResponses: [],
+      canSend: false,
+    });
+
+    assert
+      .dom('.final-edit-history-text strong')
+      .exists('Safe formatting tags are preserved');
+    assert
+      .dom('.final-edit-history-text')
+      .includesText('Safe format', 'Visible text is preserved');
+    assert
+      .dom('.final-edit-history-text script')
+      .doesNotExist('Script tags are stripped');
+
+    const historyHtml = findAll('.final-edit-history-text')
+      .map((el) => el.innerHTML)
+      .join(' ');
+    assert.notOk(
+      historyHtml.includes('onerror='),
+      'Dangerous event handler attributes are removed'
+    );
+  });
+
+  test('preserves line breaks for plain text final edit history entries', async function (assert) {
+    const store = this.owner.lookup('service:store');
+    const submission = store.createRecord('submission', {
+      id: 'sub-final-history-plain-text',
+      creator: { username: 'Test Student', safeName: 'Test Student' },
+    });
+
+    submission.aiFinalEditVersions = [
+      {
+        text: 'Line one\nLine two',
+        savedAt: new Date('2026-03-06T10:00:00.000Z'),
+        savedBy: 'user1',
+      },
+    ];
+
+    this.set('submission', submission);
+
+    await renderMentorReply(this, {
+      submission,
+      submissionResponses: [],
+      canSend: false,
+    });
+
+    assert
+      .dom('.final-edit-history-text')
+      .includesText('Line one', 'First line is rendered');
+    assert
+      .dom('.final-edit-history-text')
+      .includesText('Line two', 'Second line is rendered');
+
+    const historyHtml = findAll('.final-edit-history-text')
+      .map((el) => el.innerHTML)
+      .join(' ');
+    assert.ok(
+      historyHtml.includes('<br>'),
+      'Newlines are rendered as line breaks'
+    );
   });
 
   // --- Status and Permission Tests ---
@@ -928,8 +1223,13 @@ module('Integration | Component | response-mentor-reply', function (hooks) {
 
   test('shows Edit Draft button for own draft response', async function (assert) {
     const store = this.owner.lookup('service:store');
-    const user = store.createRecord('user', { id: 'user1', username: 'mentor' });
-    const submission = store.createRecord('submission', { creator: { username: 'student' } });
+    const user = store.createRecord('user', {
+      id: 'user1',
+      username: 'mentor',
+    });
+    const submission = store.createRecord('submission', {
+      creator: { username: 'student' },
+    });
     const draft = store.createRecord('response', {
       text: 'Draft text',
       status: 'draft',
@@ -952,8 +1252,13 @@ module('Integration | Component | response-mentor-reply', function (hooks) {
 
   test('shows Delete button for own draft response', async function (assert) {
     const store = this.owner.lookup('service:store');
-    const user = store.createRecord('user', { id: 'user1', username: 'mentor' });
-    const submission = store.createRecord('submission', { creator: { username: 'student' } });
+    const user = store.createRecord('user', {
+      id: 'user1',
+      username: 'mentor',
+    });
+    const submission = store.createRecord('submission', {
+      creator: { username: 'student' },
+    });
     const draft = store.createRecord('response', {
       text: 'Draft text',
       status: 'draft',
@@ -979,8 +1284,13 @@ module('Integration | Component | response-mentor-reply', function (hooks) {
     const store = this.owner.lookup('service:store');
     // beforeEach sets currentUser.user = { id: 'user1', username: 'testuser' }
     // Create draft owned by different user
-    const otherUser = store.createRecord('user', { id: 'otherUser456', username: 'other' });
-    const submission = store.createRecord('submission', { creator: { username: 'student' } });
+    const otherUser = store.createRecord('user', {
+      id: 'otherUser456',
+      username: 'other',
+    });
+    const submission = store.createRecord('submission', {
+      creator: { username: 'student' },
+    });
     const draft = store.createRecord('response', {
       text: 'Draft text',
       status: 'draft',
@@ -1007,8 +1317,13 @@ module('Integration | Component | response-mentor-reply', function (hooks) {
 
   test('displays DRAFT badge for draft responses', async function (assert) {
     const store = this.owner.lookup('service:store');
-    const user = store.createRecord('user', { id: 'user1', username: 'mentor' });
-    const submission = store.createRecord('submission', { creator: { username: 'student' } });
+    const user = store.createRecord('user', {
+      id: 'user1',
+      username: 'mentor',
+    });
+    const submission = store.createRecord('submission', {
+      creator: { username: 'student' },
+    });
     const draft = store.createRecord('response', {
       text: 'Draft text',
       status: 'draft',
@@ -1031,8 +1346,13 @@ module('Integration | Component | response-mentor-reply', function (hooks) {
 
   test('does not show DRAFT badge for approved responses', async function (assert) {
     const store = this.owner.lookup('service:store');
-    const user = store.createRecord('user', { id: 'user1', username: 'mentor' });
-    const submission = store.createRecord('submission', { creator: { username: 'student' } });
+    const user = store.createRecord('user', {
+      id: 'user1',
+      username: 'mentor',
+    });
+    const submission = store.createRecord('submission', {
+      creator: { username: 'student' },
+    });
     const approved = store.createRecord('response', {
       text: 'Approved text',
       status: 'approved',
@@ -1055,8 +1375,13 @@ module('Integration | Component | response-mentor-reply', function (hooks) {
 
   test('shows Delete button for pendingApproval response when user can approve', async function (assert) {
     const store = this.owner.lookup('service:store');
-    const user = store.createRecord('user', { id: 'user1', username: 'mentor' });
-    const submission = store.createRecord('submission', { creator: { username: 'student' } });
+    const user = store.createRecord('user', {
+      id: 'user1',
+      username: 'mentor',
+    });
+    const submission = store.createRecord('submission', {
+      creator: { username: 'student' },
+    });
     const pending = store.createRecord('response', {
       text: 'Pending text',
       status: 'pendingApproval',
@@ -1080,8 +1405,13 @@ module('Integration | Component | response-mentor-reply', function (hooks) {
 
   test('hides action buttons in parent workspace', async function (assert) {
     const store = this.owner.lookup('service:store');
-    const user = store.createRecord('user', { id: 'user1', username: 'mentor' });
-    const submission = store.createRecord('submission', { creator: { username: 'student' } });
+    const user = store.createRecord('user', {
+      id: 'user1',
+      username: 'mentor',
+    });
+    const submission = store.createRecord('submission', {
+      creator: { username: 'student' },
+    });
     const draft = store.createRecord('response', {
       text: 'Draft text',
       status: 'draft',
@@ -1107,16 +1437,23 @@ module('Integration | Component | response-mentor-reply', function (hooks) {
 
   test('filters out trashed responses from display', async function (assert) {
     const store = this.owner.lookup('service:store');
-    const user = store.createRecord('user', { id: 'user1', username: 'mentor' });
-    const submission = store.createRecord('submission', { creator: { username: 'student' } });
-    
+    const user = store.createRecord('user', {
+      id: 'user1',
+      username: 'mentor',
+    });
+    const submission = store.createRecord('submission', {
+      creator: { username: 'student' },
+    });
+
     const visibleDraft = store.createRecord('response', {
       text: 'Visible draft',
       status: 'draft',
       createDate: new Date('2024-01-01'),
     });
     visibleDraft.createdBy = user;
-    visibleDraft.recipient = store.createRecord('user', { username: 'student' });
+    visibleDraft.recipient = store.createRecord('user', {
+      username: 'student',
+    });
     visibleDraft.submission = submission;
     mockResponseGet(visibleDraft);
     setupResponse(visibleDraft, submission);
@@ -1128,7 +1465,9 @@ module('Integration | Component | response-mentor-reply', function (hooks) {
       createDate: new Date('2024-01-02'),
     });
     trashedDraft.createdBy = user;
-    trashedDraft.recipient = store.createRecord('user', { username: 'student' });
+    trashedDraft.recipient = store.createRecord('user', {
+      username: 'student',
+    });
     trashedDraft.submission = submission;
     mockResponseGet(trashedDraft);
     setupResponse(trashedDraft, submission);
@@ -1154,8 +1493,12 @@ module('Integration | Component | response-mentor-reply', function (hooks) {
       isOlderRevision: true,
     });
 
-    assert.dom('a.primary-button').doesNotExist('New Response button should be hidden for older revisions');
-    assert.dom('.info').doesNotExist('No replies message should also be hidden');
+    assert
+      .dom('a.primary-button')
+      .doesNotExist('New Response button should be hidden for older revisions');
+    assert
+      .dom('.info')
+      .doesNotExist('No replies message should also be hidden');
   });
 
   test('shows New Response button when isOlderRevision is false', async function (assert) {
@@ -1168,7 +1511,9 @@ module('Integration | Component | response-mentor-reply', function (hooks) {
       isOlderRevision: false,
     });
 
-    assert.dom('a.primary-button').exists('New Response button should appear for most recent submission');
+    assert
+      .dom('a.primary-button')
+      .exists('New Response button should appear for most recent submission');
     assert.dom('a.primary-button').hasText('New Response');
   });
 });


### PR DESCRIPTION
## Description
Adds Final Edit History rendering to `response-mentor-reply` so prior saved final edits are visible under Previous Conversation, with ownership filtering and safe HTML rendering.  
Also includes related integration tests and a small `response-new` button-label fix (`canDirectSend` => `Send`).

## Problem
- Previous Conversation was gated by mentor replies only, so final-edit-only history was not shown.
- Final edit history needed safe rendering (avoid raw/unsafe HTML) while preserving readable formatting.
- History visibility needed ownership filtering so users only see their own saved history entries.
- `response-new` direct-send button text did not match expected behavior (`Submit` vs `Send`).

## What Changed
- Updated `app/components/response-mentor-reply.js`:
  - `sortedMentorReplies` safely handles plain arrays + Ember arrays and returns `[]` when empty.
  - simplified `sortedMentorReplies` to a single deterministic native date-sort path by removing redundant/unreachable branching.
  - added `finalEditHistoryEntries` pipeline:
    - reads `submission.aiFinalEditVersions`
    - supports `toArray` fallback
    - sorts by `savedAt` ascending
    - falls back to legacy fields (`aiFinalEditText`, `aiFinalEditAt`, `aiFinalEditBy`)
    - filters to current logged-in user entries
  - added safe rendering + identity helpers:
    - `_toSafeHistoryHtml`
    - `_buildUserNameByIdMap`
    - `_resolveSavedByDisplay`
    - `_normalizeObjectId`
    - `_getUserDisplayName`
- Updated `app/components/response-mentor-reply.hbs`:
  - switched gate from `this.sortedMentorReplies.length` to `this.hasPreviousConversation`
  - added `Final Edit History` section under Previous Conversation
  - renders timestamp + optional saved-by
  - renders sanitized history body (`entry.html`)
  - hides empty-state/no-reply message when `@isOlderRevision` is true
- Updated `tests/integration/components/response-mentor-reply-test.js`:
  - added coverage for:
    - ascending history order
    - current-user-only visibility
    - no render for non-owner history
    - legacy fallback ownership behavior
    - saved-by display resolution
    - HTML sanitization behavior
    - plain-text newline preservation
- Updated `app/components/response-new.js`:
  - `submitButtonText` returns `Send` when `canDirectSend` is true

## Impact
- Final edit history now appears even when no mentor replies exist.
- History rendering is safer and preserves expected formatting.
- Users only see their own saved final edit history entries.
- Older revisions no longer show incorrect empty-state messaging.
- `response-new` direct-send CTA now matches expected UX/test behavior.
- No backend schema/API changes in this PR; frontend + tests only.

## Testing
1. Open a submission with `aiFinalEditVersions` data and no mentor replies.
2. Confirm Previous Conversation renders and includes Final Edit History.
3. Verify entries are shown in ascending `savedAt` order.
4. Verify only current user’s entries are shown.
5. Verify no history section renders when only other users’ final-edit entries exist.
6. Verify (`aiFinalEditText/At/By`) appears only when owner matches.
7. Verify rich text is preserved safely and plain text line breaks are rendered.
8. Verify `response-new` save button shows `Send` when `canDirectSend=true`.