### PR TITLE
Restore prefilled markup context in A/B draft editor

### DIFF
--- a/app/components/response-mentor-reply.hbs
+++ b/app/components/response-mentor-reply.hbs
@@ -13,7 +13,7 @@
         @attrSectionId='variant-draft-editor'
         @onEditorChange={{this.updateVariantComposeText}}
         @onQuillReady={{this.onVariantQuillReady}}
-        @startingText={{this.variantComposeText}}
+        @startingText={{this.variantEditorStartingText}}
         @maxLength={{10000}}
         @showErrors={{true}}
         @emptyErrorMessage='Message body cannot be blank'

--- a/app/components/response-mentor-reply.js
+++ b/app/components/response-mentor-reply.js
@@ -148,6 +148,57 @@ export default class ResponseMentorReplyComponent extends Component {
       : this.args.displayResponse;
   }
 
+  get variantSourceResponseData() {
+    return this.responseNewModel;
+  }
+
+  get variantFilteredSelections() {
+    const selections = this.variantSourceResponseData?.selections;
+    const selectionArray = Array.isArray(selections)
+      ? selections
+      : selections?.toArray?.() || selections?.content || [];
+
+    return selectionArray.filter((selection) => {
+      if (!selection || selection.isTrashed) {
+        return false;
+      }
+      const creatorId = this.utils.getBelongsToId(selection, 'createdBy');
+      return creatorId === this.currentUser.id;
+    });
+  }
+
+  get variantFilteredComments() {
+    const comments = this.variantSourceResponseData?.comments;
+    const commentArray = Array.isArray(comments)
+      ? comments
+      : comments?.toArray?.() || comments?.content || [];
+
+    return commentArray.filter((comment) => {
+      if (!comment || comment.isTrashed) {
+        return false;
+      }
+      const creatorId = this.utils.getBelongsToId(comment, 'createdBy');
+      return creatorId === this.currentUser.id;
+    });
+  }
+
+  get variantGreeting() {
+    const student = this.variantSourceResponseData?.student;
+    if (!student) return 'Hello,';
+    const firstSpace = student.indexOf(' ');
+    const firstName =
+      firstSpace === -1 ? student : student.slice(0, firstSpace);
+    return `Hello ${firstName},`;
+  }
+
+  get variantWho() {
+    return 'You';
+  }
+
+  get variantEditorStartingText() {
+    return this.variantComposeText || this.preFormatVariantText();
+  }
+
   get replyHeadingText() {
     if (this.isEditing) return 'Editing Mentor Reply';
     if (this.isRevising) return 'New Revision';
@@ -517,6 +568,82 @@ export default class ResponseMentorReplyComponent extends Component {
     if (variantKey === 'A') return 'Variant A';
     if (variantKey === 'D') return 'Variant B';
     return 'AI Draft';
+  }
+
+  _quotePrefillText(string, opts, isImageTag = false) {
+    let normalized = String(string || '').replace(/(\r\n|\n|\r)/gm, ' ');
+    const defaultPrefix = '         ';
+    let prefix = defaultPrefix;
+    let html = '';
+    let wrapInBlockQuote = true;
+
+    if (opts && Object.prototype.hasOwnProperty.call(opts, 'type')) {
+      wrapInBlockQuote = false;
+      if (opts.usePrefix) {
+        switch (opts.type) {
+          case 'notice':
+            prefix = '...and I noticed that...';
+            break;
+          case 'wonder':
+            prefix = '...and I wondered about...';
+            break;
+          case 'feedback':
+            prefix = '...and I thought...';
+            break;
+          default:
+            prefix = defaultPrefix;
+        }
+      }
+    }
+
+    if (wrapInBlockQuote) {
+      html += isImageTag
+        ? normalized
+        : `<blockquote class="pf-response-text">${normalized}</blockquote><br>`;
+    } else {
+      html += `<p>${prefix}</p><br>`;
+      html += isImageTag
+        ? normalized
+        : `<p class="pf-response-text">${normalized}</p><br>`;
+    }
+
+    return html;
+  }
+
+  preFormatVariantText() {
+    let text = `<p>${this.variantGreeting}</p><br>`;
+
+    if (this.variantFilteredSelections.length === 0) {
+      return text;
+    }
+
+    this.variantFilteredSelections.forEach((selection) => {
+      const who = this.variantWho;
+      const selectionText = selection.text || '';
+      const imageTagLink = selection.imageTagLink;
+      let quoteInput = selectionText;
+      let isImageTag = false;
+
+      if (imageTagLink) {
+        isImageTag = true;
+        quoteInput = `<img src="${imageTagLink}" alt="${selectionText}"><br>`;
+      }
+
+      text += `<p>${who} wrote:</p><br>`;
+      text += this._quotePrefillText(quoteInput, null, isImageTag);
+
+      this.variantFilteredComments.forEach((comment) => {
+        const selectionId = this.utils.getBelongsToId(comment, 'selection');
+        if (selectionId === selection.id) {
+          text += this._quotePrefillText(comment.text, {
+            type: comment.label,
+            usePrefix: true,
+          });
+        }
+      });
+    });
+
+    return text;
   }
 
   _withDraftHeadline(draftText, variantKey = null, customHeadline = null) {
@@ -1064,7 +1191,8 @@ export default class ResponseMentorReplyComponent extends Component {
 
     const preparedDraft = this._prepareDraftForEditor(draftText);
     this.aiGeneratedText = preparedDraft;
-    const existingContent = this.quillText || this.variantComposeText;
+    const existingContent =
+      this.quillText || this.variantComposeText || this.preFormatVariantText();
     const mergedText = this._mergeDraftIntoEditor(
       existingContent,
       preparedDraft,


### PR DESCRIPTION
## Description
Restores the pre-populated teacher markup context in the A/B draft editor so the draft area is seeded with the teacher's selections and comments before AI text is copied into the editor.

## What Changed

### Frontend

**app/components/response-mentor-reply.js**
- Added draft-editor prefill logic for the A/B compose flow
- Rebuilt the same teacher markup context pattern previously used in `response-new`
- Filtered the prefilled content to the current teacher's non-trashed selections and comments
- Restored greeting and quoted selection/comment formatting in the draft editor seed text
- Updated draft merge behavior so copied AI variants append below the existing prefilled context instead of replacing it

**app/components/response-mentor-reply.hbs**
- Changed the A/B draft editor to start from the restored prefilled text instead of an empty editor

## Why
The A/B draft editor no longer showed the existing teacher markup context that users previously saw in the response editor. That made it harder to tell what selections and comments were being used when generating and refining drafts.

## Testing
1. Open the A/B draft flow for a submission with teacher selections/comments
2. Verify the draft editor is pre-populated immediately on open
3. Verify the prefilled text includes the greeting plus quoted selections/comments
4. Generate or select an AI draft and click `Copy to Editor`
5. Verify the AI draft is appended below the existing prefilled context
6. Verify existing editor content is not overwritten when copying a draft

## Files Changed
- `app/components/response-mentor-reply.js` (prefill reconstruction, append behavior)
- `app/components/response-mentor-reply.hbs` (draft editor starting text)
