### PR TITLE
Add selection filter

### DIFF
--- a/app/components/workspace-submission.hbs
+++ b/app/components/workspace-submission.hbs
@@ -91,7 +91,10 @@
     {{/if}}
   </aside>
 
-  <div id='al_submission'>
+  <div
+    id='al_submission'
+    style={{if this.makingSelection 'height: auto; overflow-y: visible;' ''}}
+  >
     {{#if this.makingSelection}}
       <h3 id='sel-view-header' class='selectable-view-header'>Selectable View!</h3>
 
@@ -218,6 +221,48 @@
   </div>{{!/al_submission}}
   <h5 id='selections-header' class='submission-header selections'>
     Selections
+    <span
+      class='hide-show-selections'
+      style='position: relative; margin-right: 8px; padding: 0 5px;'
+      {{did-insert this.registerSelectionFilterMenu}}
+      {{will-destroy this.unregisterSelectionFilterMenu}}
+    >
+      <span
+        role='button'
+        tabindex='0'
+        title='Filter selections'
+        style='font-size: 1em; font-weight: 400; color: #5e5e5e; line-height: 25px; cursor: pointer;'
+        {{on 'click' this.toggleSelectionFilterMenu}}
+        {{on 'keydown' this.handleSelectionFilterKeydown}}
+      >
+        <span class='filter-label' style='margin-right: 5px;'>Filter</span><i class='fas fa-filter'></i>
+      </span>
+      {{#if this.showSelectionFilterMenu}}
+        <span
+          class='hover-menu checkbox'
+          style='display: block; position: absolute; top: 24px; right: 0; min-width: 240px; font-size: 1em; font-weight: 400; color: #5e5e5e;'
+        >
+          <ul>
+            {{#each-in this.selectionFilterOptions as |option values|}}
+              <li>
+                <label>
+                  <input
+                    type='checkbox'
+                    checked={{values.isChecked}}
+                    name={{option}}
+                    {{on 'click' (fn this.updateSelectionFilter option)}}
+                    disabled={{values.isDisabled}}
+                  />
+                  <span>
+                    <span class='radio-text' style='white-space: nowrap;'>{{values.label}}</span>
+                  </span>
+                </label>
+              </li>
+            {{/each-in}}
+          </ul>
+        </span>
+      {{/if}}
+    </span>
     {{#if this.showExpandSelections}}
       <div class='expand-selections'>
         <img

--- a/app/components/workspace-submission.js
+++ b/app/components/workspace-submission.js
@@ -24,6 +24,12 @@ export default class WorkspaceSubmissionComponent extends Component {
   @tracked vmtReplayerInfo = null;
   @tracked vmtScreenshot = null;
   @tracked vmtListener = null;
+  @tracked thisSubmissionOnly = true;
+  @tracked thisWorkspaceOnly = true;
+  @tracked mySelectionsOnly = true;
+  @tracked showSelectionFilterMenu = false;
+  selectionFilterMenuElement = null;
+  selectionFilterMenuOutsideHandler = null;
 
   get currentSelection() {
     return this.currentSelectionService.selection;
@@ -43,14 +49,48 @@ export default class WorkspaceSubmissionComponent extends Component {
   }
 
   get workspaceSelections() {
-    let subId = this.args.currentSubmission.id;
     return this.args.selections.filter((sel) => {
-      return subId === this.utils.getBelongsToId(sel, 'submission');
+      if (sel.isTrashed) return false;
+      return (
+        this._matchesSelectionWorkspaceFilter(sel) &&
+        this._matchesSelectionSubmissionFilter(sel) &&
+        this._matchesSelectionOwnerFilter(sel)
+      );
     });
   }
 
+  get selectionFilterOptions() {
+    const base = {
+      thisWorkspaceOnly: {
+        label: 'This Workspace Only',
+        isChecked: this.thisWorkspaceOnly,
+        isDisabled: this.args.isParentWorkspace,
+      },
+      thisSubmissionOnly: {
+        label: 'This Submission Only',
+        isChecked: this.thisSubmissionOnly,
+        isDisabled: false,
+      },
+    };
+    if (!this.args.isParentWorkspace) {
+      base.mySelectionsOnly = {
+        label: 'My Selections Only',
+        isChecked: this.mySelectionsOnly,
+        isDisabled: false,
+      };
+    }
+    return base;
+  }
+
   get trashedSelections() {
-    return this.workspaceSelections.filter((selection) => selection.isTrashed);
+    return this.args.selections.filter((selection) => {
+      if (!selection.isTrashed) return false;
+      return (
+        this._matchesSelectionWorkspaceFilter(selection) &&
+        this._matchesSelectionSubmissionFilter(selection) &&
+        this._matchesSelectionOwnerFilter(selection)
+      );
+    });
   }
 
   get canSelect() {
@@ -175,6 +215,90 @@ export default class WorkspaceSubmissionComponent extends Component {
   @action
   hideShowSelections() {
     this.areSelectionsHidden = !this.areSelectionsHidden;
+  }
+
+  @action
+  updateSelectionFilter(prop) {
+    if (prop === 'mySelectionsOnly' && this.args.isParentWorkspace) {
+      return;
+    }
+    this[prop] = !this[prop];
+  }
+
+  @action
+  toggleSelectionFilterMenu() {
+    this.showSelectionFilterMenu = !this.showSelectionFilterMenu;
+  }
+
+  @action
+  handleSelectionFilterKeydown(event) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.toggleSelectionFilterMenu();
+      return;
+    }
+    if (event.key === 'Escape') {
+      this.showSelectionFilterMenu = false;
+    }
+  }
+
+  @action
+  registerSelectionFilterMenu(element) {
+    this.selectionFilterMenuElement = element;
+    if (this.selectionFilterMenuOutsideHandler) {
+      return;
+    }
+    this.selectionFilterMenuOutsideHandler = (event) => {
+      if (!this.showSelectionFilterMenu || !this.selectionFilterMenuElement) {
+        return;
+      }
+      if (this.selectionFilterMenuElement.contains(event.target)) {
+        return;
+      }
+      this.showSelectionFilterMenu = false;
+    };
+    document.addEventListener(
+      'mousedown',
+      this.selectionFilterMenuOutsideHandler
+    );
+    document.addEventListener(
+      'touchstart',
+      this.selectionFilterMenuOutsideHandler
+    );
+  }
+
+  @action
+  unregisterSelectionFilterMenu() {
+    if (this.selectionFilterMenuOutsideHandler) {
+      document.removeEventListener(
+        'mousedown',
+        this.selectionFilterMenuOutsideHandler
+      );
+      document.removeEventListener(
+        'touchstart',
+        this.selectionFilterMenuOutsideHandler
+      );
+    }
+    this.selectionFilterMenuOutsideHandler = null;
+    this.selectionFilterMenuElement = null;
+  }
+
+  _matchesSelectionOwnerFilter(selection) {
+    if (!this.mySelectionsOnly) return true;
+    const creatorId = this.utils.getBelongsToId(selection, 'createdBy');
+    return creatorId === this.currentUser.id;
+  }
+
+  _matchesSelectionSubmissionFilter(selection) {
+    if (!this.thisSubmissionOnly) return true;
+    const submissionId = this.utils.getBelongsToId(selection, 'submission');
+    return submissionId === this.args.currentSubmission?.id;
+  }
+
+  _matchesSelectionWorkspaceFilter(selection) {
+    if (!this.thisWorkspaceOnly) return true;
+    const workspaceId = this.utils.getBelongsToId(selection, 'workspace');
+    return workspaceId === this.args.currentWorkspace?.id;
   }
 
   @action
@@ -350,28 +474,6 @@ export default class WorkspaceSubmissionComponent extends Component {
     super(...arguments);
     if (this.args.currentWorkspace?.workspaceType === 'parent') {
       this.makingSelection = false;
-    }
-  }
-
-  didInsertElement() {
-    super.didInsertElement(...arguments);
-    this.setOwnHeight();
-    this.setupResizeHandler();
-    this.setupVmtListener();
-  }
-
-  didReceiveAttrs() {
-    super.didReceiveAttrs(...arguments);
-    this.setupVmtListener();
-  }
-
-  didRender() {
-    super.didRender(...arguments);
-    if (this.args.switching === true) {
-      // Clear the switching flag after render is complete
-      setTimeout(() => {
-        // Notifies parent that switch is complete
-      }, 0);
     }
   }
 


### PR DESCRIPTION
## Description
Adds selection filtering controls in the workspace submission panel so selections can be scoped like comments (`This Workspace Only`, `This Submission Only`, `My Selections Only`), with defaults set to local/safe visibility.

## What Changed

### Frontend

**app/components/workspace-submission.js**
- Added tracked filter state for selections:
  - `thisWorkspaceOnly` (default `true`)
  - `thisSubmissionOnly` (default `true`)
  - `mySelectionsOnly` (default `true`, hidden/disabled in parent-workspace context)
- Added selection filter option model used by the template dropdown.
- Updated `workspaceSelections` and `trashedSelections` to apply workspace/submission/owner filter matching.
- Added filter actions:
  - `updateSelectionFilter`
  - `toggleSelectionFilterMenu`
  - `handleSelectionFilterKeydown`
  - `registerSelectionFilterMenu`
  - `unregisterSelectionFilterMenu`
- Added helper matchers for owner, submission, and workspace scope.
- Removed obsolete classic lifecycle hooks from this Glimmer component (`didInsertElement`, `didReceiveAttrs`, `didRender`).

**app/components/workspace-submission.hbs**
- Added a `Filter` control in the selections header with checkbox options matching comment-style filter UX.
- Wired dropdown lifecycle with `did-insert` / `will-destroy` for outside-click close handling.
- Bound filter option toggles to `updateSelectionFilter`.
- Kept selections panel directly below selectable view and set `#al_submission` inline style during selection mode to avoid layout push-down.

## Testing
1. Open a submission with selections from multiple users and/or submissions.
2. Verify default selection filter state is:
   - `This Workspace Only` = checked
   - `This Submission Only` = checked
   - `My Selections Only` = checked (non-parent workspaces)
3. Toggle each filter option and verify selection list updates correctly.
4. Open filter menu and click outside the menu; verify the menu closes.
5. Keyboard test: `Enter`/`Space` opens menu and `Escape` closes it.
6. Verify the selections panel remains positioned directly under the selectable view in selection mode.

## Files Changed
- `app/components/workspace-submission.js`
- `app/components/workspace-submission.hbs`
