### PR TITLE
fix(ai-timeouts): increase AI draft request/poll timeouts for ticket …

### DIFF
--- a/app_server/services/ai.js
+++ b/app_server/services/ai.js
@@ -59,6 +59,9 @@ const normalizeApiPath = (path = '') => {
 };
 
 const STAGE_NAMES = new Set(['prod', 'dev', 'test', 'stage', 'staging']);
+const AI_DRAFT_HTTP_TIMEOUT_MS = 120000;
+const AI_DRAFT_POLL_MAX_MS = 120000 * 4;
+const AI_DRAFT_POLL_INTERVAL_MS = 1000;
 
 const getStagePrefix = (path = '') => {
   const segments = normalizeApiPath(path).split('/').filter(Boolean);
@@ -467,7 +470,7 @@ const makeAIRequest = async (requestBody) => {
             })
           )
         );
-        req.setTimeout(30000, () => {
+        req.setTimeout(AI_DRAFT_HTTP_TIMEOUT_MS, () => {
           req.destroy();
           rejectRequest(
             buildAIServiceError({
@@ -508,7 +511,7 @@ const makeAIRequest = async (requestBody) => {
         }
 
         const poll = () => {
-          if (Date.now() - startedAt >= 180000) {
+          if (Date.now() - startedAt >= AI_DRAFT_POLL_MAX_MS) {
             reject(new Error('Draft generation timed out. Please retry.'));
             return;
           }
@@ -536,7 +539,7 @@ const makeAIRequest = async (requestBody) => {
                 return;
               }
 
-              setTimeout(poll, 1000);
+              setTimeout(poll, AI_DRAFT_POLL_INTERVAL_MS);
             })
             .catch(reject);
         };


### PR DESCRIPTION
## Description
This PR updates Encompass AI ticket polling timeouts to reduce premature failures during slower upstream draft generation.

## What Changed
- Updated `app_server/services/ai.js` timeout handling in `makeAIRequest()`:
  - per-request HTTP timeout: `30s -> 120s`
  - total polling window: `180s -> 480s` (`120 * 4`)
  - polling interval remains `1s`, now through a named constant
- Replaced hardcoded values with constants:
  - `AI_DRAFT_HTTP_TIMEOUT_MS`
  - `AI_DRAFT_POLL_MAX_MS`
  - `AI_DRAFT_POLL_INTERVAL_MS`

## Why
Current behavior can fail while waiting for ticket completion when upstream latency is higher than expected. Increasing these limits gives longer-running ticket jobs time to finish.

## Manual Testing
1. Trigger AI draft generation for a submission.
3. Confirm no timeout failure before 480 seconds.
4. Validate timeout still occurs if job exceeds the total poll window.

## Files Changed
- `app_server/services/ai.js`