### PR TITLE
Feat/ai report attribution

### DIFF
--- a/app/components/ai-variant-comparison.js
+++ b/app/components/ai-variant-comparison.js
@@ -226,6 +226,14 @@ export default class AiVariantComparisonComponent extends Component {
         break;
     }
     this._resetReviewInputs(variantCode);
+
+    if (this.args.onVariantGenerated && variantLogId) {
+      this.args.onVariantGenerated({
+        variantKey: variantCode,
+        variantLogId,
+        requestId: requestId || null,
+      });
+    }
   }
 
   _canLogReview(variantCode) {

--- a/app/components/response-mentor-reply.hbs
+++ b/app/components/response-mentor-reply.hbs
@@ -5,6 +5,7 @@
     <AiVariantComparison
       @submission={{@submission}}
       @workspace={{@workspace}}
+      @onVariantGenerated={{this.handleVariantGenerated}}
       @onDraftSelected={{this.handleVariantDraftSelected}}
     />
     <div class='ab-draft-editor-section'>

--- a/app/components/response-mentor-reply.js
+++ b/app/components/response-mentor-reply.js
@@ -35,6 +35,8 @@ export default class ResponseMentorReplyComponent extends Component {
   @tracked latestBroughtDownVariantKey = null;
   @tracked latestBroughtDownRating = null;
   @tracked latestBroughtDownFeedback = null;
+  @tracked generatedVariantLogIds = [];
+  @tracked broughtDownVariantLogIds = [];
   @tracked isHistoryExpanded = false;
   @tracked expandedHistoryItems = new Set();
 
@@ -887,7 +889,7 @@ export default class ResponseMentorReplyComponent extends Component {
       this._resetEditState();
 
       if (!isDraft) {
-        await this._saveFinalVersionToVariant(this.quillText);
+        await this._saveFinalVersionToVariants(this.quillText);
         this.args.onSaveSuccess?.(this.args.submission, savedResponse);
       }
     } catch (err) {
@@ -924,7 +926,7 @@ export default class ResponseMentorReplyComponent extends Component {
 
     try {
       await this.args.displayResponse.save();
-      await this._saveFinalVersionToVariant(this.quillText);
+      await this._saveFinalVersionToVariants(this.quillText);
       this._endLoading();
       this._showSuccessToast('Response Updated');
       this.isEditing = false;
@@ -984,7 +986,7 @@ export default class ResponseMentorReplyComponent extends Component {
       }
       const [savedRevision] = await Promise.all(promises);
       if (!isDraft) {
-        await this._saveFinalVersionToVariant(this.quillText);
+        await this._saveFinalVersionToVariants(this.quillText);
       }
       this._endLoading();
       this._showSuccessToast(toastMessage);
@@ -1081,13 +1083,54 @@ export default class ResponseMentorReplyComponent extends Component {
     this.updateQuillText(content, isEmpty, isOverLengthLimit);
   }
 
-  async _markSelectedVariantAsUsed() {
-    if (!this.latestBroughtDownVariantLogId) {
+  _rememberBroughtDownVariantLogId(variantLogId) {
+    if (!variantLogId) {
+      return;
+    }
+
+    const normalizedId = String(variantLogId);
+    if (this.broughtDownVariantLogIds.includes(normalizedId)) {
+      return;
+    }
+
+    this.broughtDownVariantLogIds = [
+      ...this.broughtDownVariantLogIds,
+      normalizedId,
+    ];
+  }
+
+  _rememberGeneratedVariantLogId(variantLogId) {
+    if (!variantLogId) {
+      return;
+    }
+
+    const normalizedId = String(variantLogId);
+    if (this.generatedVariantLogIds.includes(normalizedId)) {
+      return;
+    }
+
+    this.generatedVariantLogIds = [
+      ...this.generatedVariantLogIds,
+      normalizedId,
+    ];
+  }
+
+  _getFinalVersionTargetVariantIds() {
+    const mergedIds = [
+      ...this.generatedVariantLogIds,
+      ...this.broughtDownVariantLogIds,
+      this.latestBroughtDownVariantLogId,
+    ].filter(Boolean);
+    return [...new Set(mergedIds)];
+  }
+
+  async _markSelectedVariantAsUsed(variantLogId) {
+    if (!variantLogId) {
       return;
     }
 
     try {
-      await fetch(`/api/aiVariants/${this.latestBroughtDownVariantLogId}`, {
+      await fetch(`/api/aiVariants/${variantLogId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'same-origin',
@@ -1103,26 +1146,54 @@ export default class ResponseMentorReplyComponent extends Component {
     }
   }
 
-  async _saveFinalVersionToVariant(finalText) {
-    if (!this.latestBroughtDownVariantLogId || !finalText) {
+  async _saveFinalVersionToVariants(finalText) {
+    if (!finalText) {
+      return;
+    }
+
+    const targetVariantLogIds = this._getFinalVersionTargetVariantIds();
+    if (targetVariantLogIds.length === 0) {
       return;
     }
 
     try {
-      await fetch(`/api/aiVariants/${this.latestBroughtDownVariantLogId}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'same-origin',
-        body: JSON.stringify({
-          aiVariant: {
-            isSelected: true,
-            finalVersionText: finalText,
-          },
-        }),
-      });
+      const results = await Promise.allSettled(
+        targetVariantLogIds.map((variantLogId) =>
+          fetch(`/api/aiVariants/${variantLogId}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'same-origin',
+            body: JSON.stringify({
+              aiVariant: {
+                finalVersionText: finalText,
+              },
+            }),
+          })
+        )
+      );
+
+      const failedIds = results
+        .map((result, index) => ({
+          result,
+          variantLogId: targetVariantLogIds[index],
+        }))
+        .filter(({ result }) => {
+          if (result.status === 'rejected') {
+            return true;
+          }
+          return !result.value?.ok;
+        })
+        .map(({ variantLogId }) => variantLogId);
+
+      if (failedIds.length > 0) {
+        console.warn(
+          'Failed to persist final AI version on some variants:',
+          failedIds
+        );
+      }
     } catch (error) {
       // Best-effort tracking only; do not block save flow.
-      console.warn('Failed to persist final AI version on variant:', error);
+      console.warn('Failed to persist final AI version on variants:', error);
     }
   }
 
@@ -1176,6 +1247,8 @@ export default class ResponseMentorReplyComponent extends Component {
       this.args.submission.aiFinalEditVersions =
         existingVersions.concat(appendedVersion);
 
+      await this._saveFinalVersionToVariants(payload.aiFinalEditText);
+
       this.alert.showToast(
         'success',
         'Final edit version saved',
@@ -1226,6 +1299,16 @@ export default class ResponseMentorReplyComponent extends Component {
 
   // TEMPORARY A/B TEST CODE - REMOVE AFTER TESTING PERIOD
   @action
+  handleVariantGenerated(variantGeneration) {
+    if (!variantGeneration || typeof variantGeneration !== 'object') {
+      return;
+    }
+
+    this._rememberGeneratedVariantLogId(variantGeneration.variantLogId);
+  }
+
+  // TEMPORARY A/B TEST CODE - REMOVE AFTER TESTING PERIOD
+  @action
   handleVariantDraftSelected(draftSelection) {
     // TEMPORARY A/B TEST CODE: Set the selected draft for the in-place editor
     const draftText =
@@ -1244,7 +1327,11 @@ export default class ResponseMentorReplyComponent extends Component {
       this.latestBroughtDownFeedback = draftSelection.writtenFeedback || null;
 
       if (this.latestBroughtDownVariantLogId) {
-        this._markSelectedVariantAsUsed();
+        this._rememberGeneratedVariantLogId(this.latestBroughtDownVariantLogId);
+        this._rememberBroughtDownVariantLogId(
+          this.latestBroughtDownVariantLogId
+        );
+        this._markSelectedVariantAsUsed(this.latestBroughtDownVariantLogId);
       }
     }
 

--- a/app/services/ai-generation-reports.js
+++ b/app/services/ai-generation-reports.js
@@ -99,6 +99,77 @@ export default class AiGenerationReportsService extends Service {
     return String(value);
   }
 
+  toArray(value) {
+    if (Array.isArray(value)) return value;
+    if (value && typeof value.toArray === 'function') {
+      return value.toArray();
+    }
+    if (value && typeof value.slice === 'function') {
+      return value.slice();
+    }
+    return [];
+  }
+
+  getTimestamp(value) {
+    if (!value) return 0;
+    const dateValue = value instanceof Date ? value : new Date(value);
+    return isValid(dateValue) ? dateValue.getTime() : 0;
+  }
+
+  getVariantFinalEditText(variant, submission) {
+    const variantText = variant?.finalVersionText;
+    if (typeof variantText === 'string' && variantText.trim().length > 0) {
+      return variantText;
+    }
+
+    const versionHistory = this.toArray(
+      this.readPath(submission, 'aiFinalEditVersions') ||
+        submission?.aiFinalEditVersions
+    );
+    if (!versionHistory.length) {
+      return '';
+    }
+
+    const variantLogId = this.normalizeObjectId(variant?._id || variant?.id);
+    const requestId = String(variant?.requestId || '').trim();
+    const matchingEntries = versionHistory.filter((entry) => {
+      const sourceVariantLogId = this.normalizeObjectId(
+        this.readPath(entry, 'sourceVariantLogId') || entry?.sourceVariantLogId
+      );
+      if (
+        variantLogId &&
+        sourceVariantLogId &&
+        sourceVariantLogId === variantLogId
+      ) {
+        return true;
+      }
+
+      const sourceRequestId = String(
+        this.readPath(entry, 'sourceRequestId') || entry?.sourceRequestId || ''
+      ).trim();
+      return Boolean(
+        requestId && sourceRequestId && sourceRequestId === requestId
+      );
+    });
+
+    if (!matchingEntries.length) {
+      return '';
+    }
+
+    const latestMatch = matchingEntries
+      .slice()
+      .sort(
+        (a, b) =>
+          this.getTimestamp(this.readPath(a, 'savedAt') || a?.savedAt) -
+          this.getTimestamp(this.readPath(b, 'savedAt') || b?.savedAt)
+      )
+      .pop();
+
+    return String(
+      this.readPath(latestMatch, 'text') || latestMatch?.text || ''
+    );
+  }
+
   formatDateTimeOrEmpty(value) {
     if (!value) return '';
     const dateValue = value instanceof Date ? value : new Date(value);
@@ -301,7 +372,7 @@ export default class AiGenerationReportsService extends Service {
         'Sent Annotation Snapshot':
           this.buildSentAnnotationSnapshot(sentAnnotations),
         'Final Edit Text': this.stripHtml(
-          variant?.finalVersionText || submission?.aiFinalEditText || ''
+          this.getVariantFinalEditText(variant, submission)
         ),
       };
     });

--- a/app_server/datasource/api/aiVariantApi.js
+++ b/app_server/datasource/api/aiVariantApi.js
@@ -118,13 +118,6 @@ async function putVariant(req, res) {
       variant.finalVersionText = payload.finalVersionText;
       variant.finalVersionSavedAt = new Date();
       variant.finalVersionSavedBy = user._id;
-      variant.isSelected = true;
-      if (!variant.selectedAt) {
-        variant.selectedAt = variant.finalVersionSavedAt;
-      }
-      if (!variant.selectedBy) {
-        variant.selectedBy = user._id;
-      }
     }
 
     variant.lastModifiedBy = user._id;


### PR DESCRIPTION
## Summary
The report workflow was already mostly complete. This PR finishes the missing behavior so it matches the expected response lifecycle.

Now, final saved version can be reflected on one or multiple generated rows depending on how many generations were part of that response flow.

AI usage is tracked separately and explicitly through `AI Is Selected`:
- `AI Is Selected = Yes` only when that specific generation is actually used via `Copy to Editor`.
- So final text linkage and usage tracking are both captured, but usage remains tied to explicit selection.

## Files Touched

### `app/services/ai-generation-reports.js`
- Added generation-scoped final-text resolver.
- `Final Edit Text` is now resolved in this order:
  1. `variant.finalVersionText`
  2. `submission.aiFinalEditVersions` match by `sourceVariantLogId`
  3. fallback match by `sourceRequestId`
- Removed submission-wide fallback behavior for this report field.

### `app/components/response-mentor-reply.js`
- Added tracked ID lists:
  - `generatedVariantLogIds`
  - `broughtDownVariantLogIds`
- Added helper methods to:
  - remember generated/copied variant IDs
  - compute all final-save target variant IDs
  - write final text to all linked variants using best-effort async flow
- Updated save paths (`saveDraft` non-draft path, `saveEdit`, `saveRevision`, `saveFinalEditVersion`) to use multi-target final-text persistence.
- Updated draft selection flow to store variant linkage and keep explicit selection tracking.

### `app/components/response-mentor-reply.hbs`
- Wired `@onVariantGenerated={{this.handleVariantGenerated}}` into `AiVariantComparison` so generated variant IDs can be tracked in parent flow.

### `app/components/ai-variant-comparison.js`
- Emits generation metadata to parent after successful variant generation:
  - `{ variantKey, variantLogId, requestId }`
- Supports parent-side linking of final saved text to generated rows.

### `app_server/datasource/api/aiVariantApi.js`
- Removed implicit selection mutations from final-text-only updates:
  - no auto `isSelected = true`
  - no auto `selectedAt/selectedBy`
- Keeps AI usage tracking tied to explicit copy/select action.

## Testing
- Manual verification:
  - Generate only -> row saved
  - Log review -> same row updated
  - Copy one variant -> only that row marked `AI Is Selected = Yes`
  - Save final after multi-generation flow -> final text reflected on linked generation row(s)
  - Export report -> updates remain tied to correct generation row(s)