### PR TITLE
Persist AI draft annotation snapshots and use them in workspace reports

### DIFF
--- a/app/components/ai-variant-comparison.hbs
+++ b/app/components/ai-variant-comparison.hbs
@@ -66,7 +66,7 @@
           disabled={{not this.canBringDownA}}
           title={{this.bringDownTooltipA}}
           {{on "click" (fn this.bringDownVariant 'A')}}
-        >Bring It Down</button>
+        >Copy to Editor</button>
       </div>
     </div>
     <div class="variant-cell-simple">
@@ -113,7 +113,7 @@
           disabled={{not this.canBringDownD}}
           title={{this.bringDownTooltipB}}
           {{on "click" (fn this.bringDownVariant 'D')}}
-        >Bring It Down</button>
+        >Copy to Editor</button>
       </div>
     </div>
   </div>

--- a/app/services/workspace-reports.js
+++ b/app/services/workspace-reports.js
@@ -175,6 +175,92 @@ export default class WorkspaceReportsService extends Service {
     return 'The student is sharing their mathematical thinking and work.';
   }
 
+  buildSelectionRowsFromSubmission(submission) {
+    const selections = submission
+      .get('selections')
+      .filterBy('isTrashed', false)
+      .slice();
+
+    return selections.length === 0
+      ? [{}]
+      : selections.flatMap((selection) => {
+          const selectorInfo = this.createSelectorInfo(selection);
+          const folders = this.getUniqueFolderNames(selection).join('; ');
+          const comments = (selection.get('comments') || []).filterBy(
+            'isTrashed',
+            false
+          );
+
+          if (comments.length === 0) {
+            return [
+              {
+                [`Selector of Text`]: selectorInfo.username,
+                [`Text of Selection`]: selectorInfo.text,
+                [`Selector Date`]: selectorInfo.selectionCreateDate,
+                [`Annotator`]: '',
+                [`Text of Annotator`]: '',
+                [`Annotator Date`]: '',
+                [`Folder(s) for Selection`]: folders,
+              },
+            ];
+          }
+
+          return comments.map((comment) => {
+            const annotatorText = this.stripHtml(comment.get('text'));
+            const annotatorUsername = comment.get('createdBy.username');
+            const commentDate = new Date(comment.get('createDate'));
+            const annotatorCreateDate = isValid(commentDate)
+              ? format(commentDate, 'MM/dd/yyyy')
+              : '';
+            return {
+              [`Selector of Text`]: selectorInfo.username,
+              [`Text of Selection`]: selectorInfo.text,
+              [`Selector Date`]: selectorInfo.selectionCreateDate,
+              [`Annotator`]: annotatorUsername,
+              [`Text of Annotator`]: annotatorText,
+              [`Annotation Label`]: comment.get('label') || '',
+              [`Annotator Date`]: annotatorCreateDate,
+              [`Folder(s) for Selection`]: folders,
+            };
+          });
+        });
+  }
+
+  buildSelectionRowsFromSnapshot(sentAnnotations) {
+    if (!Array.isArray(sentAnnotations) || sentAnnotations.length === 0) {
+      return [{}];
+    }
+
+    return sentAnnotations.flatMap((selection) => {
+      const baseRow = {
+        [`Selector of Text`]: selection.selectorUsername || '',
+        [`Text of Selection`]: this.stripHtml(selection.selectedText || ''),
+        [`Selector Date`]: this.formatDateOnlyOrEmpty(selection.selectorDate),
+        [`Folder(s) for Selection`]: '',
+      };
+      const comments = Array.isArray(selection.comments) ? selection.comments : [];
+
+      if (comments.length === 0) {
+        return [
+          {
+            ...baseRow,
+            [`Annotator`]: '',
+            [`Text of Annotator`]: '',
+            [`Annotator Date`]: '',
+          },
+        ];
+      }
+
+      return comments.map((comment) => ({
+        ...baseRow,
+        [`Annotator`]: comment.annotatorUsername || '',
+        [`Text of Annotator`]: this.stripHtml(comment.text || ''),
+        [`Annotation Label`]: comment.type || '',
+        [`Annotator Date`]: this.formatDateOnlyOrEmpty(comment.annotatorDate),
+      }));
+    });
+  }
+
   async submissionReportCsv(model) {
     const submissionsArray = model.submissions.slice();
 
@@ -268,6 +354,8 @@ export default class WorkspaceReportsService extends Service {
             ),
             'AI Final Edit Version': '',
             'AI Final Edit Saved At': '',
+            _sentAnnotations:
+              variantB?.sentAnnotations || variantA?.sentAnnotations || [],
           };
         }
       );
@@ -366,70 +454,24 @@ export default class WorkspaceReportsService extends Service {
         'Number of Notice/Wonder/Feedback': model.workspace.commentsLength,
         'EnCoMPASS templated response': '',
       };
-      const selections = submission
-        .get('selections')
-        .filterBy('isTrashed', false)
-        .slice();
-      const selectionRows =
-        selections.length === 0
-          ? [{}]
-          : selections.flatMap((selection) => {
-              const selectorInfo = this.createSelectorInfo(selection);
-              const folders = this.getUniqueFolderNames(selection).join('; ');
-              const comments = (selection.get('comments') || []).filterBy(
-                'isTrashed',
-                false
-              );
+      const liveSelectionRows = this.buildSelectionRowsFromSubmission(submission);
 
-              if (comments.length === 0) {
-                return [
-                  {
-                    [`Selector of Text`]: selectorInfo.username,
-                    [`Text of Selection`]: selectorInfo.text,
-                    [`Selector Date`]: selectorInfo.selectionCreateDate,
-                    [`Annotator`]: '',
-                    [`Text of Annotator`]: '',
-                    [`Annotator Date`]: '',
-                    [`Folder(s) for Selection`]: folders,
-                  },
-                ];
-              }
+      return combinedAiRows.flatMap((aiData) => {
+        const sentAnnotations = Array.isArray(aiData._sentAnnotations)
+          ? aiData._sentAnnotations
+          : [];
+        const selectionRows = sentAnnotations.length
+          ? this.buildSelectionRowsFromSnapshot(sentAnnotations)
+          : liveSelectionRows;
+        const reportAiData = { ...aiData };
+        delete reportAiData._sentAnnotations;
 
-              return comments.map((comment) => {
-                const annotatorText = this.stripHtml(comment.get('text'));
-                const annotatorUsername = comment.get('createdBy.username');
-                const commentDate = new Date(comment.get('createDate'));
-                const annotatorCreateDate = isValid(commentDate)
-                  ? format(commentDate, 'MM/dd/yyyy')
-                  : '';
-                return {
-                  [`Selector of Text`]: selectorInfo.username,
-                  [`Text of Selection`]: selectorInfo.text,
-                  [`Selector Date`]: selectorInfo.selectionCreateDate,
-                  [`Annotator`]: annotatorUsername,
-                  [`Text of Annotator`]: annotatorText,
-                  [`Annotation Label`]: comment.get('label') || '',
-                  [`Annotator Date`]: annotatorCreateDate,
-                  [`Folder(s) for Selection`]: folders,
-                };
-              });
-            });
-
-      const baseRows = selectionRows.map((selectionData, index) => ({
-        ...staticData,
-        ...(index === 0 ? combinedAiRows[0] || emptyAiData : emptyAiData),
-        ...selectionData,
-      }));
-
-      if (combinedAiRows.length <= 1) {
-        return baseRows;
-      }
-
-      const extraAiRows = combinedAiRows.slice(1).map((aiData) => ({
-        ...staticData,
-        ...aiData,
-      }));
-      return baseRows.concat(extraAiRows);
+        return selectionRows.map((selectionData) => ({
+          ...staticData,
+          ...reportAiData,
+          ...selectionData,
+        }));
+      });
     });
 
     const headers = [...new Set(data.flatMap((row) => Object.keys(row)))];
@@ -481,6 +523,12 @@ export default class WorkspaceReportsService extends Service {
     if (!value) return '';
     const dateValue = value instanceof Date ? value : new Date(value);
     return isValid(dateValue) ? format(dateValue, 'MM/dd/yyyy HH:mm') : '';
+  }
+
+  formatDateOnlyOrEmpty(value) {
+    if (!value) return '';
+    const dateValue = value instanceof Date ? value : new Date(value);
+    return isValid(dateValue) ? format(dateValue, 'MM/dd/yyyy') : '';
   }
 
   generateRevisionFields(submissionLabel, maxRevisions) {

--- a/app_server/datasource/api/aiApi.js
+++ b/app_server/datasource/api/aiApi.js
@@ -57,6 +57,9 @@ async function aiDraft(req, res) {
       typeof draftResult === 'object' && draftResult?.draft
         ? draftResult.draft
         : draftResult;
+    const sentAnnotations = Array.isArray(draftResult?.sentAnnotations)
+      ? draftResult.sentAnnotations
+      : [];
     const variantConfigData = variantConfig.activeVariants.find(
       (v) => v.key === variant
     );
@@ -75,6 +78,7 @@ async function aiDraft(req, res) {
           variantLabel: variantConfigData.label,
           inputType: variantConfigData.inputType,
           draftText: draftText,
+          sentAnnotations,
           requestId,
           createdBy: user._id,
         });
@@ -102,6 +106,7 @@ async function aiDraft(req, res) {
                 variantLabel: variantConfigData.label,
                 inputType: variantConfigData.inputType,
                 draftText,
+                sentAnnotations,
                 requestId,
                 lastModifiedBy: user._id,
                 lastModifiedDate: new Date(),

--- a/app_server/datasource/schemas/aiVariant.js
+++ b/app_server/datasource/schemas/aiVariant.js
@@ -30,6 +30,21 @@ var AIVariantSchema = new Schema(
 
     // AI-generated content
     draftText: { type: String, required: true },
+    sentAnnotations: [
+      {
+        selectedText: { type: String },
+        selectorUsername: { type: String },
+        selectorDate: { type: Date },
+        comments: [
+          {
+            type: { type: String },
+            text: { type: String },
+            annotatorUsername: { type: String },
+            annotatorDate: { type: Date },
+          },
+        ],
+      },
+    ],
 
     // Teacher evaluation/interaction
     rating: { type: Number, min: 1, max: 5 }, // Teacher's rating of this variant (latest)

--- a/app_server/services/ai.js
+++ b/app_server/services/ai.js
@@ -204,16 +204,19 @@ const generateDraft = async (
     },
   };
 
-  const selectionsAndObservations = await buildSelectionsAndObservations(
+  const { requestRows, sentAnnotations } = await buildSelectionsAndObservations(
     targetSubmissionId,
     variant,
     workspaceId,
     teacherId
   );
-  requestBody.mentor_teacher_context.selections_and_observations =
-    selectionsAndObservations;
+  requestBody.mentor_teacher_context.selections_and_observations = requestRows;
 
-  return await makeAIRequest(requestBody);
+  const draft = await makeAIRequest(requestBody);
+  return {
+    draft,
+    sentAnnotations,
+  };
 };
 
 /**
@@ -236,12 +239,15 @@ const getTeacherSelections = async (submissionId, workspaceId, teacherId) => {
       selectionQuery.workspace = workspaceId;
     }
     const selections = await models.Selection.find(selectionQuery)
-      .select('text')
+      .populate('createdBy', 'username')
+      .select('text createDate createdBy')
       .lean()
       .exec();
     return selections.map((sel) => ({
       selection_id: String(sel._id),
       selected_text: stripHtml(sel.text),
+      selector_username: sel.createdBy?.username || '',
+      selector_date: sel.createDate || null,
       comments: [],
     }));
   } catch (error) {
@@ -271,7 +277,8 @@ const getTeacherComments = async (submissionId, workspaceId, teacherId) => {
     }
     const comments = await models.Comment.find(commentQuery)
       .populate('selection', 'text')
-      .select('text label selection')
+      .populate('createdBy', 'username')
+      .select('text label selection createDate createdBy')
       .lean()
       .exec();
     return comments.map((comment) => ({
@@ -283,6 +290,8 @@ const getTeacherComments = async (submissionId, workspaceId, teacherId) => {
       selected_text: stripHtml(comment.selection?.text || ''),
       type: comment.label, // notice, wonder, feedback
       text: stripHtml(comment.text),
+      annotator_username: comment.createdBy?.username || '',
+      annotator_date: comment.createDate || null,
     }));
   } catch (error) {
     logger.error('Error fetching teacher comments:', error);
@@ -318,7 +327,10 @@ const buildSelectionsAndObservations = async (
   selections.forEach((selection) => {
     const key = selection.selection_id || `sel_${list.length}`;
     const row = {
+      selection_id: selection.selection_id || null,
       selected_text: selection.selected_text || '',
+      selector_username: selection.selector_username || '',
+      selector_date: selection.selector_date || null,
       comments: [],
     };
     selectionMap.set(key, row);
@@ -331,7 +343,10 @@ const buildSelectionsAndObservations = async (
 
     if (!row) {
       row = {
+        selection_id: comment.selection_id || null,
         selected_text: comment.selected_text || '',
+        selector_username: '',
+        selector_date: null,
         comments: [],
       };
       selectionMap.set(key, row);
@@ -341,10 +356,31 @@ const buildSelectionsAndObservations = async (
     row.comments.push({
       type: comment.type || '',
       text: comment.text || '',
+      annotator_username: comment.annotator_username || '',
+      annotator_date: comment.annotator_date || null,
     });
   });
 
-  return list;
+  return {
+    requestRows: list.map((row) => ({
+      selected_text: row.selected_text || '',
+      comments: row.comments.map((comment) => ({
+        type: comment.type || '',
+        text: comment.text || '',
+      })),
+    })),
+    sentAnnotations: list.map((row) => ({
+      selectedText: row.selected_text || '',
+      selectorUsername: row.selector_username || '',
+      selectorDate: row.selector_date || null,
+      comments: row.comments.map((comment) => ({
+        type: comment.type || '',
+        text: comment.text || '',
+        annotatorUsername: comment.annotator_username || '',
+        annotatorDate: comment.annotator_date || null,
+      })),
+    })),
+  };
 };
 
 /**


### PR DESCRIPTION
# Description
store the exact selection/comment context sent with AI draft generation so workspace reports can reconstruct draft-specific annotation context even after workspace markup changes later

# Changes
- update `app_server/services/ai.js` to:
  - build a normalized `sentAnnotations` snapshot alongside the AI request
  - return `{ draft, sentAnnotations }` from draft generation
- update `app_server/datasource/api/aiApi.js` to:
  - save `sentAnnotations` on each `AIVariant`
  - persist the snapshot in both create and duplicate-key fallback paths
- update `app_server/datasource/schemas/aiVariant.js` to:
  - add `sentAnnotations` schema field
- update `app/services/workspace-reports.js` to:
  - prefer stored `sentAnnotations` when rendering workspace CSV rows
  - fall back to live submission selections/comments only when no snapshot exists
- update `app/components/ai-variant-comparison.hbs` to:
  - change button label from `Bring It Down` to `Copy to Editor`

# Testing
- Generated fresh Variant D drafts and confirmed new `AIVariant` rows contain `sentAnnotations` in the database
- Exported workspace reports before and after the report changes and compared the CSVs
- Deleted one live selection after draft generation and verified the post-snapshot reports did not show an obvious loss of already-generated draft context