### PR TITLE
Test/workspace submission delete coverage

### DIFF
--- a/app/components/workspace-comment.js
+++ b/app/components/workspace-comment.js
@@ -21,8 +21,18 @@ export default class WorkspaceCommentComponent extends Component {
   }
 
   get childrenLength() {
-    const childrenIds = this.utils.getHasManyIds(this.args.comment, 'children');
-    return childrenIds?.length || 0;
+    const getHasManyIds = this.utils?.getHasManyIds;
+    if (typeof getHasManyIds === 'function') {
+      const childrenIds = getHasManyIds.call(
+        this.utils,
+        this.args.comment,
+        'children'
+      );
+      return childrenIds?.length || 0;
+    }
+
+    const children = this.args.comment?.children;
+    return Array.isArray(children) ? children.length : 0;
   }
 
   get isOwnComment() {

--- a/tests/integration/components/comment-list-test.js
+++ b/tests/integration/components/comment-list-test.js
@@ -4,36 +4,16 @@ import { render, click, fillIn } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 import Component from '@glimmer/component';
-import ClassicComponent from '@ember/component';
 
 module('Integration | Component | comment-list', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
-    class WorkspaceCommentStub extends Component {
-      // Non-empty class to satisfy lint rule for Glimmer stub components.
-      get isStubComponent() {
-        return true;
-      }
-    }
-    this.owner.register('component:workspace-comment', WorkspaceCommentStub);
-    this.owner.register(
-      'template:components/workspace-comment',
-      hbs`<li class='ws-comment-comp'>
-        <button
-          type='button'
-          class='stub-delete-comment'
-          {{on 'click' (fn @deleteComment @comment)}}
-        >
-          Delete
-        </button>
-      </li>`
-    );
     this.owner.register(
       'component:search-bar',
-      ClassicComponent.extend({
-        layout: hbs`<div class="search-bar-comp"></div>`,
-      })
+      class extends Component {
+        static template = hbs`<div class='search-bar-comp'></div>`;
+      }
     );
     this.owner.register(
       'component:pagination-control',
@@ -166,6 +146,50 @@ module('Integration | Component | comment-list', function (hooks) {
       @containerLayoutClass={{this.containerLayoutClass}}
       @isHidden={{this.isHidden}}
     />`);
+  }
+
+  function registerCurrentUser(owner, overrides = {}) {
+    owner.unregister('service:currentUser');
+    owner.register(
+      'service:currentUser',
+      class extends Service {
+        user = { id: 'u1', username: 'testuser' };
+        id = 'u1';
+        isAdmin = false;
+        isStudent = false;
+
+        constructor() {
+          super(...arguments);
+          Object.assign(this, overrides);
+        }
+      }
+    );
+  }
+
+  function registerWorkspaceCommentDeleteStub(owner) {
+    owner.unregister('component:workspace-comment');
+    owner.unregister('template:components/workspace-comment');
+    owner.register(
+      'component:workspace-comment',
+      class extends Component {
+        // Keep non-empty class body for lint consistency in test stubs.
+        get isStubComponent() {
+          return true;
+        }
+      }
+    );
+    owner.register(
+      'template:components/workspace-comment',
+      hbs`<li class='ws-comment-comp'>
+        <button
+          type='button'
+          class='stub-delete-comment'
+          {{on 'click' (fn @deleteComment @comment)}}
+        >
+          Delete
+        </button>
+      </li>`
+    );
   }
 
   test('renders and shows empty message when no comments', async function (assert) {
@@ -611,6 +635,8 @@ module('Integration | Component | comment-list', function (hooks) {
   });
 
   test('blocks non-admin cross-user delete attempt with toast and no modal', async function (assert) {
+    registerWorkspaceCommentDeleteStub(this.owner);
+
     let saveCalled = false;
     const comment = {
       id: 'c1',
@@ -650,15 +676,12 @@ module('Integration | Component | comment-list', function (hooks) {
   });
 
   test('admin cross-user delete uses warning modal copy', async function (assert) {
-    this.owner.register(
-      'service:currentUser',
-      class extends Service {
-        user = { id: 'u1', username: 'admin' };
-        id = 'u1';
-        isAdmin = true;
-        isStudent = false;
-      }
-    );
+    registerCurrentUser(this.owner, {
+      user: { id: 'u1', username: 'admin' },
+      id: 'u1',
+      isAdmin: true,
+      isStudent: false,
+    });
 
     const comment = {
       id: 'c1',
@@ -679,11 +702,11 @@ module('Integration | Component | comment-list', function (hooks) {
     });
 
     await click('input[name="myCommentsOnly"]');
-    assert.dom('.stub-delete-comment').exists();
+    assert.dom('.delete_button').exists();
     const alert = this.owner.lookup('service:sweet-alert');
     alert.modalResult = { value: false };
 
-    await click('.stub-delete-comment');
+    await click('.delete_button');
 
     assert.strictEqual(
       alert.modalCalls.length,
@@ -701,15 +724,12 @@ module('Integration | Component | comment-list', function (hooks) {
   });
 
   test('canceling admin cross-user delete does not delete comment', async function (assert) {
-    this.owner.register(
-      'service:currentUser',
-      class extends Service {
-        user = { id: 'u1', username: 'admin' };
-        id = 'u1';
-        isAdmin = true;
-        isStudent = false;
-      }
-    );
+    registerCurrentUser(this.owner, {
+      user: { id: 'u1', username: 'admin' },
+      id: 'u1',
+      isAdmin: true,
+      isStudent: false,
+    });
 
     let saveCalled = false;
     const comment = {
@@ -732,13 +752,91 @@ module('Integration | Component | comment-list', function (hooks) {
     });
 
     await click('input[name="myCommentsOnly"]');
-    assert.dom('.stub-delete-comment').exists();
+    assert.dom('.delete_button').exists();
     const alert = this.owner.lookup('service:sweet-alert');
     alert.modalResult = { value: false };
 
-    await click('.stub-delete-comment');
+    await click('.delete_button');
 
     assert.false(saveCalled, 'does not save when modal is canceled');
     assert.false(comment.isTrashed, 'comment remains not trashed');
+  });
+
+  test('admin cross-user delete confirm=true marks comment trashed and saves', async function (assert) {
+    registerCurrentUser(this.owner, {
+      user: { id: 'u1', username: 'admin' },
+      id: 'u1',
+      isAdmin: true,
+      isStudent: false,
+    });
+
+    let saveCalls = 0;
+    const comment = {
+      id: 'c1',
+      text: 'cross-user',
+      createDate: new Date(),
+      isTrashed: false,
+      submission: { id: 'sub1' },
+      workspace: { id: 'w1' },
+      createdBy: { id: 'u2' },
+      save() {
+        saveCalls += 1;
+        return Promise.resolve({});
+      },
+    };
+
+    await renderCommentList(this, {
+      comments: [comment],
+      isParentWorkspace: false,
+    });
+
+    await click('input[name="myCommentsOnly"]');
+    const alert = this.owner.lookup('service:sweet-alert');
+    alert.modalResult = { value: true };
+
+    await click('.delete_button');
+
+    assert.true(comment.isTrashed, 'comment marked trashed on confirm');
+    assert.strictEqual(saveCalls, 1, 'comment save called exactly once');
+    assert.strictEqual(
+      alert.toastCalls[0][1],
+      'Comment Deleted',
+      'shows deleted toast'
+    );
+  });
+
+  test('owner delete uses standard confirmation copy', async function (assert) {
+    let saveCalls = 0;
+    const comment = {
+      id: 'c1',
+      text: 'own comment',
+      createDate: new Date(),
+      isTrashed: false,
+      submission: { id: 'sub1' },
+      workspace: { id: 'w1' },
+      createdBy: { id: 'u1' },
+      save() {
+        saveCalls += 1;
+        return Promise.resolve({});
+      },
+    };
+
+    await renderCommentList(this, {
+      comments: [comment],
+      isParentWorkspace: false,
+    });
+
+    const alert = this.owner.lookup('service:sweet-alert');
+    alert.modalResult = { value: false };
+
+    await click('.delete_button');
+
+    assert.strictEqual(alert.modalCalls.length, 1, 'opens one confirmation');
+    assert.strictEqual(
+      alert.modalCalls[0][1],
+      'Are you sure you want to delete this comment?'
+    );
+    assert.strictEqual(alert.modalCalls[0][3], 'Yes, delete it');
+    assert.strictEqual(saveCalls, 0, 'does not save when modal is canceled');
   });
 });

--- a/tests/integration/components/draggable-selection-test.js
+++ b/tests/integration/components/draggable-selection-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click, settled } from '@ember/test-helpers';
+import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 
@@ -92,6 +92,23 @@ module('Integration | Component | draggable-selection', function (hooks) {
     />`);
   }
 
+  function registerCurrentUser(owner, overrides = {}) {
+    owner.unregister('service:currentUser');
+    owner.register(
+      'service:currentUser',
+      class extends Service {
+        id = 'u1';
+        isAdmin = false;
+        isStudent = false;
+
+        constructor() {
+          super(...arguments);
+          Object.assign(this, overrides);
+        }
+      }
+    );
+  }
+
   test('shows delete icon for owner even when canDeleteSelections is false', async function (assert) {
     await renderSelection(this, {
       selection: createSelection({
@@ -115,15 +132,11 @@ module('Integration | Component | draggable-selection', function (hooks) {
   });
 
   test('shows delete icon for admin on another user selection when permission allows', async function (assert) {
-    this.owner.unregister('service:currentUser');
-    this.owner.register(
-      'service:currentUser',
-      class extends Service {
-        id = 'u1';
-        isAdmin = true;
-        isStudent = false;
-      }
-    );
+    registerCurrentUser(this.owner, {
+      id: 'u1',
+      isAdmin: true,
+      isStudent: false,
+    });
 
     await renderSelection(this, {
       selection: createSelection({
@@ -135,16 +148,46 @@ module('Integration | Component | draggable-selection', function (hooks) {
     assert.dom('.fa-minus-circle').exists();
   });
 
+  test('hides delete icon for admin on another user selection when canDeleteSelections is false', async function (assert) {
+    registerCurrentUser(this.owner, {
+      id: 'u1',
+      isAdmin: true,
+      isStudent: false,
+    });
+
+    await renderSelection(this, {
+      selection: createSelection({
+        createdBy: { id: 'u2', username: 'other' },
+      }),
+      canDeleteSelections: false,
+    });
+
+    assert.dom('.fa-minus-circle').doesNotExist();
+  });
+
+  test('hides delete icon when admin is acting as student on another user selection', async function (assert) {
+    registerCurrentUser(this.owner, {
+      id: 'u1',
+      isAdmin: true,
+      isStudent: true,
+    });
+
+    await renderSelection(this, {
+      selection: createSelection({
+        createdBy: { id: 'u2', username: 'other' },
+      }),
+      canDeleteSelections: true,
+    });
+
+    assert.dom('.fa-minus-circle').doesNotExist();
+  });
+
   test('uses admin warning modal copy for admin cross-user delete', async function (assert) {
-    this.owner.unregister('service:currentUser');
-    this.owner.register(
-      'service:currentUser',
-      class extends Service {
-        id = 'u1';
-        isAdmin = true;
-        isStudent = false;
-      }
-    );
+    registerCurrentUser(this.owner, {
+      id: 'u1',
+      isAdmin: true,
+      isStudent: false,
+    });
 
     let deletedSelection = null;
     await renderSelection(this, {
@@ -161,7 +204,6 @@ module('Integration | Component | draggable-selection', function (hooks) {
     alert.modalResult = { value: false };
 
     await click('.fa-minus-circle');
-    await settled();
 
     assert.strictEqual(alert.modalCalls.length, 1);
     assert.strictEqual(
@@ -193,7 +235,6 @@ module('Integration | Component | draggable-selection', function (hooks) {
     alert.modalResult = { value: true };
 
     await click('.fa-minus-circle');
-    await settled();
 
     assert.strictEqual(alert.modalCalls.length, 1);
     assert.strictEqual(

--- a/tests/integration/components/workspace-submission-test.js
+++ b/tests/integration/components/workspace-submission-test.js
@@ -1,0 +1,375 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import Service from '@ember/service';
+import Component from '@glimmer/component';
+
+module('Integration | Component | workspace-submission', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    let canEditImpl = () => true;
+
+    this.setCanEdit = (fn) => {
+      canEditImpl = fn;
+    };
+
+    this.owner.register(
+      'service:workspace-permissions',
+      class extends Service {
+        canEdit(workspace, area, level) {
+          return canEditImpl(workspace, area, level);
+        }
+      }
+    );
+
+    this.owner.register(
+      'service:utility-methods',
+      class extends Service {
+        getBelongsToId(record, key) {
+          if (!record || !key) {
+            return null;
+          }
+          const value = record[key];
+          if (!value) {
+            return null;
+          }
+          if (typeof value === 'object') {
+            return value.id ?? null;
+          }
+          return value;
+        }
+
+        isValidMongoId(value) {
+          return typeof value === 'string' && value.length === 24;
+        }
+
+        getTimeStringFromMs(ms) {
+          return String(ms ?? '');
+        }
+      }
+    );
+
+    this.owner.register(
+      'service:current-user',
+      class extends Service {
+        id = 'u1';
+        user = { id: 'u1', username: 'test-user' };
+      }
+    );
+    this.owner.register(
+      'service:currentUser',
+      class extends Service {
+        id = 'u1';
+        user = { id: 'u1', username: 'test-user' };
+      }
+    );
+
+    this.owner.register(
+      'service:current-selection',
+      class extends Service {
+        selection = null;
+
+        setSelection(selection) {
+          this.selection = selection;
+        }
+      }
+    );
+
+    this.owner.register(
+      'service:navigation',
+      class extends Service {
+        toNewResponse() {}
+        openProblem() {}
+      }
+    );
+
+    this.owner.register(
+      'component:selectable-area',
+      class extends Component {
+        static template = hbs`<div class='selectable-area-stub'>{{yield}}</div>`;
+      }
+    );
+
+    this.owner.register(
+      'component:draggable-selection',
+      class extends Component {
+        static template = hbs`<div
+          class='draggable-selection-stub'
+          data-selection-id={{@selection.id}}
+          data-can-delete={{if @canDeleteSelections 'true' 'false'}}
+        >
+          <button
+            type='button'
+            class='trigger-delete-selection'
+            {{on 'click' (fn @deleteSelection @selection)}}
+          >
+            Delete Selection
+          </button>
+        </div>`;
+      }
+    );
+
+    this.owner.register(
+      'component:undraggable-selection',
+      class extends Component {
+        static template = hbs`<div
+          class='undraggable-selection-stub'
+        >Undraggable Selection</div>`;
+      }
+    );
+  });
+
+  async function renderWorkspaceSubmission(context, overrides = {}) {
+    const defaultSelection = {
+      id: 'sel-1',
+      text: 'x + 1',
+      isTrashed: false,
+      createdBy: { id: 'u1' },
+      submission: { id: 'sub-1' },
+      workspace: { id: 'ws-1' },
+    };
+
+    context.setProperties({
+      currentSubmission: {
+        id: 'sub-1',
+        puzzle: { title: 'Test Assignment' },
+        answer: { answer: '', explanation: '' },
+        shortAnswer: 'short answer',
+        longAnswer: 'long answer',
+        uploadedFile: {},
+      },
+      currentWorkspace: {
+        id: 'ws-1',
+        workspaceType: 'individual',
+        save() {
+          return Promise.resolve(this);
+        },
+      },
+      isParentWorkspace: false,
+      selections: [defaultSelection],
+      responses: [],
+      canRespond: false,
+      addSelection: () => {},
+      deleteSelection: () => {},
+      ...overrides,
+    });
+
+    await render(hbs`<WorkspaceSubmission
+      @currentSubmission={{this.currentSubmission}}
+      @currentWorkspace={{this.currentWorkspace}}
+      @selections={{this.selections}}
+      @responses={{this.responses}}
+      @canRespond={{this.canRespond}}
+      @isParentWorkspace={{this.isParentWorkspace}}
+      @addSelection={{this.addSelection}}
+      @deleteSelection={{this.deleteSelection}}
+    />`);
+  }
+
+  function selection(overrides = {}) {
+    return {
+      id: 'sel-default',
+      text: 'selection text',
+      isTrashed: false,
+      createdBy: { id: 'u1' },
+      submission: { id: 'sub-1' },
+      workspace: { id: 'ws-1' },
+      ...overrides,
+    };
+  }
+
+  test('passes canDeleteSelections=true to DraggableSelection when delete permission is granted', async function (assert) {
+    this.setCanEdit(() => true);
+
+    await renderWorkspaceSubmission(this);
+
+    assert.dom('.draggable-selection-stub').exists();
+    assert
+      .dom('.draggable-selection-stub')
+      .hasAttribute('data-can-delete', 'true');
+  });
+
+  test('passes canDeleteSelections=false to DraggableSelection when delete permission is denied', async function (assert) {
+    this.setCanEdit((workspace, area, level) => {
+      if (area === 'selections' && level === 4) {
+        return false;
+      }
+      return true;
+    });
+
+    await renderWorkspaceSubmission(this);
+
+    assert.dom('.draggable-selection-stub').exists();
+    assert
+      .dom('.draggable-selection-stub')
+      .hasAttribute('data-can-delete', 'false');
+  });
+
+  test('wires child delete action to parent deleteSelection callback', async function (assert) {
+    let deletedSelection = null;
+    const selection = {
+      id: 'sel-2',
+      text: 'delete me',
+      isTrashed: false,
+      createdBy: { id: 'u1' },
+      submission: { id: 'sub-1' },
+      workspace: { id: 'ws-1' },
+    };
+
+    await renderWorkspaceSubmission(this, {
+      selections: [selection],
+      deleteSelection: (sel) => {
+        deletedSelection = sel;
+      },
+    });
+
+    await click('.trigger-delete-selection');
+
+    assert.strictEqual(
+      deletedSelection,
+      selection,
+      'deleteSelection callback receives the selected record from child action'
+    );
+  });
+
+  test('renders UndraggableSelection when user cannot create selections', async function (assert) {
+    this.setCanEdit((workspace, area, level) => {
+      if (area === 'selections' && level === 2) {
+        return false;
+      }
+      return true;
+    });
+
+    await renderWorkspaceSubmission(this);
+
+    assert.dom('.draggable-selection-stub').doesNotExist();
+    assert.dom('.undraggable-selection-stub').exists();
+  });
+
+  test('mySelectionsOnly filter hides non-owner selections by default and shows them after toggle', async function (assert) {
+    await renderWorkspaceSubmission(this, {
+      selections: [
+        selection({ id: 'sel-owner', createdBy: { id: 'u1' } }),
+        selection({ id: 'sel-other', createdBy: { id: 'u2' } }),
+      ],
+    });
+
+    assert
+      .dom('.draggable-selection-stub[data-selection-id="sel-owner"]')
+      .exists();
+    assert
+      .dom('.draggable-selection-stub[data-selection-id="sel-other"]')
+      .doesNotExist();
+
+    await click('[title="Filter selections"]');
+    await click('input[name="mySelectionsOnly"]');
+
+    assert
+      .dom('.draggable-selection-stub[data-selection-id="sel-owner"]')
+      .exists();
+    assert
+      .dom('.draggable-selection-stub[data-selection-id="sel-other"]')
+      .exists();
+  });
+
+  test('thisSubmissionOnly filter excludes other submission selections until toggled off', async function (assert) {
+    await renderWorkspaceSubmission(this, {
+      selections: [
+        selection({ id: 'sel-sub-1', submission: { id: 'sub-1' } }),
+        selection({ id: 'sel-sub-2', submission: { id: 'sub-2' } }),
+      ],
+    });
+
+    assert
+      .dom('.draggable-selection-stub[data-selection-id="sel-sub-1"]')
+      .exists();
+    assert
+      .dom('.draggable-selection-stub[data-selection-id="sel-sub-2"]')
+      .doesNotExist();
+
+    await click('[title="Filter selections"]');
+    await click('input[name="thisSubmissionOnly"]');
+
+    assert
+      .dom('.draggable-selection-stub[data-selection-id="sel-sub-1"]')
+      .exists();
+    assert
+      .dom('.draggable-selection-stub[data-selection-id="sel-sub-2"]')
+      .exists();
+  });
+
+  test('thisWorkspaceOnly filter excludes other workspace selections until toggled off', async function (assert) {
+    await renderWorkspaceSubmission(this, {
+      selections: [
+        selection({ id: 'sel-ws-1', workspace: { id: 'ws-1' } }),
+        selection({ id: 'sel-ws-2', workspace: { id: 'ws-2' } }),
+      ],
+    });
+
+    assert
+      .dom('.draggable-selection-stub[data-selection-id="sel-ws-1"]')
+      .exists();
+    assert
+      .dom('.draggable-selection-stub[data-selection-id="sel-ws-2"]')
+      .doesNotExist();
+
+    await click('[title="Filter selections"]');
+    await click('input[name="thisWorkspaceOnly"]');
+
+    assert
+      .dom('.draggable-selection-stub[data-selection-id="sel-ws-1"]')
+      .exists();
+    assert
+      .dom('.draggable-selection-stub[data-selection-id="sel-ws-2"]')
+      .exists();
+  });
+
+  test('parent workspace renders non-selectable view and hides mySelectionsOnly filter option', async function (assert) {
+    await renderWorkspaceSubmission(this, {
+      currentWorkspace: {
+        id: 'ws-parent',
+        workspaceType: 'parent',
+        save() {
+          return Promise.resolve(this);
+        },
+      },
+      isParentWorkspace: true,
+    });
+
+    assert.dom('#sel-view-header').doesNotExist();
+    assert.dom('.non-selectable-sub').exists();
+
+    await click('[title="Filter selections"]');
+    assert.dom('input[name="mySelectionsOnly"]').doesNotExist();
+  });
+
+  test('respond button is disabled when no selections are visible', async function (assert) {
+    await renderWorkspaceSubmission(this, {
+      canRespond: true,
+      selections: [],
+    });
+
+    assert.dom('button.action_button.new-response').isDisabled();
+  });
+
+  test('respond button is enabled when at least one selection is visible', async function (assert) {
+    await renderWorkspaceSubmission(this, {
+      canRespond: true,
+      selections: [selection({ id: 'sel-present' })],
+    });
+
+    assert.dom('button.action_button.new-response').isNotDisabled();
+  });
+
+  test('shows empty selections message when there are no selections', async function (assert) {
+    await renderWorkspaceSubmission(this, {
+      selections: [],
+    });
+
+    assert
+      .dom('#submission_selections .info')
+      .includesText('No selections have been made yet.');
+  });
+});


### PR DESCRIPTION
## Description

This PR focuses on test coverage and test stability for delete permissions, plus integration coverage for `workspace-submission`.

### Runtime safety
- `app/components/workspace-comment.js`
  - Made `childrenLength` safer when `utility-methods.getHasManyIds` is not available.
  - Falls back to `comment.children.length` instead of throwing.

### Comment delete tests
- `tests/integration/components/comment-list-test.js`
  - Cleaned up setup so tests use the real `workspace-comment` path by default.
  - Kept a small targeted stub only for the non-admin action-guard case.
  - Added coverage for:
    - admin cross-user delete confirm path (`isTrashed`, save call, delete toast)
    - owner delete default confirmation copy

### Selection delete tests
- `tests/integration/components/draggable-selection-test.js`
  - Added coverage for:
    - admin cross-user + `canDeleteSelections=false` (no delete affordance)
    - admin acting as student (no admin override)
  - Removed unnecessary `settled()` after `click()` in tests.

### New workspace-submission integration tests
- `tests/integration/components/workspace-submission-test.js` (new)
  - Added integration checks for:
    - `@canDeleteSelections` passed into `DraggableSelection`
    - child delete wiring to parent `@deleteSelection`
    - `UndraggableSelection` rendering when selection-create is denied
    - filter behavior (`mySelectionsOnly`, `thisSubmissionOnly`, `thisWorkspaceOnly`)
    - parent workspace rendering branch
    - respond button enabled/disabled state
    - empty selections message