### PR TITLE
Feat/selection delete admin only

### DIFF
--- a/app/components/comment-list.js
+++ b/app/components/comment-list.js
@@ -472,11 +472,33 @@ export default class CommentListComponent extends Component {
 
   @action
   async deleteComment(comment) {
+    if (!comment) {
+      return;
+    }
+
+    const creatorId = this.utils.getBelongsToId(comment, 'createdBy');
+    const isOwnComment = creatorId === this.currentUser.id;
+    const isAdmin = this.currentUser.isAdmin && !this.currentUser.isStudent;
+
+    if (!isOwnComment && !isAdmin) {
+      this.alert.showToast('error', 'You can only delete your own comments.');
+      return;
+    }
+
+    const modalTitle =
+      isAdmin && !isOwnComment
+        ? 'This comment belongs to another user. Delete it anyway?'
+        : 'Are you sure you want to delete this comment?';
+    const confirmText =
+      isAdmin && !isOwnComment
+        ? 'Yes, delete another user comment'
+        : 'Yes, delete it';
+
     const confirmed = await this.alert.showModal(
       'warning',
-      'Are you sure you want to delete this comment?',
+      modalTitle,
       null,
-      'Yes, delete it'
+      confirmText
     );
 
     if (confirmed.value) {

--- a/app/components/draggable-selection.hbs
+++ b/app/components/draggable-selection.hbs
@@ -29,9 +29,11 @@
       </LinkTo>
     {{/if}}
     {{#unless this.isImage}}
-      <span {{on 'click' (fn this.deleteSelection @selection)}}><i
-          class='fas fa-minus-circle'
-        ></i></span>
+      {{#if this.canDelete}}
+        <span {{on 'click' (fn this.deleteSelection @selection)}}><i
+            class='fas fa-minus-circle'
+          ></i></span>
+      {{/if}}
     {{/unless}}
   </div>
   {{#if this.isImage}}

--- a/app/components/draggable-selection.js
+++ b/app/components/draggable-selection.js
@@ -65,10 +65,27 @@ export default class DraggableSelectionComponent extends Component {
 
   get canDelete() {
     const currentUserId = this.currentUser.id;
-    const creatorId =
+    const creatorId = this.selectionCreatorId;
+    const isAdmin = this.currentUser.isAdmin && !this.currentUser.isStudent;
+    return (
+      currentUserId === creatorId || (isAdmin && this.args.canDeleteSelections)
+    );
+  }
+
+  get selectionCreatorId() {
+    return (
       this.utils.getBelongsToId(this.args.selection, 'createdBy') ||
-      readPath(this.args.selection, 'createdBy.id');
-    return currentUserId === creatorId || this.args.canDeleteSelections;
+      readPath(this.args.selection, 'createdBy.id')
+    );
+  }
+
+  get isOwnSelection() {
+    return this.currentUser.id === this.selectionCreatorId;
+  }
+
+  get isAdminDeletingOthersSelection() {
+    const isAdmin = this.currentUser.isAdmin && !this.currentUser.isStudent;
+    return isAdmin && !this.isOwnSelection;
   }
 
   get isImage() {
@@ -164,18 +181,24 @@ export default class DraggableSelectionComponent extends Component {
 
   @action
   deleteSelection() {
-    this.alert
-      .showModal(
-        'warning',
-        'Are you sure you want to delete this selection?',
-        null,
-        'Yes, delete it'
-      )
-      .then((result) => {
-        if (result.value) {
-          this.args.deleteSelection(this.args.selection);
-        }
-      });
+    if (!this.canDelete) {
+      this.alert.showToast('error', 'You can only delete your own selections.');
+      return;
+    }
+
+    const isAdminDeletingOthers = this.isAdminDeletingOthersSelection;
+    const title = isAdminDeletingOthers
+      ? 'This selection belongs to another user. Delete it anyway?'
+      : 'Are you sure you want to delete this selection?';
+    const confirmText = isAdminDeletingOthers
+      ? 'Yes, delete another user selection'
+      : 'Yes, delete it';
+
+    this.alert.showModal('warning', title, null, confirmText).then((result) => {
+      if (result.value) {
+        this.args.deleteSelection(this.args.selection);
+      }
+    });
   }
 
   @action

--- a/app/components/workspace-comment.js
+++ b/app/components/workspace-comment.js
@@ -31,7 +31,8 @@ export default class WorkspaceCommentComponent extends Component {
   }
 
   get canDelete() {
-    return this._canEditComments(4);
+    const isAdmin = this.currentUser.isAdmin && !this.currentUser.isStudent;
+    return this._canEditComments(4) && (this.isOwnComment || isAdmin);
   }
 
   get permittedToComment() {
@@ -145,6 +146,10 @@ export default class WorkspaceCommentComponent extends Component {
 
   @action
   deleteComment() {
+    if (!this.canDelete) {
+      return;
+    }
+
     this.args.deleteComment?.(this.args.comment);
   }
 

--- a/app/controllers/workspace/submissions/submission.js
+++ b/app/controllers/workspace/submissions/submission.js
@@ -500,14 +500,7 @@ export default class WorkspaceSubmissionController extends Controller {
     const isAdmin = this.currentUser.isAdmin && !this.currentUser.isStudent;
 
     if (!isOwnSelection && !isAdmin) {
-      this.alert.showToast(
-        'error',
-        'You can only delete your own selections.',
-        'bottom-end',
-        3000,
-        false,
-        null
-      );
+      this.alert.showToast('error', 'You can only delete your own selections.');
       return;
     }
 
@@ -531,14 +524,7 @@ export default class WorkspaceSubmissionController extends Controller {
     selection.save().then(function (record) {
       record.deleteRecord(); // Locally delete the object to update UI
 
-      controller.alert.showToast(
-        'success',
-        'Selection Deleted',
-        'bottom-end',
-        3000,
-        false,
-        null
-      );
+      controller.alert.showToast('success', 'Selection Deleted');
 
       controller.transitionToRoute(
         'workspace.submissions.submission',

--- a/app/controllers/workspace/submissions/submission.js
+++ b/app/controllers/workspace/submissions/submission.js
@@ -495,6 +495,21 @@ export default class WorkspaceSubmissionController extends Controller {
   @action
   deleteSelection(selection) {
     var controller = this;
+    const creatorId = this.utils.getBelongsToId(selection, 'createdBy');
+    const isOwnSelection = creatorId === this.currentUser.id;
+    const isAdmin = this.currentUser.isAdmin && !this.currentUser.isStudent;
+
+    if (!isOwnSelection && !isAdmin) {
+      this.alert.showToast(
+        'error',
+        'You can only delete your own selections.',
+        'bottom-end',
+        3000,
+        false,
+        null
+      );
+      return;
+    }
 
     selection.set('isTrashed', true);
 

--- a/app_server/datasource/api/commentApi.js
+++ b/app_server/datasource/api/commentApi.js
@@ -340,9 +340,32 @@ async function putComment(req, res, next) {
       return utils.sendResponse(res, null);
     }
 
+    let comment = await models.Comment.findById(req.params.id).exec();
+
+    if (!comment) {
+      logger.info(
+        `${user.username} attempted to modify missing comment ${req.params.id} for workspace ${workspaceId}`
+      );
+      return utils.sendResponse(res, null);
+    }
+
+    const isAdmin = user.accountType === 'A' && user.actingRole !== 'student';
+    const isCommentCreator = areObjectIdsEqual(user._id, comment.createdBy);
+    const isDeleteAttempt =
+      req.body.comment?.isTrashed === true && comment.isTrashed !== true;
+
+    if (isDeleteAttempt && !isCommentCreator && !isAdmin) {
+      logger.info(
+        `Permission denied: ${user.username} attempted to delete comment ${req.params.id} created by another user`
+      );
+      return utils.sendError.NotAuthorizedError(
+        'You can only delete your own comments.',
+        res
+      );
+    }
+
     let canModifyCommentInWs =
-      _.isEqual(user._id, req.body.comment.createdBy) ||
-      wsAccess.canModify(user, popWs, 'comments', 3);
+      isCommentCreator || wsAccess.canModify(user, popWs, 'comments', 3);
 
     if (!canModifyCommentInWs) {
       logger.info(
@@ -352,15 +375,6 @@ async function putComment(req, res, next) {
         `You don't have permission to modify comments in this workspace`,
         res
       );
-    }
-
-    let comment = await models.Comment.findById(req.params.id).exec();
-
-    if (!comment) {
-      logger.info(
-        `${user.username} attempted to modify missing comment ${req.params.id} for workspace ${workspaceId}`
-      );
-      return utils.sendResponse(res, null);
     }
 
     for (let field in req.body.comment) {

--- a/app_server/datasource/api/selectionApi.js
+++ b/app_server/datasource/api/selectionApi.js
@@ -371,13 +371,57 @@ async function putSelection(req, res, next) {
       return utils.sendError.InvalidCredentialsError('No user logged in!', res);
     }
 
-    let selection = await models.Selection.findById(req.params.id);
+    let selection = await models.Selection.findById(req.params.id).exec();
 
     if (!selection) {
       logger.info(
         `${user.username} attempted to update nonexistant selection with id ${req.params.id}`
       );
       return utils.sendResponse(res, null);
+    }
+
+    let workspaceId = selection.workspace || req.body.selection?.workspace;
+
+    let popWs = await models.Workspace.findById(workspaceId)
+      .lean()
+      .populate('owner')
+      .populate('editors')
+      .populate('createdBy')
+      .exec();
+
+    if (!popWs || popWs.isTrashed) {
+      logger.info(
+        `${user.username} attempted to modify selection ${req.params.id} for missing or trashed workspace ${workspaceId}`
+      );
+      return utils.sendResponse(res, null);
+    }
+
+    const isAdmin = user.accountType === 'A' && user.actingRole !== 'student';
+    const isSelectionCreator = areObjectIdsEqual(user._id, selection.createdBy);
+    const isDeleteAttempt =
+      req.body.selection?.isTrashed === true && selection.isTrashed !== true;
+
+    if (isDeleteAttempt && !isSelectionCreator && !isAdmin) {
+      logger.info(
+        `Permission denied: ${user.username} attempted to delete selection ${req.params.id} created by another user`
+      );
+      return utils.sendError.NotAuthorizedError(
+        'You can only delete your own selections.',
+        res
+      );
+    }
+
+    let canModifySelectionInWs =
+      isSelectionCreator || wsAccess.canModify(user, popWs, 'selections', 3);
+
+    if (!canModifySelectionInWs) {
+      logger.info(
+        `Permission denied to modify selection ${req.params.id} in workspace ${popWs.name} (id: ${popWs._id})`
+      );
+      return utils.sendError.NotAuthorizedError(
+        `You don't have permission to modify selections in this workspace`,
+        res
+      );
     }
 
     for (let field in req.body.selection) {

--- a/tests/integration/components/comment-list-test.js
+++ b/tests/integration/components/comment-list-test.js
@@ -10,11 +10,24 @@ module('Integration | Component | comment-list', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
-    this.owner.register(
-      'component:workspace-comment',
-      class extends Component {
-        static template = hbs`<li class="ws-comment-comp"></li>`;
+    class WorkspaceCommentStub extends Component {
+      // Non-empty class to satisfy lint rule for Glimmer stub components.
+      get isStubComponent() {
+        return true;
       }
+    }
+    this.owner.register('component:workspace-comment', WorkspaceCommentStub);
+    this.owner.register(
+      'template:components/workspace-comment',
+      hbs`<li class='ws-comment-comp'>
+        <button
+          type='button'
+          class='stub-delete-comment'
+          {{on 'click' (fn @deleteComment @comment)}}
+        >
+          Delete
+        </button>
+      </li>`
     );
     this.owner.register(
       'component:search-bar',
@@ -42,11 +55,17 @@ module('Integration | Component | comment-list', function (hooks) {
     );
 
     class SweetAlertService extends Service {
+      toastCalls = [];
+      modalCalls = [];
+      modalResult = { value: false };
+
       showToast() {
+        this.toastCalls.push([...arguments]);
         return Promise.resolve({ value: false });
       }
       showModal() {
-        return Promise.resolve({ value: false });
+        this.modalCalls.push([...arguments]);
+        return Promise.resolve(this.modalResult);
       }
     }
 
@@ -56,6 +75,9 @@ module('Integration | Component | comment-list', function (hooks) {
       }
       getBelongsToId(record, key) {
         return record[key]?.id;
+      }
+      getHasManyIds(record, key) {
+        return record?.[key] || [];
       }
     }
 
@@ -586,5 +608,137 @@ module('Integration | Component | comment-list', function (hooks) {
     await click('input[name="thisSubmissionOnly"]');
 
     assert.dom('.results-message').includesText('for current workspace');
+  });
+
+  test('blocks non-admin cross-user delete attempt with toast and no modal', async function (assert) {
+    let saveCalled = false;
+    const comment = {
+      id: 'c1',
+      text: 'cross-user',
+      createDate: new Date(),
+      isTrashed: false,
+      submission: { id: 'sub1' },
+      workspace: { id: 'w1' },
+      createdBy: { id: 'u2' },
+      save() {
+        saveCalled = true;
+        return Promise.resolve({});
+      },
+    };
+
+    await renderCommentList(this, {
+      comments: [comment],
+      isParentWorkspace: false,
+    });
+
+    await click('input[name="myCommentsOnly"]');
+    assert.dom('.stub-delete-comment').exists();
+    const alert = this.owner.lookup('service:sweet-alert');
+    await click('.stub-delete-comment');
+    assert.false(saveCalled, 'does not save on unauthorized delete');
+    assert.strictEqual(
+      alert.modalCalls.length,
+      0,
+      'does not open confirmation modal'
+    );
+    assert.strictEqual(alert.toastCalls.length, 1, 'shows one toast');
+    assert.strictEqual(
+      alert.toastCalls[0][1],
+      'You can only delete your own comments.',
+      'shows ownership block message'
+    );
+  });
+
+  test('admin cross-user delete uses warning modal copy', async function (assert) {
+    this.owner.register(
+      'service:currentUser',
+      class extends Service {
+        user = { id: 'u1', username: 'admin' };
+        id = 'u1';
+        isAdmin = true;
+        isStudent = false;
+      }
+    );
+
+    const comment = {
+      id: 'c1',
+      text: 'cross-user',
+      createDate: new Date(),
+      isTrashed: false,
+      submission: { id: 'sub1' },
+      workspace: { id: 'w1' },
+      createdBy: { id: 'u2' },
+      save() {
+        return Promise.resolve({});
+      },
+    };
+
+    await renderCommentList(this, {
+      comments: [comment],
+      isParentWorkspace: false,
+    });
+
+    await click('input[name="myCommentsOnly"]');
+    assert.dom('.stub-delete-comment').exists();
+    const alert = this.owner.lookup('service:sweet-alert');
+    alert.modalResult = { value: false };
+
+    await click('.stub-delete-comment');
+
+    assert.strictEqual(
+      alert.modalCalls.length,
+      1,
+      'opens one confirmation modal'
+    );
+    assert.strictEqual(
+      alert.modalCalls[0][1],
+      'This comment belongs to another user. Delete it anyway?'
+    );
+    assert.strictEqual(
+      alert.modalCalls[0][3],
+      'Yes, delete another user comment'
+    );
+  });
+
+  test('canceling admin cross-user delete does not delete comment', async function (assert) {
+    this.owner.register(
+      'service:currentUser',
+      class extends Service {
+        user = { id: 'u1', username: 'admin' };
+        id = 'u1';
+        isAdmin = true;
+        isStudent = false;
+      }
+    );
+
+    let saveCalled = false;
+    const comment = {
+      id: 'c1',
+      text: 'cross-user',
+      createDate: new Date(),
+      isTrashed: false,
+      submission: { id: 'sub1' },
+      workspace: { id: 'w1' },
+      createdBy: { id: 'u2' },
+      save() {
+        saveCalled = true;
+        return Promise.resolve({});
+      },
+    };
+
+    await renderCommentList(this, {
+      comments: [comment],
+      isParentWorkspace: false,
+    });
+
+    await click('input[name="myCommentsOnly"]');
+    assert.dom('.stub-delete-comment').exists();
+    const alert = this.owner.lookup('service:sweet-alert');
+    alert.modalResult = { value: false };
+
+    await click('.stub-delete-comment');
+
+    assert.false(saveCalled, 'does not save when modal is canceled');
+    assert.false(comment.isTrashed, 'comment remains not trashed');
   });
 });

--- a/tests/integration/components/draggable-selection-test.js
+++ b/tests/integration/components/draggable-selection-test.js
@@ -1,0 +1,206 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click, settled } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import Service from '@ember/service';
+
+module('Integration | Component | draggable-selection', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    class UtilityMethodsService extends Service {
+      getBelongsToId(record, key) {
+        if (!record || !key) {
+          return null;
+        }
+
+        const value = record[key];
+        if (!value) {
+          return null;
+        }
+
+        if (typeof value === 'object') {
+          return value.id ?? null;
+        }
+
+        return value;
+      }
+
+      getTimeStringFromMs(ms) {
+        return String(ms ?? '');
+      }
+    }
+
+    class CurrentUserService extends Service {
+      id = 'u1';
+      isAdmin = false;
+      isStudent = false;
+    }
+
+    class CurrentSelectionService extends Service {
+      isCurrentSelection() {
+        return false;
+      }
+    }
+
+    class AlertService extends Service {
+      modalCalls = [];
+      toastCalls = [];
+      modalResult = { value: true };
+
+      showModal(...args) {
+        this.modalCalls.push(args);
+        return Promise.resolve(this.modalResult);
+      }
+
+      showToast(...args) {
+        this.toastCalls.push(args);
+      }
+    }
+
+    this.owner.register('service:utility-methods', UtilityMethodsService);
+    this.owner.register('service:currentUser', CurrentUserService);
+    this.owner.register('service:currentSelection', CurrentSelectionService);
+    this.owner.register('service:sweet-alert', AlertService);
+  });
+
+  function createSelection(overrides = {}) {
+    return {
+      id: 'sel-1',
+      text: 'x + 1',
+      createDate: Date.now(),
+      imageTagLink: '',
+      createdBy: { id: 'u1', username: 'owner-user' },
+      ...overrides,
+    };
+  }
+
+  async function renderSelection(context, props = {}) {
+    context.setProperties({
+      selection: props.selection || createSelection(),
+      canDeleteSelections:
+        props.canDeleteSelections === undefined
+          ? true
+          : props.canDeleteSelections,
+      onDelete: props.onDelete || (() => {}),
+    });
+
+    await render(hbs`<DraggableSelection
+      @selection={{this.selection}}
+      @canDeleteSelections={{this.canDeleteSelections}}
+      @deleteSelection={{this.onDelete}}
+    />`);
+  }
+
+  test('shows delete icon for owner even when canDeleteSelections is false', async function (assert) {
+    await renderSelection(this, {
+      selection: createSelection({
+        createdBy: { id: 'u1', username: 'owner' },
+      }),
+      canDeleteSelections: false,
+    });
+
+    assert.dom('.fa-minus-circle').exists();
+  });
+
+  test('hides delete icon for non-admin user on another user selection', async function (assert) {
+    await renderSelection(this, {
+      selection: createSelection({
+        createdBy: { id: 'u2', username: 'other' },
+      }),
+      canDeleteSelections: true,
+    });
+
+    assert.dom('.fa-minus-circle').doesNotExist();
+  });
+
+  test('shows delete icon for admin on another user selection when permission allows', async function (assert) {
+    this.owner.unregister('service:currentUser');
+    this.owner.register(
+      'service:currentUser',
+      class extends Service {
+        id = 'u1';
+        isAdmin = true;
+        isStudent = false;
+      }
+    );
+
+    await renderSelection(this, {
+      selection: createSelection({
+        createdBy: { id: 'u2', username: 'other' },
+      }),
+      canDeleteSelections: true,
+    });
+
+    assert.dom('.fa-minus-circle').exists();
+  });
+
+  test('uses admin warning modal copy for admin cross-user delete', async function (assert) {
+    this.owner.unregister('service:currentUser');
+    this.owner.register(
+      'service:currentUser',
+      class extends Service {
+        id = 'u1';
+        isAdmin = true;
+        isStudent = false;
+      }
+    );
+
+    let deletedSelection = null;
+    await renderSelection(this, {
+      selection: createSelection({
+        createdBy: { id: 'u2', username: 'other' },
+      }),
+      canDeleteSelections: true,
+      onDelete: (selection) => {
+        deletedSelection = selection;
+      },
+    });
+
+    const alert = this.owner.lookup('service:sweet-alert');
+    alert.modalResult = { value: false };
+
+    await click('.fa-minus-circle');
+    await settled();
+
+    assert.strictEqual(alert.modalCalls.length, 1);
+    assert.strictEqual(
+      alert.modalCalls[0][1],
+      'This selection belongs to another user. Delete it anyway?'
+    );
+    assert.strictEqual(
+      alert.modalCalls[0][3],
+      'Yes, delete another user selection'
+    );
+    assert.strictEqual(deletedSelection, null);
+  });
+
+  test('uses standard modal copy for owner delete and calls callback on confirm', async function (assert) {
+    let deletedSelection = null;
+    const selection = createSelection({
+      createdBy: { id: 'u1', username: 'owner' },
+    });
+
+    await renderSelection(this, {
+      selection,
+      canDeleteSelections: false,
+      onDelete: (selected) => {
+        deletedSelection = selected;
+      },
+    });
+
+    const alert = this.owner.lookup('service:sweet-alert');
+    alert.modalResult = { value: true };
+
+    await click('.fa-minus-circle');
+    await settled();
+
+    assert.strictEqual(alert.modalCalls.length, 1);
+    assert.strictEqual(
+      alert.modalCalls[0][1],
+      'Are you sure you want to delete this selection?'
+    );
+    assert.strictEqual(alert.modalCalls[0][3], 'Yes, delete it');
+    assert.strictEqual(deletedSelection, selection);
+  });
+});

--- a/tests/integration/components/workspace-comment-test.js
+++ b/tests/integration/components/workspace-comment-test.js
@@ -39,6 +39,8 @@ module('Integration | Component | workspace-comment', function (hooks) {
     class CurrentUserService extends Service {
       id = 'u1';
       user = { id: 'u1', username: 'testuser' };
+      isAdmin = false;
+      isStudent = false;
     }
 
     class CurrentSelectionService extends Service {
@@ -191,6 +193,31 @@ module('Integration | Component | workspace-comment', function (hooks) {
     );
     await renderWorkspaceComment(this);
     assert.dom('.delete_button').doesNotExist();
+  });
+
+  test('hides delete button for non-admin user on another user comment', async function (assert) {
+    await renderWorkspaceComment(this, {
+      comment: createComment({ createdBy: { id: 'u2', username: 'other-user' } }),
+    });
+    assert.dom('.delete_button').doesNotExist();
+  });
+
+  test('shows delete button for admin on another user comment', async function (assert) {
+    this.owner.unregister('service:currentUser');
+    this.owner.register(
+      'service:currentUser',
+      class extends Service {
+        id = 'u1';
+        user = { id: 'u1', username: 'admin-user' };
+        isAdmin = true;
+        isStudent = false;
+      }
+    );
+
+    await renderWorkspaceComment(this, {
+      comment: createComment({ createdBy: { id: 'u2', username: 'other-user' } }),
+    });
+    assert.dom('.delete_button').exists();
   });
 
   test('shows reuse button when user can comment', async function (assert) {


### PR DESCRIPTION
### Description
Update delete permissions for selections/comments (owner or admin), with admin warning on cross-user delete.

### Why
We needed to tighten delete behavior so users can’t delete other users’ work by mistake or via direct API requests.

Intended behavior:
- Regular users can delete only their own selections/comments.
- Admins can delete other users’ selections/comments, but should see a clear warning first.

### What Changed

#### Frontend
- `app/components/draggable-selection.js`
  - Added owner/admin checks for selection delete.
  - Added explicit admin cross-user warning modal copy.
  - Added unauthorized guard path with error toast.
- `app/components/draggable-selection.hbs`
  - Text-selection delete icon now renders only when `canDelete` is true.
- `app/components/workspace-comment.js`
  - Delete affordance now requires owner/admin in addition to workspace permission.
- `app/components/comment-list.js`
  - Blocks non-admin cross-user comment delete attempts.
  - Shows admin warning modal for cross-user comment deletes.
- `app/controllers/workspace/submissions/submission.js`
  - Added owner/admin guard before selection delete cascade.
  - Updated delete-related toast calls to use `sweet-alert` service defaults (per Dr. Irv feedback) while keeping same user-facing messages.

#### Backend
- `app_server/datasource/api/commentApi.js` (`putComment`)
  - Detects delete transitions and enforces owner/admin rule.
- `app_server/datasource/api/selectionApi.js` (`putSelection`)
  - Detects delete transitions and enforces owner/admin rule.
  - Preserves workspace modify checks after ownership gate.

### Expected Behavior After This PR
- Regular users:
  - can delete their own selections/comments
  - cannot delete other users’ selections/comments
- Admins:
  - can delete other users’ selections/comments
  - see explicit warning confirmation for cross-user delete
- Direct API attempts by non-admin users to delete others’ content are blocked.

### Tests
- Updated integration tests in `tests/integration/components/workspace-comment-test.js`:
  1. Non-admin user does not see delete button on another user’s comment.
  2. Admin user does see delete button on another user’s comment.
- Added integration tests in `tests/integration/components/draggable-selection-test.js`:
  1. Owner sees selection delete icon.
  2. Non-admin non-owner does not see selection delete icon.
  3. Admin non-owner sees selection delete icon (with permission enabled).
  4. Admin cross-user selection delete uses warning modal + confirm text.
  5. Owner delete uses standard modal and triggers delete callback on confirm.
- Added integration tests in `tests/integration/components/comment-list-test.js`:
  1. Non-admin cross-user delete attempt is blocked (error toast, no modal, no delete save).
  2. Admin cross-user delete shows warning modal copy.
  3. Canceling admin warning modal does not delete the comment.

### Manual Validation Checklist
1. Login as non-admin and delete your own selection/comment.
2. As non-admin, try deleting another user’s selection/comment and confirm it is blocked.
3. Login as admin and try deleting another user’s selection/comment.
4. Confirm warning modal appears for cross-user delete.
5. Confirm delete only happens after explicit confirmation.
6. Try direct API delete as non-admin for another user’s record and confirm authorization error.

### Risk / Rollback
- Risk is moderate because permission checks were updated in both UI and API paths.
- Rollback is straightforward: revert this PR if needed.

### Notes
- API-side authorization is included intentionally so behavior cannot be bypassed by direct requests.
