### PR TITLE
fix(navigation): Fix workspace problem-link navigation in submission view

### DIFF
--- a/app/components/workspace-submission.js
+++ b/app/components/workspace-submission.js
@@ -452,20 +452,37 @@ export default class WorkspaceSubmissionComponent extends Component {
   }
 
   @action
-  async openProblem() {
-    const problemId = await this.args.currentSubmission?.answer?.problem?.id;
+  async openProblem(event) {
+    event?.preventDefault?.();
+
+    const readProp = (obj, key) => {
+      if (!obj) return undefined;
+      if (typeof obj.get === 'function') {
+        return obj.get(key);
+      }
+      return obj[key];
+    };
+
+    const submission = this.args.currentSubmission;
+    const answer = readProp(submission, 'answer');
+
+    let problem = readProp(answer, 'problem');
+    if (problem?.then) {
+      problem = await problem;
+    }
+
+    const puzzle = readProp(submission, 'puzzle');
+    const problemId =
+      readProp(problem, 'id') ||
+      this.utils.getBelongsToId(answer, 'problem') ||
+      readProp(answer, 'problemId') ||
+      readProp(puzzle, 'problemId');
+
     if (!problemId) {
       return;
     }
 
-    let getUrl = window.location;
-    let baseUrl = getUrl.protocol + '//' + getUrl.host;
-
-    window.open(
-      `${baseUrl}/#/problems/${problemId}`,
-      'newwindow',
-      'width=1200, height=700'
-    );
+    this.navigation.openProblem(problemId);
   }
 
   // Lifecycle hooks

--- a/app/services/navigation.js
+++ b/app/services/navigation.js
@@ -103,27 +103,23 @@ export default class NavigationService extends Service {
   /** Opens a problem in a new window */
   openProblem(problemId) {
     if (!problemId) return;
-    window.open(
-      `${window.location.origin}/#${this.router.urlFor(
-        'problems.problem',
-        problemId
-      )}`,
-      'newwindow',
-      'width=1200, height=700'
-    );
+    const problemPath = this.router.urlFor('problems.problem', problemId);
+    const problemUrl = new URL(problemPath, window.location.origin).toString();
+    window.open(problemUrl, 'newwindow', 'width=1200, height=700');
   }
 
   /** Opens a workspace submission in a new window */
   openSubmission(workspaceId, submissionId) {
     if (!workspaceId || !submissionId) return;
-    window.open(
-      `${window.location.origin}/#${this.router.urlFor(
-        'workspace.submissions.submission',
-        workspaceId,
-        submissionId
-      )}`,
-      'newwindow',
-      'width=1200, height=700'
+    const submissionPath = this.router.urlFor(
+      'workspace.submissions.submission',
+      workspaceId,
+      submissionId
     );
+    const submissionUrl = new URL(
+      submissionPath,
+      window.location.origin
+    ).toString();
+    window.open(submissionUrl, 'newwindow', 'width=1200, height=700');
   }
 }


### PR DESCRIPTION
## Description
Fixes broken problem-link navigation from workspace submissions.  
The link flow now resolves problem ids safely from mixed Ember data shapes and uses centralized navigation URL building so clicks reliably open the intended problem page.

## What Changed

### Frontend

**app/components/workspace-submission.js**
- Refactored `openProblem` to use proxy-safe property reads (`.get(...)` fallback) to avoid assertion failures on Ember proxy objects.
- Added robust problem id resolution from multiple available fields:
  - `answer.problem.id`
  - belongs-to relationship id via `getBelongsToId(answer, 'problem')`
  - `answer.problemId`
  - `submission.puzzle.problemId`
- Delegates final navigation to `navigation.openProblem(problemId)`.

**app/services/navigation.js**
- Updated `openProblem(problemId)` to build the destination URL via `router.urlFor('problems.problem', problemId)` and open it in a new window.
- Updated `openSubmission(workspaceId, submissionId)` similarly to use `router.urlFor(...)` path generation.

## Testing
1. Open workspace submission and click problem external-link icon.
2. Verify navigation opens the correct `/problems/:problem_id` target.
3. Test with submissions where `answer.problem` is loaded and where only relationship ids are present.
4. Confirm no Ember proxy assertion is thrown during click.
5. Confirm submission-link opening via navigation service still works.

## Files Changed
- `app/components/workspace-submission.js`
- `app/services/navigation.js`
