### PR TITLE
Upgarde bulk upload 1

### DIFF
--- a/app/components/details-list-item.js
+++ b/app/components/details-list-item.js
@@ -1,39 +1,29 @@
-import Component from '@ember/component';
-import { computed } from '@ember/object';
-import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
 
-export default Component.extend({
-  classNames: ['details-list-item'],
-  utils: service('utility-methods'),
-
-  doShowRemoveIcon: computed(
-    'cannotBeRemoved',
-    'children',
-    'displayValue',
-    'hasValidChild',
-    function () {
-      if (this.cannotBeRemoved) {
-        return false;
-      }
-      const val = this.displayValue;
-      const children = this.children;
-
-      if (children) {
-        children.map((child) => {
-          let val = child.displayValue;
-          if (!this.utils.isNullOrUndefined(val)) {
-            this.set('hasValidChild', true);
-          }
-        });
-      }
-
-      return !this.utils.isNullOrUndefined(val) || this.hasValidChild;
+export default class DetailsListItemComponent extends Component {
+  get doShowRemoveIcon() {
+    if (this.args.cannotBeRemoved) {
+      return false;
     }
-  ),
 
-  actions: {
-    editValue() {
-      this.editValue(this.associatedStep);
-    },
-  },
-});
+    const hasValue =
+      this.args.displayValue !== null && this.args.displayValue !== undefined;
+    const children = Array.isArray(this.args.children)
+      ? this.args.children
+      : [];
+    const hasValidChild = children.some((child) => {
+      const childValue = child?.displayValue;
+      return childValue !== null && childValue !== undefined;
+    });
+
+    return hasValue || hasValidChild;
+  }
+
+  @action
+  editValue() {
+    if (typeof this.args.editValue === 'function') {
+      this.args.editValue(this.args.associatedStep);
+    }
+  }
+}

--- a/app/components/import-work-container.js
+++ b/app/components/import-work-container.js
@@ -338,7 +338,10 @@ export default class ImportWorkComponent extends Component {
   }
 
   @action
-  setSelectedProblem() {
+  setSelectedProblem(problem) {
+    if (problem) {
+      this.selectedProblem = problem;
+    }
     this.currentStep = this.steps[2];
   }
 

--- a/app/components/import-work-step1.js
+++ b/app/components/import-work-step1.js
@@ -1,50 +1,66 @@
-import Component from '@ember/component';
-import { computed } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 
-export default Component.extend({
-  elementId: 'import-work-step1',
-  utils: service('utility-methods'),
+export default class ImportWorkStep1Component extends Component {
+  @service('utility-methods') utils;
+  @service store;
 
-  initialProblemItem: computed('selectedProblem', function () {
-    const selectedProblem = this.selectedProblem;
+  @tracked selectedProblem = null;
+  @tracked missingProblem = null;
+
+  constructor() {
+    super(...arguments);
+    this.selectedProblem = this.args.selectedProblem || null;
+  }
+
+  get initialProblemItem() {
+    const selectedProblem = this.args.selectedProblem;
     if (this.utils.isNonEmptyObject(selectedProblem)) {
       return [selectedProblem.id];
     }
     return [];
-  }),
+  }
 
-  actions: {
-    setSelectedProblem(val, $item) {
-      if (!val) {
-        return;
-      }
+  @action
+  setSelectedProblem(value, item) {
+    if (!value) {
+      return;
+    }
 
-      const isRemoval = this.utils.isNullOrUndefined($item);
-      if (isRemoval) {
-        this.set('selectedProblem', null);
-        return;
-      }
+    const isRemoval = this.utils.isNullOrUndefined(item);
+    if (isRemoval) {
+      this.selectedProblem = null;
+      return;
+    }
 
-      const problem = this.store.peekRecord('problem', val);
-      if (this.utils.isNullOrUndefined(problem)) {
-        return;
-      }
+    const problem = this.store.peekRecord('problem', value);
+    if (this.utils.isNullOrUndefined(problem)) {
+      return;
+    }
 
-      this.set('selectedProblem', problem);
-      if (this.missingProblem) {
-        this.set('missingProblem', null);
-      }
-    },
-    next() {
-      const problem = this.selectedProblem;
+    this.selectedProblem = problem;
+    if (this.missingProblem) {
+      this.missingProblem = null;
+    }
+  }
 
-      // workspace is required to go to next step
-      if (this.utils.isNonEmptyObject(problem)) {
-        this.onProceed();
-        return;
+  @action
+  resetMissingProblem() {
+    this.missingProblem = null;
+  }
+
+  @action
+  next() {
+    const problem = this.selectedProblem;
+
+    if (this.utils.isNonEmptyObject(problem)) {
+      if (typeof this.args.onProceed === 'function') {
+        this.args.onProceed(problem);
       }
-      this.set('missingProblem', true);
-    },
-  },
-});
+      return;
+    }
+    this.missingProblem = true;
+  }
+}

--- a/app/styles/_import.scss
+++ b/app/styles/_import.scss
@@ -103,6 +103,12 @@
     }
     .detail-header {
       font-weight: $bold-font-weight;
+      .detail-edit-button {
+        background: none;
+        border: 0;
+        padding: 0;
+        cursor: pointer;
+      }
       i {
         position: relative;
         left: 5px;

--- a/app/styles/_vmt-import.scss
+++ b/app/styles/_vmt-import.scss
@@ -133,6 +133,12 @@
     }
     .detail-header {
       font-weight: $bold-font-weight;
+      .detail-edit-button {
+        background: none;
+        border: 0;
+        padding: 0;
+        cursor: pointer;
+      }
       i {
         position: relative;
         left: 5px;

--- a/app/styles/_workspaces-copy.scss
+++ b/app/styles/_workspaces-copy.scss
@@ -68,6 +68,12 @@
     }
     .detail-header {
       font-weight: $bold-font-weight;
+      .detail-edit-button {
+        background: none;
+        border: 0;
+        padding: 0;
+        cursor: pointer;
+      }
       i {
         position: relative;
         left: 5px;

--- a/app/templates/components/details-list-item.hbs
+++ b/app/templates/components/details-list-item.hbs
@@ -1,9 +1,16 @@
 {{#if (greater-equal @currentStep @associatedStep)}}
-<li>
+<li class='details-list-item'>
   <h3 class="detail-header">
     {{@label}}
     {{#if this.doShowRemoveIcon}}
-      <i {{action "editValue" }} class="far fa-edit" aria-hidden="true" title="Edit"></i>
+      <button
+        type='button'
+        class='detail-edit-button'
+        {{on 'click' this.editValue}}
+        title='Edit'
+      >
+        <i class='far fa-edit' aria-hidden='true'></i>
+      </button>
     {{/if}}
   </h3>
   {{#if @displayValue}}

--- a/app/templates/components/import-work-step1.hbs
+++ b/app/templates/components/import-work-step1.hbs
@@ -15,8 +15,8 @@
     @query={{hash
       returnTo='import'
       importProblemId=this.selectedProblem.id
-      importSectionId=this.selectedSection.id
-      importUseClass=this.selectedValue
+      importSectionId=@selectedSection.id
+      importUseClass=@selectedValue
     }}
     class='new-link'
   >here</LinkTo>.</p>
@@ -25,8 +25,8 @@
   @isAsync={{true}}
   @maxItems={{1}}
   @initialItems={{this.initialProblemItem}}
-  @onItemAdd={{action 'setSelectedProblem'}}
-  @onItemRemove={{action 'setSelectedProblem'}}
+  @onItemAdd={{this.setSelectedProblem}}
+  @onItemRemove={{this.setSelectedProblem}}
   @labelField='title'
   @searchField='title'
   @valueField='id'
@@ -41,11 +41,11 @@
 {{#if this.missingProblem}}
   <Ui::ErrorBox
     @error='Please select a problem'
-    @resetError={{action (mut this.missingProblem) null}}
+    @resetError={{this.resetMissingProblem}}
     @showDismiss={{true}}
   />
 {{/if}}
 
 <div class='nav-btn-container'>
-  <button class='primary-button' type='button' {{action 'next'}}>Next</button>
+  <button class='primary-button' type='button' {{on 'click' this.next}}>Next</button>
 </div>

--- a/tests/integration/components/details-list-item-test.js
+++ b/tests/integration/components/details-list-item-test.js
@@ -1,0 +1,113 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | details-list-item', function (hooks) {
+  setupRenderingTest(hooks);
+
+  async function renderComponent(context, overrides = {}) {
+    context.setProperties({
+      label: 'Selected Problem',
+      currentStep: 2,
+      associatedStep: 1,
+      displayValue: 'Problem A',
+      emptyValue: 'No Problem',
+      isArray: false,
+      children: null,
+      cannotBeRemoved: false,
+      editCalls: [],
+      onEdit: (step) => context.editCalls.push(step),
+      ...overrides,
+    });
+
+    await render(hbs`
+      <ul>
+        <DetailsListItem
+          @label={{this.label}}
+          @currentStep={{this.currentStep}}
+          @associatedStep={{this.associatedStep}}
+          @displayValue={{this.displayValue}}
+          @emptyValue={{this.emptyValue}}
+          @isArray={{this.isArray}}
+          @children={{this.children}}
+          @cannotBeRemoved={{this.cannotBeRemoved}}
+          @editValue={{this.onEdit}}
+        />
+      </ul>
+    `);
+  }
+
+  test('it renders when current step has reached associated step', async function (assert) {
+    await renderComponent(this, {
+      currentStep: 3,
+      associatedStep: 2,
+      displayValue: 'Problem 3',
+    });
+
+    assert.dom('.details-list-item').exists();
+    assert.dom('.detail-header').includesText('Selected Problem');
+    assert.dom('.display-info').hasText('Problem 3');
+  });
+
+  test('it does not render when current step is below associated step', async function (assert) {
+    await renderComponent(this, {
+      currentStep: 1,
+      associatedStep: 2,
+    });
+
+    assert.dom('.details-list-item').doesNotExist();
+  });
+
+  test('it renders array display values as sub-list children', async function (assert) {
+    await renderComponent(this, {
+      isArray: true,
+      displayValue: ['alpha', 'beta', 'gamma'],
+    });
+
+    assert
+      .dom('.sub-content-child')
+      .exists({ count: 3 }, 'array values are rendered as child list items');
+    assert.dom('.sub-list').includesText('alpha');
+    assert.dom('.sub-list').includesText('beta');
+    assert.dom('.sub-list').includesText('gamma');
+  });
+
+  test('it shows edit button when a child has value and triggers callback with associated step', async function (assert) {
+    await renderComponent(this, {
+      displayValue: null,
+      currentStep: 4,
+      children: [
+        { label: 'Class', displayValue: null, emptyValue: 'No Class' },
+        {
+          label: 'Workspace',
+          displayValue: 'WS-1',
+          emptyValue: 'No Workspace',
+        },
+      ],
+      associatedStep: 4,
+    });
+
+    assert
+      .dom('.detail-edit-button')
+      .exists('edit button is shown when child contains a display value');
+    assert.dom('.sub-list').includesText('WS-1');
+
+    await click('.detail-edit-button');
+
+    assert.deepEqual(
+      this.editCalls,
+      [4],
+      'edit callback receives the associated step'
+    );
+  });
+
+  test('it hides edit button when cannotBeRemoved is true', async function (assert) {
+    await renderComponent(this, {
+      displayValue: 'Problem A',
+      cannotBeRemoved: true,
+    });
+
+    assert.dom('.detail-edit-button').doesNotExist();
+  });
+});

--- a/tests/integration/components/import-work-step1-test.js
+++ b/tests/integration/components/import-work-step1-test.js
@@ -1,0 +1,195 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import Service from '@ember/service';
+import Component from '@glimmer/component';
+
+class UtilityMethodsStub extends Service {
+  isNonEmptyObject(value) {
+    return (
+      !!value && typeof value === 'object' && Object.keys(value).length > 0
+    );
+  }
+
+  isNullOrUndefined(value) {
+    return value === null || value === undefined;
+  }
+}
+
+class SelectizeInputStub extends Component {
+  get isStub() {
+    return true;
+  }
+}
+class ErrorBoxStub extends Component {
+  get isStub() {
+    return true;
+  }
+}
+
+module('Integration | Component | import-work-step1', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    const problemRecord = { id: 'problem-1', title: 'Linear Functions' };
+    this.problemRecord = problemRecord;
+
+    this.owner.register('service:utility-methods', UtilityMethodsStub);
+    this.owner.register(
+      'service:store',
+      class extends Service {
+        peekRecord(modelName, id) {
+          if (modelName === 'problem' && id === 'problem-1') {
+            return problemRecord;
+          }
+          return null;
+        }
+      }
+    );
+
+    this.owner.register('component:selectize-input', SelectizeInputStub);
+    this.owner.register(
+      'template:components/selectize-input',
+      hbs`
+        <div class='selectize-input-stub' data-input-id={{@inputId}}>
+          <ul class='stub-initial-items'>
+            {{#each @initialItems as |item|}}
+              <li class='stub-item'>{{item}}</li>
+            {{/each}}
+          </ul>
+          <button
+            type='button'
+            class='stub-add-problem'
+            {{on 'click' (fn @onItemAdd 'problem-1' (hash added=true))}}
+          >
+            Add Problem
+          </button>
+          <button
+            type='button'
+            class='stub-remove-problem'
+            {{on 'click' (fn @onItemRemove 'problem-1' null)}}
+          >
+            Remove Problem
+          </button>
+        </div>
+      `
+    );
+
+    this.owner.register('component:ui/error-box', ErrorBoxStub);
+    this.owner.register(
+      'template:components/ui/error-box',
+      hbs`
+        <div class='error-box-stub'>
+          <span class='error-text'>{{@error}}</span>
+          <button
+            type='button'
+            class='dismiss-error'
+            {{on 'click' @resetError}}
+          >
+            Dismiss
+          </button>
+        </div>
+      `
+    );
+  });
+
+  async function renderComponent(context, overrides = {}) {
+    context.setProperties({
+      selectedProblem: null,
+      selectedSection: { id: 'section-1' },
+      selectedValue: true,
+      proceededProblem: null,
+      proceedCount: 0,
+      onProceed: (problem) => {
+        context.proceededProblem = problem;
+        context.proceedCount += 1;
+      },
+      ...overrides,
+    });
+
+    await render(hbs`
+      <ImportWorkStep1
+        @selectedProblem={{this.selectedProblem}}
+        @selectedSection={{this.selectedSection}}
+        @selectedValue={{this.selectedValue}}
+        @onProceed={{this.onProceed}}
+      />
+    `);
+  }
+
+  test('it passes selected problem id into selectize initial items', async function (assert) {
+    await renderComponent(this, {
+      selectedProblem: { id: 'problem-1', title: 'Linear Functions' },
+    });
+
+    assert
+      .dom('.selectize-input-stub')
+      .hasAttribute('data-input-id', 'select-problem');
+    assert.dom('.stub-item').exists({ count: 1 });
+    assert.dom('.stub-item').hasText('problem-1');
+  });
+
+  test('it shows validation error when Next is clicked with no selected problem', async function (assert) {
+    await renderComponent(this);
+
+    await click('.nav-btn-container .primary-button');
+
+    assert.dom('.error-box-stub').exists();
+    assert.dom('.error-text').hasText('Please select a problem');
+    assert.strictEqual(this.proceedCount, 0, 'onProceed is not called');
+  });
+
+  test('it selects problem from store and calls onProceed on Next', async function (assert) {
+    await renderComponent(this);
+
+    await click('.stub-add-problem');
+    await click('.nav-btn-container .primary-button');
+
+    assert.strictEqual(
+      this.proceededProblem,
+      this.problemRecord,
+      'selected store record is passed to onProceed'
+    );
+    assert.strictEqual(this.proceedCount, 1, 'onProceed is called once');
+  });
+
+  test('it clears validation error when a valid problem is selected', async function (assert) {
+    await renderComponent(this);
+
+    await click('.nav-btn-container .primary-button');
+    assert.dom('.error-box-stub').exists('error is shown after invalid next');
+
+    await click('.stub-add-problem');
+    assert
+      .dom('.error-box-stub')
+      .doesNotExist('error clears after selecting a problem');
+  });
+
+  test('it clears local selection on remove and blocks proceed', async function (assert) {
+    await renderComponent(this);
+
+    await click('.stub-add-problem');
+    await click('.stub-remove-problem');
+    await click('.nav-btn-container .primary-button');
+
+    assert.strictEqual(
+      this.proceedCount,
+      0,
+      'onProceed is not called after removal'
+    );
+    assert
+      .dom('.error-box-stub')
+      .exists('error returns when selection is removed');
+  });
+
+  test('it dismisses error through Ui::ErrorBox reset callback', async function (assert) {
+    await renderComponent(this);
+
+    await click('.nav-btn-container .primary-button');
+    assert.dom('.error-box-stub').exists();
+
+    await click('.dismiss-error');
+    assert.dom('.error-box-stub').doesNotExist();
+  });
+});


### PR DESCRIPTION
## Description
This PR modernizes the Step 1 import flow and details summary item to current Ember patterns, while keeping the UI behavior the same.  
It also adds integration coverage for both upgraded components so we can catch regressions in selection, validation, and edit-button behavior.

## What Changed
- Converted `details-list-item` to Glimmer class style.
- Updated `details-list-item.hbs` to modern event wiring (`{{on}}`) and semantic button markup for edit.
- Removed render-time mutation in `details-list-item` and replaced it with pure getter logic.
- Converted `import-work-step1` to Glimmer class style with tracked state (`selectedProblem`, `missingProblem`).
- Updated `import-work-step1.hbs` to modern callback/event syntax and explicit error reset handler.
- Updated `import-work-container` to persist selected problem before moving to the next step.
- Updated styles in `_import.scss`, `_vmt-import.scss`, and `_workspaces-copy.scss` so the edit icon/button looks unchanged after markup migration.
- Added integration tests for `details-list-item`.
- Added integration tests for `import-work-step1`.

## Testing

### Integration Testing
- Ran integration coverage for:
- `tests/integration/components/details-list-item-test.js`
- `tests/integration/components/import-work-step1-test.js`
- All integration tests passing

### UI Testing
- No breaking flow observed.
- Step 1 selection/validation flow works as expected.
- Details summary edit interaction works as expected.
- Existing UI behavior remains intact after modernization.