### PR TITLE
Feat/ai draft review history

### DIFF
--- a/app/components/ai-variant-comparison.js
+++ b/app/components/ai-variant-comparison.js
@@ -372,6 +372,8 @@ export default class AiVariantComparisonComponent extends Component {
           this.requestIdA,
           this.requestIdD
         ),
+        rating: variantCode === 'A' ? this.ratingA : this.ratingD,
+        writtenFeedback: variantCode === 'A' ? this.feedbackA : this.feedbackD,
       });
     }
   }

--- a/app/components/response-mentor-reply.hbs
+++ b/app/components/response-mentor-reply.hbs
@@ -194,21 +194,41 @@
         {{#each this.finalEditHistoryEntries as |entry|}}
           <div class='response-mentor-container final-edit-history-item'>
             <div class='response-mentor-info'>
-              <div class='response-users'>
-                <p class='response-time final-edit-history-saved-at'>
-                  {{#if entry.savedAt}}
-                    {{format-date entry.savedAt 'MMMM Do, YYYY'}}
-                    {{format-date entry.savedAt 'h:mm a'}}
-                  {{else}}
-                    Saved time unavailable
-                  {{/if}}
-                </p>
-                {{#if entry.savedBy}}
-                  <p>
-                    <span class='response-label'>Saved By:</span>
-                    <span class='response-value final-edit-history-saved-by'>{{entry.savedBy}}</span>
+              <div class='response-users' style='display: flex; justify-content: space-between; align-items: flex-start; gap: 2rem;'>
+                <div class='final-edit-history-left'>
+                  <p class='response-time final-edit-history-saved-at'>
+                    {{#if entry.savedAt}}
+                      {{format-date entry.savedAt 'MMMM Do, YYYY'}}
+                      {{format-date entry.savedAt 'h:mm a'}}
+                    {{else}}
+                      Saved time unavailable
+                    {{/if}}
                   </p>
-                {{/if}}
+                  {{#if entry.savedBy}}
+                    <p>
+                      <span class='response-label'>Saved By:</span>
+                      <span class='response-value final-edit-history-saved-by'>{{entry.savedBy}}</span>
+                    </p>
+                  {{/if}}
+                </div>
+                <div class='final-edit-history-right' style='text-align: right;'>
+                  {{#if entry.rating}}
+                    <p class='final-edit-history-rating' style='margin-bottom: 0.5rem;'>
+                      <span class='response-label'>AI Draft Rating:</span>
+                      <span class='response-value star-rating-display' style='display: inline-flex; gap: 0.3em; margin-left: 0.5rem;'>
+                        {{#each (array 1 2 3 4 5) as |starNum|}}
+                          <i class='fas fa-star star-icon {{if (this.isHistoryStarFilled starNum entry.rating) "star-filled" "star-empty"}}' style='font-size: 18px;'></i>
+                        {{/each}}
+                      </span>
+                    </p>
+                  {{/if}}
+                  {{#if entry.writtenFeedback}}
+                    <p class='final-edit-history-feedback' style='margin-top: 0.5rem; text-align: left;'>
+                      <span class='response-label' style='display: block; margin-bottom: 0.25rem;'>AI Draft Feedback:</span>
+                      <span class='response-value' style='display: block; font-style: italic; word-break: break-word;'>{{entry.writtenFeedback}}</span>
+                    </p>
+                  {{/if}}
+                </div>
               </div>
               <div class='response-text-container'>
                 <div class='response-text final-edit-history-text'>

--- a/app/components/response-mentor-reply.hbs
+++ b/app/components/response-mentor-reply.hbs
@@ -10,7 +10,9 @@
     <div class='ab-draft-editor-section'>
       <p class='response-header'>Draft Editor</p>
       <Ui::QuillContainer
+        @attrSectionId='variant-draft-editor'
         @onEditorChange={{this.updateVariantComposeText}}
+        @onQuillReady={{this.onVariantQuillReady}}
         @startingText={{this.variantComposeText}}
         @maxLength={{10000}}
         @showErrors={{true}}
@@ -235,6 +237,13 @@
                   {{{entry.html}}}
                 </div>
               </div>
+              {{#if @isCreating}}
+                <div class='final-edit-history-actions button-row'>
+                  <button {{on 'click' (fn this.copyHistoryEntryToEditor entry)}} class='primary-button' type='button' title='Copy this version into the Draft Editor'>
+                    Copy to Editor
+                  </button>
+                </div>
+              {{/if}}
             </div>
           </div>
         {{/each}}

--- a/app/components/response-mentor-reply.js
+++ b/app/components/response-mentor-reply.js
@@ -32,6 +32,8 @@ export default class ResponseMentorReplyComponent extends Component {
   @tracked latestBroughtDownVariantLogId = null;
   @tracked latestBroughtDownRequestId = null;
   @tracked latestBroughtDownVariantKey = null;
+  @tracked latestBroughtDownRating = null;
+  @tracked latestBroughtDownFeedback = null;
 
   maxResponseLength = 14680064;
 
@@ -50,6 +52,10 @@ export default class ResponseMentorReplyComponent extends Component {
 
   get statusIconFill() {
     return this.args.iconFillOptions?.[this.args.displayResponse?.status];
+  }
+
+  isHistoryStarFilled(starNum, rating) {
+    return rating != null && starNum <= rating;
   }
 
   _checkResponseChange() {
@@ -207,6 +213,8 @@ export default class ResponseMentorReplyComponent extends Component {
           savedAt,
           savedBy,
           savedById,
+          rating: version?.rating ?? null,
+          writtenFeedback: version?.writtenFeedback ?? null,
         };
       })
       .filter((entry) => entry.html || entry.savedAt);
@@ -232,14 +240,16 @@ export default class ResponseMentorReplyComponent extends Component {
             fallbackSavedAt && !Number.isNaN(fallbackSavedAt.getTime())
               ? fallbackSavedAt
               : null,
+          rating: null,
+          writtenFeedback: null,
         },
       ];
     }
 
     return normalized.sort((a, b) => {
-      const aMs = a.savedAt ? a.savedAt.getTime() : Number.POSITIVE_INFINITY;
-      const bMs = b.savedAt ? b.savedAt.getTime() : Number.POSITIVE_INFINITY;
-      return aMs - bMs;
+      const aMs = a.savedAt ? a.savedAt.getTime() : Number.NEGATIVE_INFINITY;
+      const bMs = b.savedAt ? b.savedAt.getTime() : Number.NEGATIVE_INFINITY;
+      return bMs - aMs;
     });
   }
 
@@ -934,6 +944,8 @@ export default class ResponseMentorReplyComponent extends Component {
       sourceVariantLogId: this.latestBroughtDownVariantLogId,
       sourceRequestId: this.latestBroughtDownRequestId,
       sourceVariantKey: this.latestBroughtDownVariantKey,
+      rating: this.latestBroughtDownRating,
+      writtenFeedback: this.latestBroughtDownFeedback,
     };
     const payload = {
       aiFinalEditText: this.quillText,
@@ -1025,6 +1037,8 @@ export default class ResponseMentorReplyComponent extends Component {
       this.latestBroughtDownVariantLogId = draftSelection.variantLogId || null;
       this.latestBroughtDownRequestId = draftSelection.requestId || null;
       this.latestBroughtDownVariantKey = draftSelection.variantKey || null;
+      this.latestBroughtDownRating = draftSelection.rating || null;
+      this.latestBroughtDownFeedback = draftSelection.writtenFeedback || null;
     }
 
     const preparedDraft = this._prepareDraftForEditor(draftText);

--- a/app/components/response-mentor-reply.js
+++ b/app/components/response-mentor-reply.js
@@ -29,6 +29,7 @@ export default class ResponseMentorReplyComponent extends Component {
   @tracked quillKey = 0;
   @tracked variantComposeText = '';
   @tracked isSavingFinalEdit = false;
+  @tracked variantQuillInstance = null;
   @tracked latestBroughtDownVariantLogId = null;
   @tracked latestBroughtDownRequestId = null;
   @tracked latestBroughtDownVariantKey = null;
@@ -512,13 +513,22 @@ export default class ResponseMentorReplyComponent extends Component {
     return 'AI Draft';
   }
 
-  _withDraftHeadline(draftText, variantKey = null) {
-    const headline = this._headlineForVariant(variantKey);
+  _withDraftHeadline(draftText, variantKey = null, customHeadline = null) {
+    const headline = customHeadline || this._headlineForVariant(variantKey);
     return `<p><strong>${headline}</strong></p><p><br></p>${draftText}`;
   }
 
-  _mergeDraftIntoEditor(existingContent, draftText, variantKey = null) {
-    const block = this._withDraftHeadline(draftText, variantKey);
+  _mergeDraftIntoEditor(
+    existingContent,
+    draftText,
+    variantKey = null,
+    customHeadline = null
+  ) {
+    const block = this._withDraftHeadline(
+      draftText,
+      variantKey,
+      customHeadline
+    );
     if (this._isEmptyEditorContent(existingContent)) {
       return block;
     }
@@ -1001,6 +1011,11 @@ export default class ResponseMentorReplyComponent extends Component {
   }
 
   @action
+  onVariantQuillReady(quillInstance) {
+    this.variantQuillInstance = quillInstance;
+  }
+
+  @action
   cancelCompose() {
     this.editRevisionText = '';
     this.editRevisionNote = '';
@@ -1053,4 +1068,40 @@ export default class ResponseMentorReplyComponent extends Component {
     this.quillText = mergedText;
   }
   // END TEMPORARY A/B TEST CODE
+
+  @action
+  copyHistoryEntryToEditor(entry) {
+    if (!entry?.html) return;
+
+    // Check if we have the Quill instance
+    if (!this.variantQuillInstance) {
+      console.error('Variant Quill instance not ready');
+      return;
+    }
+
+    // Get existing content from the Quill editor
+    const existingContent = this.variantQuillInstance.root.innerHTML || '';
+
+    // Merge: if editor is empty, just use the entry html; otherwise append
+    const mergedText = this._isEmptyEditorContent(existingContent)
+      ? entry.html
+      : `${existingContent}<p><br></p>${entry.html}`;
+
+    // Use Quill's clipboard API to properly set HTML content
+    const delta = this.variantQuillInstance.clipboard.convert(mergedText);
+    this.variantQuillInstance.setContents(delta, 'user');
+
+    // Update tracked properties to keep them in sync
+    this.variantComposeText = mergedText;
+    this.quillText = mergedText;
+
+    this.alert.showToast(
+      'success',
+      'Final edit version copied to editor',
+      'bottom-end',
+      2000,
+      false,
+      null
+    );
+  }
 }

--- a/app/components/ui/quill-container.js
+++ b/app/components/ui/quill-container.js
@@ -67,6 +67,11 @@ export default class QuillContainerComponent extends Component {
     this.handleStartingText();
     this.handleQuillChange();
     this.previousStartingText = this.args.startingText;
+
+    // Notify parent component if callback provided
+    if (this.args.onQuillReady) {
+      this.args.onQuillReady(quill);
+    }
   }
 
   @action

--- a/app_server/datasource/api/aiVariantApi.js
+++ b/app_server/datasource/api/aiVariantApi.js
@@ -71,6 +71,16 @@ async function putVariant(req, res) {
 
     variant.rating = rating;
     variant.teacherNotes = teacherNotes;
+    // Append to history so each logged review is preserved (never overwritten)
+    if (!Array.isArray(variant.reviewHistory)) {
+      variant.reviewHistory = [];
+    }
+    variant.reviewHistory.push({
+      rating,
+      teacherNotes,
+      reviewedAt: new Date(),
+      reviewedBy: user._id,
+    });
     variant.lastModifiedBy = user._id;
     variant.lastModifiedDate = new Date();
     await variant.save();

--- a/app_server/datasource/api/submissionApi.js
+++ b/app_server/datasource/api/submissionApi.js
@@ -418,6 +418,8 @@ function putSubmission(req, res, next) {
         sourceVariantLogId: appendAiFinalEditVersion.sourceVariantLogId || null,
         sourceRequestId: appendAiFinalEditVersion.sourceRequestId || null,
         sourceVariantKey: appendAiFinalEditVersion.sourceVariantKey || null,
+        rating: appendAiFinalEditVersion.rating || null,
+        writtenFeedback: appendAiFinalEditVersion.writtenFeedback || null,
       });
     }
 

--- a/app_server/datasource/schemas/aiVariant.js
+++ b/app_server/datasource/schemas/aiVariant.js
@@ -32,9 +32,18 @@ var AIVariantSchema = new Schema(
     draftText: { type: String, required: true },
 
     // Teacher evaluation/interaction
-    rating: { type: Number, min: 1, max: 5 }, // Teacher's rating of this variant
+    rating: { type: Number, min: 1, max: 5 }, // Teacher's rating of this variant (latest)
     isSelected: { type: Boolean, default: false }, // Did teacher choose this variant?
-    teacherNotes: { type: String }, // Teacher's notes about this variant
+    teacherNotes: { type: String }, // Teacher's notes about this variant (latest)
+    // Append-only review history so past reviews are never overwritten
+    reviewHistory: [
+      {
+        rating: { type: Number, min: 1, max: 5 },
+        teacherNotes: { type: String },
+        reviewedAt: { type: Date },
+        reviewedBy: { type: ObjectId, ref: 'User' },
+      },
+    ],
 
     // Technical metadata
     requestId: { type: String },

--- a/app_server/datasource/schemas/submission.js
+++ b/app_server/datasource/schemas/submission.js
@@ -58,6 +58,8 @@ var baseSubmission = {
       sourceVariantLogId: { type: ObjectId, ref: 'AIVariant' },
       sourceRequestId: { type: String },
       sourceVariantKey: { type: String },
+      rating: { type: Number },
+      writtenFeedback: { type: String },
     },
   ],
 };


### PR DESCRIPTION
## Description
Adds Final Edit History rendering to `response-mentor-reply` with rating/feedback display, copy-to-editor functionality, and append-only review history tracking.

## What Changed

### Frontend
- **response-mentor-reply.js**
  - Added `variantQuillInstance`, `latestBroughtDownRating`, `latestBroughtDownFeedback` tracked properties
  - Added `isHistoryStarFilled()` helper for star rendering
  - Extended `finalEditHistoryEntries` to include `rating` and `writtenFeedback`
  - Changed sort order: ascending → descending (newest first)
  - Added `onVariantQuillReady()` to capture Quill instance
  - Added `copyHistoryEntryToEditor()` action using Quill clipboard API
  - Updated `bringDraftDown()` and `saveFinalEdit()` to persist rating/feedback

- **response-mentor-reply.hbs**
  - Added `@onQuillReady` callback to QuillContainer
  - Split history layout: left (timestamp/saved-by) + right (rating/feedback display)
  - Added "Copy to Editor" button per history entry (visible when `@isCreating`)

- **ui/quill-container.js**
  - Added `@args.onQuillReady` callback invocation after init

- **ai-variant-comparison.js**
  - Pass `rating` and `writtenFeedback` when bringing down draft

### Backend
- **submission.js schema**
  - Added `rating` (Number) and `writtenFeedback` (String) to `aiFinalEditVersions`

- **submissionApi.js**
  - Persist `rating` and `writtenFeedback` when appending final edit version

- **aiVariant.js schema**
  - Added append-only `reviewHistory` array (prevents rating/feedback overwrites)

- **aiVariantApi.js**
  - Push to `reviewHistory` instead of overwriting `rating`/`teacherNotes`

## Testing
1. Open submission with final edit history → verify display with rating/feedback
2. Verify newest-first sorting
3. Verify ownership filtering (only current user's entries)
4. Click "Copy to Editor" → verify content merges correctly
5. Rate AI draft, bring down, save → verify rating/feedback persist
6. Update variant rating multiple times → verify `reviewHistory` appends

## Files Changed
- `app/components/response-mentor-reply.{js,hbs}`
- `app/components/ui/quill-container.js`
- `app/components/ai-variant-comparison.js`
- `app_server/datasource/api/{submissionApi.js,aiVariantApi.js}`
- `app_server/datasource/schemas/{submission.js,aiVariant.js}`