### PR TITLE
fix(selection-tooltip): stable custom creator tooltip for selection rows

### DIFF
--- a/app/components/draggable-selection.hbs
+++ b/app/components/draggable-selection.hbs
@@ -1,12 +1,9 @@
 <div class='draggable-selection'>
   <div
-    class='selectionLink
+    class='selectionLink selection-tooltip
       {{if this.isImage "image-tag"}}
       {{if this.isSelected "is-selected"}}'
-    title='{{this.titleText}} {{if this.isParentWorkspace " by "}} {{if
-      this.isParentWorkspace
-      @selection.createdBy.username
-    }}'
+    data-selection-tooltip={{this.selectionTooltip}}
   >
 
     {{#if this.modelIdsReady}}

--- a/app/components/draggable-selection.js
+++ b/app/components/draggable-selection.js
@@ -3,6 +3,33 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 
+const SELECTION_DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'short',
+  timeStyle: 'short',
+});
+const SELECTION_TOOLTIP_CACHE = new WeakMap();
+
+function readPath(obj, path) {
+  if (!obj || !path) {
+    return undefined;
+  }
+
+  if (typeof obj.get === 'function') {
+    try {
+      return obj.get(path);
+    } catch (_error) {
+      return undefined;
+    }
+  }
+
+  return path.split('.').reduce((current, segment) => {
+    if (current == null) {
+      return undefined;
+    }
+    return current[segment];
+  }, obj);
+}
+
 export default class DraggableSelectionComponent extends Component {
   @service('sweet-alert') alert;
   @service('utility-methods') utils;
@@ -38,7 +65,9 @@ export default class DraggableSelectionComponent extends Component {
 
   get canDelete() {
     const currentUserId = this.currentUser.id;
-    const creatorId = this.args.selection.createdBy.id;
+    const creatorId =
+      this.utils.getBelongsToId(this.args.selection, 'createdBy') ||
+      readPath(this.args.selection, 'createdBy.id');
     return currentUserId === creatorId || this.args.canDeleteSelections;
   }
 
@@ -65,17 +94,48 @@ export default class DraggableSelectionComponent extends Component {
       const createDate = new Date(
         this.args.selection?.createDate ?? Date.now()
       );
-      const formatter = new Intl.DateTimeFormat(undefined, {
-        dateStyle: 'short',
-        timeStyle: 'short',
-      });
-      const displayDate = formatter.format(createDate);
+      const displayDate = SELECTION_DATE_FORMATTER.format(createDate);
       return `Created ${displayDate}`;
     }
     const { startTime, endTime } = this.args.selection.vmtInfo;
     return `${this.utils.getTimeStringFromMs(
       startTime
     )} - ${this.utils.getTimeStringFromMs(endTime)}`;
+  }
+
+  get selectionCreatorName() {
+    const selection = this.args.selection;
+    if (!selection) {
+      return '';
+    }
+
+    const directCreator =
+      readPath(selection, 'createdBy.username') ||
+      readPath(selection, 'originalSelection.createdBy.username');
+    if (directCreator) {
+      return directCreator;
+    }
+
+    return '';
+  }
+
+  get selectionTooltip() {
+    const selection = this.args.selection;
+    if (!selection) {
+      return '';
+    }
+
+    const cachedTooltip = SELECTION_TOOLTIP_CACHE.get(selection);
+    if (cachedTooltip) {
+      return cachedTooltip;
+    }
+
+    const creatorName = this.selectionCreatorName;
+    const tooltip = creatorName
+      ? `${this.titleText} by ${creatorName}`
+      : `${this.titleText}`;
+    SELECTION_TOOLTIP_CACHE.set(selection, tooltip);
+    return tooltip;
   }
 
   get overlayIcon() {

--- a/app/components/undraggable-selection.hbs
+++ b/app/components/undraggable-selection.hbs
@@ -1,16 +1,10 @@
 <div class='unundraggable-selection'>
   <div
-    class='selectionLink
+    class='selectionLink selection-tooltip
       {{if this.isImage "image-tag"}}
       {{if this.isSelected "is-selected"}}
       {{if this.isText "selection_text"}}'
-    title='{{this.titleText}} {{if this.isParentWorkspace " by "}} {{if
-      this.isParentWorkspace
-      @selection.originalSelection.createdBy.username
-    }} {{if this.isParentWorkspace " in "}} {{if
-      this.isParentWorkspace
-      @selection.originalSelection.workspace.name
-    }}'
+    data-selection-tooltip={{this.selectionTooltip}}
   >
     {{#if this.modelIdsReady}}
       <LinkTo

--- a/app/components/undraggable-selection.js
+++ b/app/components/undraggable-selection.js
@@ -3,6 +3,33 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
+const SELECTION_DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'short',
+  timeStyle: 'short',
+});
+const SELECTION_TOOLTIP_CACHE = new WeakMap();
+
+function readPath(obj, path) {
+  if (!obj || !path) {
+    return undefined;
+  }
+
+  if (typeof obj.get === 'function') {
+    try {
+      return obj.get(path);
+    } catch (_error) {
+      return undefined;
+    }
+  }
+
+  return path.split('.').reduce((current, segment) => {
+    if (current == null) {
+      return undefined;
+    }
+    return current[segment];
+  }, obj);
+}
+
 export default class UndraggableSelectionComponent extends Component {
   @service('utility-methods') utils;
   @service currentSelection;
@@ -58,17 +85,73 @@ export default class UndraggableSelectionComponent extends Component {
   get titleText() {
     if (!this.isVmtClip) {
       const createDate = new Date(this.args.selection.createDate);
-      const formatter = new Intl.DateTimeFormat(undefined, {
-        dateStyle: 'short',
-        timeStyle: 'short',
-      });
-      const displayDate = formatter.format(createDate);
+      const displayDate = SELECTION_DATE_FORMATTER.format(createDate);
       return `Created ${displayDate}`;
     }
     const { startTime, endTime } = this.args.selection.vmtInfo;
     return `${this.utils.getTimeStringFromMs(
       startTime
     )} - ${this.utils.getTimeStringFromMs(endTime)}`;
+  }
+
+  get selectionCreatorName() {
+    const selection = this.args.selection;
+    if (!selection) {
+      return '';
+    }
+
+    const directCreator =
+      readPath(selection, 'createdBy.username') ||
+      readPath(selection, 'originalSelection.createdBy.username');
+    if (directCreator) {
+      return directCreator;
+    }
+
+    return '';
+  }
+
+  get parentWorkspaceName() {
+    if (!this.isParentWorkspace) {
+      return '';
+    }
+
+    const selection = this.args.selection;
+    if (!selection) {
+      return '';
+    }
+
+    const directName = readPath(selection, 'originalSelection.workspace.name');
+    if (directName) {
+      return directName;
+    }
+
+    return '';
+  }
+
+  get selectionTooltip() {
+    const selection = this.args.selection;
+    if (!selection) {
+      return '';
+    }
+
+    const cachedTooltip = SELECTION_TOOLTIP_CACHE.get(selection);
+    if (cachedTooltip) {
+      return cachedTooltip;
+    }
+
+    const creatorName = this.selectionCreatorName;
+    const workspaceName = this.parentWorkspaceName;
+    let tooltip = `${this.titleText}`;
+
+    if (creatorName) {
+      tooltip += ` by ${creatorName}`;
+    }
+    if (workspaceName) {
+      tooltip += ` in ${workspaceName}`;
+    }
+
+    SELECTION_TOOLTIP_CACHE.set(selection, tooltip);
+    return tooltip;
   }
 
   get overlayIcon() {

--- a/app/components/workspace-submission.hbs
+++ b/app/components/workspace-submission.hbs
@@ -93,7 +93,7 @@
 
   <div
     id='al_submission'
-    style={{if this.makingSelection 'height: auto; overflow-y: visible;' ''}}
+    class='{{if this.makingSelection "is-selecting"}}'
   >
     {{#if this.makingSelection}}
       <h3 id='sel-view-header' class='selectable-view-header'>Selectable View!</h3>

--- a/app/styles/_workspace-container.scss
+++ b/app/styles/_workspace-container.scss
@@ -562,6 +562,11 @@
       margin-bottom: 0;
       height: calc(100% - 211px);
       overflow-y: auto;
+
+      &.is-selecting {
+        height: auto;
+        overflow-y: visible;
+      }
     }
 
     #confirm-text-sel {
@@ -634,6 +639,27 @@
 
         span {
           padding: 2px;
+        }
+
+        &.selection-tooltip {
+          position: relative;
+
+          &:hover::after {
+            content: attr(data-selection-tooltip);
+            position: absolute;
+            top: 100%;
+            left: 50%;
+            transform: translateX(-50%);
+            padding: 8px 12px;
+            background-color: #8bc34a;
+            color: white;
+            font-size: 13px;
+            white-space: nowrap;
+            border-radius: 4px;
+            margin-top: 5px;
+            z-index: 1000;
+            pointer-events: none;
+          }
         }
 
         &.image-tag {


### PR DESCRIPTION
## Summary
This PR adds a new hover tooltip for selections.

Before this change, selection chips did not have a dedicated selection-hover tooltip showing selection ownership details.
Now, hovering a selection shows a green tooltip with creator context (and parent workspace context when available).

## Changes
- Added new selection tooltip data + logic in `app/components/draggable-selection.js`.
- Added new selection tooltip data + logic in `app/components/undraggable-selection.js`.
- Added tooltip attribute binding in `app/components/draggable-selection.hbs` via `data-selection-tooltip`.
- Added tooltip attribute binding in `app/components/undraggable-selection.hbs` via `data-selection-tooltip`.
- Added custom green tooltip styles in `app/styles/_workspace-container.scss` for `.selection-tooltip`.
- Added `#al_submission.is-selecting` class style in `app/styles/_workspace-container.scss`.
- Replaced inline style binding in `app/components/workspace-submission.hbs` with class toggle (`is-selecting`).

## Why
- Adds the missing tooltip feature requested: show who made a selection on hover.
- Keeps tooltip rendering consistent and controlled via component-level CSS.
- Avoids Ember proxy runtime issues by using proxy-safe reads for creator/workspace fields.
- Improves stability under rerenders and avoids inline-style warning paths.


## Manual Test
- Open a submission with selections.
- Hover selection chips and confirm green tooltip appears.
- Confirm tooltip includes creator username.
- Confirm selection interactions still work (open selection, image behavior, delete where permitted).
- Confirm Selecting mode layout still behaves correctly.
- Confirm no Ember proxy assertion occurs while rendering/hovering selections.