### PR TITLE
test(workspace-submission): stabilize integration/unit suites after selection UI updates

### DIFF
--- a/tests/integration/components/workspace-submission-test.js
+++ b/tests/integration/components/workspace-submission-test.js
@@ -10,9 +10,22 @@ module('Integration | Component | workspace-submission', function (hooks) {
 
   hooks.beforeEach(function () {
     let canEditImpl = () => true;
+    let currentUserState = {
+      id: 'u1',
+      username: 'test-user',
+      isAdmin: false,
+      isStudent: false,
+    };
 
     this.setCanEdit = (fn) => {
       canEditImpl = fn;
+    };
+
+    this.setCurrentUser = (overrides = {}) => {
+      currentUserState = {
+        ...currentUserState,
+        ...overrides,
+      };
     };
 
     this.owner.register(
@@ -51,25 +64,55 @@ module('Integration | Component | workspace-submission', function (hooks) {
       }
     );
 
-    this.owner.register(
-      'service:current-user',
-      class extends Service {
-        id = 'u1';
-        user = { id: 'u1', username: 'test-user' };
+    class CurrentUserService extends Service {
+      get id() {
+        return currentUserState.id;
       }
-    );
-    this.owner.register(
-      'service:currentUser',
-      class extends Service {
-        id = 'u1';
-        user = { id: 'u1', username: 'test-user' };
+
+      get user() {
+        return {
+          id: currentUserState.id,
+          username: currentUserState.username,
+        };
       }
-    );
+
+      get isAdmin() {
+        return currentUserState.isAdmin;
+      }
+
+      get isStudent() {
+        return currentUserState.isStudent;
+      }
+    }
+
+    this.owner.unregister('service:current-user');
+    this.owner.unregister('service:currentUser');
+    this.owner.register('service:current-user', CurrentUserService);
+    this.owner.register('service:currentUser', CurrentUserService);
 
     this.owner.register(
       'service:current-selection',
       class extends Service {
         selection = null;
+
+        isCurrentSelection(selectionId) {
+          return this.selection?.id === selectionId;
+        }
+
+        setSelection(selection) {
+          this.selection = selection;
+        }
+      }
+    );
+    this.owner.unregister('service:currentSelection');
+    this.owner.register(
+      'service:currentSelection',
+      class extends Service {
+        selection = null;
+
+        isCurrentSelection(selectionId) {
+          return this.selection?.id === selectionId;
+        }
 
         setSelection(selection) {
           this.selection = selection;
@@ -85,50 +128,51 @@ module('Integration | Component | workspace-submission', function (hooks) {
       }
     );
 
+    this.owner.unregister('service:sweet-alert');
+    this.owner.register(
+      'service:sweet-alert',
+      class extends Service {
+        showModal() {
+          return Promise.resolve({ value: true });
+        }
+        showToast() {}
+      }
+    );
+
+    // Keep selectable-area lightweight for this integration suite.
+    this.owner.unregister('component:selectable-area');
+    this.owner.unregister('template:components/selectable-area');
+
     this.owner.register(
       'component:selectable-area',
       class extends Component {
         static template = hbs`<div class='selectable-area-stub'>{{yield}}</div>`;
       }
     );
-
-    this.owner.register(
-      'component:draggable-selection',
-      class extends Component {
-        static template = hbs`<div
-          class='draggable-selection-stub'
-          data-selection-id={{@selection.id}}
-          data-can-delete={{if @canDeleteSelections 'true' 'false'}}
-        >
-          <button
-            type='button'
-            class='trigger-delete-selection'
-            {{on 'click' (fn @deleteSelection @selection)}}
-          >
-            Delete Selection
-          </button>
-        </div>`;
-      }
-    );
-
-    this.owner.register(
-      'component:undraggable-selection',
-      class extends Component {
-        static template = hbs`<div
-          class='undraggable-selection-stub'
-        >Undraggable Selection</div>`;
-      }
-    );
   });
 
   async function renderWorkspaceSubmission(context, overrides = {}) {
+    const buildWorkspaceRef = (workspace = {}) => {
+      const normalized = {
+        workspaceType: 'individual',
+        ...workspace,
+      };
+      if (typeof normalized.get !== 'function') {
+        normalized.get = function (key) {
+          return this[key];
+        };
+      }
+      return normalized;
+    };
+
     const defaultSelection = {
       id: 'sel-1',
       text: 'x + 1',
       isTrashed: false,
+      createDate: new Date().toISOString(),
       createdBy: { id: 'u1' },
       submission: { id: 'sub-1' },
-      workspace: { id: 'ws-1' },
+      workspace: buildWorkspaceRef({ id: 'ws-1' }),
     };
 
     context.setProperties({
@@ -143,6 +187,9 @@ module('Integration | Component | workspace-submission', function (hooks) {
       currentWorkspace: {
         id: 'ws-1',
         workspaceType: 'individual',
+        get(key) {
+          return this[key];
+        },
         save() {
           return Promise.resolve(this);
         },
@@ -169,29 +216,61 @@ module('Integration | Component | workspace-submission', function (hooks) {
   }
 
   function selection(overrides = {}) {
-    return {
+    const buildWorkspaceRef = (workspace = {}) => {
+      const normalized = {
+        workspaceType: 'individual',
+        ...workspace,
+      };
+      if (typeof normalized.get !== 'function') {
+        normalized.get = function (key) {
+          return this[key];
+        };
+      }
+      return normalized;
+    };
+
+    const record = {
       id: 'sel-default',
       text: 'selection text',
       isTrashed: false,
+      createDate: new Date().toISOString(),
       createdBy: { id: 'u1' },
       submission: { id: 'sub-1' },
-      workspace: { id: 'ws-1' },
+      workspace: buildWorkspaceRef({ id: 'ws-1' }),
       ...overrides,
     };
+
+    record.workspace = buildWorkspaceRef(record.workspace);
+    return record;
   }
 
   test('passes canDeleteSelections=true to DraggableSelection when delete permission is granted', async function (assert) {
+    this.setCurrentUser({ id: 'admin-1', isAdmin: true, isStudent: false });
     this.setCanEdit(() => true);
 
-    await renderWorkspaceSubmission(this);
+    await renderWorkspaceSubmission(this, {
+      selections: [
+        selection({
+          id: 'sel-other-user',
+          text: 'other-user-selection',
+          createdBy: { id: 'owner-2' },
+        }),
+      ],
+    });
 
-    assert.dom('.draggable-selection-stub').exists();
+    await click('[title="Filter selections"]');
+    await click('input[name="mySelectionsOnly"]');
+
+    assert.dom('.draggable-selection').exists();
     assert
-      .dom('.draggable-selection-stub')
-      .hasAttribute('data-can-delete', 'true');
+      .dom('.draggable-selection .fa-minus-circle')
+      .exists(
+        'admin can see delete control when level-4 permission is granted'
+      );
   });
 
   test('passes canDeleteSelections=false to DraggableSelection when delete permission is denied', async function (assert) {
+    this.setCurrentUser({ id: 'admin-1', isAdmin: true, isStudent: false });
     this.setCanEdit((workspace, area, level) => {
       if (area === 'selections' && level === 4) {
         return false;
@@ -199,37 +278,47 @@ module('Integration | Component | workspace-submission', function (hooks) {
       return true;
     });
 
-    await renderWorkspaceSubmission(this);
+    await renderWorkspaceSubmission(this, {
+      selections: [
+        selection({
+          id: 'sel-other-user',
+          text: 'other-user-selection',
+          createdBy: { id: 'owner-2' },
+        }),
+      ],
+    });
 
-    assert.dom('.draggable-selection-stub').exists();
+    await click('[title="Filter selections"]');
+    await click('input[name="mySelectionsOnly"]');
+
+    assert.dom('.draggable-selection').exists();
     assert
-      .dom('.draggable-selection-stub')
-      .hasAttribute('data-can-delete', 'false');
+      .dom('.draggable-selection .fa-minus-circle')
+      .doesNotExist(
+        'admin cannot see delete control when level-4 permission is denied'
+      );
   });
 
   test('wires child delete action to parent deleteSelection callback', async function (assert) {
     let deletedSelection = null;
-    const selection = {
+    const deleteCandidate = selection({
       id: 'sel-2',
       text: 'delete me',
-      isTrashed: false,
       createdBy: { id: 'u1' },
-      submission: { id: 'sub-1' },
-      workspace: { id: 'ws-1' },
-    };
+    });
 
     await renderWorkspaceSubmission(this, {
-      selections: [selection],
+      selections: [deleteCandidate],
       deleteSelection: (sel) => {
         deletedSelection = sel;
       },
     });
 
-    await click('.trigger-delete-selection');
+    await click('.draggable-selection .fa-minus-circle');
 
     assert.strictEqual(
       deletedSelection,
-      selection,
+      deleteCandidate,
       'deleteSelection callback receives the selected record from child action'
     );
   });
@@ -244,86 +333,86 @@ module('Integration | Component | workspace-submission', function (hooks) {
 
     await renderWorkspaceSubmission(this);
 
-    assert.dom('.draggable-selection-stub').doesNotExist();
-    assert.dom('.undraggable-selection-stub').exists();
+    assert.dom('.draggable-selection').doesNotExist();
+    assert.dom('.unundraggable-selection').exists();
   });
 
   test('mySelectionsOnly filter hides non-owner selections by default and shows them after toggle', async function (assert) {
     await renderWorkspaceSubmission(this, {
       selections: [
-        selection({ id: 'sel-owner', createdBy: { id: 'u1' } }),
-        selection({ id: 'sel-other', createdBy: { id: 'u2' } }),
+        selection({
+          id: 'sel-owner',
+          text: 'owner-selection',
+          createdBy: { id: 'u1' },
+        }),
+        selection({
+          id: 'sel-other',
+          text: 'other-selection',
+          createdBy: { id: 'u2' },
+        }),
       ],
     });
 
-    assert
-      .dom('.draggable-selection-stub[data-selection-id="sel-owner"]')
-      .exists();
-    assert
-      .dom('.draggable-selection-stub[data-selection-id="sel-other"]')
-      .doesNotExist();
+    assert.dom('#submission_selections').includesText('owner-selection');
+    assert.dom('#submission_selections').doesNotIncludeText('other-selection');
 
     await click('[title="Filter selections"]');
     await click('input[name="mySelectionsOnly"]');
 
-    assert
-      .dom('.draggable-selection-stub[data-selection-id="sel-owner"]')
-      .exists();
-    assert
-      .dom('.draggable-selection-stub[data-selection-id="sel-other"]')
-      .exists();
+    assert.dom('#submission_selections').includesText('owner-selection');
+    assert.dom('#submission_selections').includesText('other-selection');
   });
 
   test('thisSubmissionOnly filter excludes other submission selections until toggled off', async function (assert) {
     await renderWorkspaceSubmission(this, {
       selections: [
-        selection({ id: 'sel-sub-1', submission: { id: 'sub-1' } }),
-        selection({ id: 'sel-sub-2', submission: { id: 'sub-2' } }),
+        selection({
+          id: 'sel-sub-1',
+          text: 'submission-one',
+          submission: { id: 'sub-1' },
+        }),
+        selection({
+          id: 'sel-sub-2',
+          text: 'submission-two',
+          submission: { id: 'sub-2' },
+        }),
       ],
     });
 
-    assert
-      .dom('.draggable-selection-stub[data-selection-id="sel-sub-1"]')
-      .exists();
-    assert
-      .dom('.draggable-selection-stub[data-selection-id="sel-sub-2"]')
-      .doesNotExist();
+    assert.dom('#submission_selections').includesText('submission-one');
+    assert.dom('#submission_selections').doesNotIncludeText('submission-two');
 
     await click('[title="Filter selections"]');
     await click('input[name="thisSubmissionOnly"]');
 
-    assert
-      .dom('.draggable-selection-stub[data-selection-id="sel-sub-1"]')
-      .exists();
-    assert
-      .dom('.draggable-selection-stub[data-selection-id="sel-sub-2"]')
-      .exists();
+    assert.dom('#submission_selections').includesText('submission-one');
+    assert.dom('#submission_selections').includesText('submission-two');
   });
 
   test('thisWorkspaceOnly filter excludes other workspace selections until toggled off', async function (assert) {
     await renderWorkspaceSubmission(this, {
       selections: [
-        selection({ id: 'sel-ws-1', workspace: { id: 'ws-1' } }),
-        selection({ id: 'sel-ws-2', workspace: { id: 'ws-2' } }),
+        selection({
+          id: 'sel-ws-1',
+          text: 'workspace-one',
+          workspace: { id: 'ws-1' },
+        }),
+        selection({
+          id: 'sel-ws-2',
+          text: 'workspace-two',
+          workspace: { id: 'ws-2' },
+        }),
       ],
     });
 
-    assert
-      .dom('.draggable-selection-stub[data-selection-id="sel-ws-1"]')
-      .exists();
-    assert
-      .dom('.draggable-selection-stub[data-selection-id="sel-ws-2"]')
-      .doesNotExist();
+    assert.dom('#submission_selections').includesText('workspace-one');
+    assert.dom('#submission_selections').doesNotIncludeText('workspace-two');
 
     await click('[title="Filter selections"]');
     await click('input[name="thisWorkspaceOnly"]');
 
-    assert
-      .dom('.draggable-selection-stub[data-selection-id="sel-ws-1"]')
-      .exists();
-    assert
-      .dom('.draggable-selection-stub[data-selection-id="sel-ws-2"]')
-      .exists();
+    assert.dom('#submission_selections').includesText('workspace-one');
+    assert.dom('#submission_selections').includesText('workspace-two');
   });
 
   test('parent workspace renders non-selectable view and hides mySelectionsOnly filter option', async function (assert) {

--- a/tests/unit/components/workspace-submission-test.js
+++ b/tests/unit/components/workspace-submission-test.js
@@ -41,17 +41,21 @@ module('Unit | Component | workspace-submission', function (hooks) {
     };
 
     // Mock current-user service
-    this.owner.register(
-      'service:current-user',
-      class extends Service {
-        user = {
-          id: 'user-1',
-          username: 'testuser',
-          accountType: 'T',
-          isAdmin: false,
-        };
-      }
-    );
+    class CurrentUserService extends Service {
+      id = 'user-1';
+      user = {
+        id: 'user-1',
+        username: 'testuser',
+        accountType: 'T',
+        isAdmin: false,
+      };
+      isAdmin = false;
+      isStudent = false;
+    }
+    this.owner.unregister('service:current-user');
+    this.owner.unregister('service:currentUser');
+    this.owner.register('service:current-user', CurrentUserService);
+    this.owner.register('service:currentUser', CurrentUserService);
 
     this.owner.register(
       'service:utility-methods',
@@ -128,7 +132,9 @@ module('Unit | Component | workspace-submission', function (hooks) {
       id,
       text: `Selection ${id}`,
       isTrashed,
+      createdBy: { id: 'user-1' },
       submission: submissionId,
+      workspace: { id: 'ws-1' },
       get(prop) {
         return this[prop];
       },
@@ -179,6 +185,27 @@ module('Unit | Component | workspace-submission', function (hooks) {
       addSelection: args.addSelection || (() => {}),
       deleteSelection: args.deleteSelection || (() => {}),
     };
+
+    // Initialize tracked state explicitly for Object.create-based unit setup.
+    component.makingSelection = true;
+    component.showingSelections = false;
+    component.isTransitioning = false;
+    component.isDirty = false;
+    component.wasShowingBeforeResizing = false;
+    component.isSelectionsBoxExpanded = false;
+    component.isMessageListenerAttached = false;
+    component.areSelectionsHidden = false;
+    component.wsSaveErrors = [];
+    component.vmtReplayerInfo = null;
+    component.vmtScreenshot = null;
+    component.vmtListener = null;
+    // Keep unit fixtures focused on submission filtering unless a test opts in.
+    component.thisSubmissionOnly = true;
+    component.thisWorkspaceOnly = false;
+    component.mySelectionsOnly = false;
+    component.showSelectionFilterMenu = false;
+    component.selectionFilterMenuElement = null;
+    component.selectionFilterMenuOutsideHandler = null;
 
     return component;
   }
@@ -239,7 +266,7 @@ module('Unit | Component | workspace-submission', function (hooks) {
       );
     });
 
-    test('areNoSelections considers trashed selections as selections', function (assert) {
+    test('areNoSelections treats trashed selections as hidden from active list', function (assert) {
       const submission = createSubmission('sub-3');
       const trashedSelection = createSelection('sel-trash-1', 'sub-3', true);
       const workspace = createWorkspace('ws-3');
@@ -250,7 +277,7 @@ module('Unit | Component | workspace-submission', function (hooks) {
         selections: [trashedSelection],
       });
 
-      // workspaceSelections includes trashed items (filtered by submission ID only)
+      // workspaceSelections excludes trashed items.
       const result = component.areNoSelections;
 
       assert.strictEqual(
@@ -261,8 +288,8 @@ module('Unit | Component | workspace-submission', function (hooks) {
 
       assert.strictEqual(
         result,
-        false,
-        'areNoSelections should be false when trashed selections exist'
+        true,
+        'areNoSelections should be true when only trashed selections exist'
       );
     });
 
@@ -324,7 +351,7 @@ module('Unit | Component | workspace-submission', function (hooks) {
       );
     });
 
-    test('workspaceSelections includes both trashed and non-trashed', function (assert) {
+    test('workspaceSelections excludes trashed selections', function (assert) {
       const submission = createSubmission('sub-6');
       const activeSelection = createSelection('sel-active', 'sub-6', false);
       const trashedSelection = createSelection('sel-trashed', 'sub-6', true);
@@ -340,8 +367,16 @@ module('Unit | Component | workspace-submission', function (hooks) {
 
       assert.strictEqual(
         filtered.length,
-        2,
-        'workspaceSelections should include both trashed and non-trashed'
+        1,
+        'workspaceSelections should exclude trashed selections'
+      );
+      assert.ok(
+        filtered.includes(activeSelection),
+        'workspaceSelections should include active selections'
+      );
+      assert.notOk(
+        filtered.includes(trashedSelection),
+        'workspaceSelections should not include trashed selections'
       );
     });
 


### PR DESCRIPTION
### Description
This updates the `workspace-submission` tests to match how the component is currently rendering and filtering selections.  
Main goal was to stop the false failures from old stubs/fixture shapes and make the tests assert real behavior again.

### Changes
- `tests/integration/components/workspace-submission-test.js`
- added a simple current-user override helper for admin/non-owner cases
- registered both service naming variants we use in app code:
  - `current-user` / `currentUser`
  - `current-selection` / `currentSelection`
- added `sweet-alert` stub so delete flows run in test without modal issues
- fixed fixture shape for selections/workspace (`workspaceType`, `get(key)`, `createDate`) to avoid runtime errors in child components
- switched assertions from stub markers to actual rendered UI:
  - draggable vs non-draggable selection rows
  - delete icon visibility with/without level 4 permission
  - selection filters (`mySelectionsOnly`, `thisSubmissionOnly`, `thisWorkspaceOnly`)
  - parent workspace behavior
  - respond button state
  - empty state message

- `tests/unit/components/workspace-submission-test.js`
- aligned current-user mock shape with what component getters expect
- added missing fixture fields (`createdBy`, `workspace`) used by filtering logic
- initialized tracked/filter flags in unit setup to avoid undefined state on object-created instances
- updated expectations where behavior intentionally excludes trashed selections from active list

### Test Status
- Targeted files:
  - `tests/integration/components/workspace-submission-test.js`
  - `tests/unit/components/workspace-submission-test.js`
- All tests passing