### PR TITLE
Fix submission navigation

### DIFF
--- a/app/components/bread-crumbs-item.hbs
+++ b/app/components/bread-crumbs-item.hbs
@@ -5,7 +5,7 @@
   <abbr title='{{unbound this.titleText}}'>
     {{@displayValue}}
   </abbr>
-  {{#if @isStarredItem}}
+  {{#if this.isStarredItem}}
     <span class='required-star'>*</span>
   {{/if}}
 </li>

--- a/app/components/bread-crumbs-item.js
+++ b/app/components/bread-crumbs-item.js
@@ -11,7 +11,9 @@ export default class BreadCumbsItemComponent extends Component {
   }
 
   get isStarredItem() {
-    return this.args.starredItemsList.includes(this.item);
+    return (this.args.starredItemsList ?? []).some((item) =>
+      isEqual(item, this.args.item)
+    );
   }
 
   get titleText() {

--- a/app/components/bread-crumbs.hbs
+++ b/app/components/bread-crumbs.hbs
@@ -25,7 +25,7 @@
         </abbr>
         {{#let this.itemsList.lastObject as |lastItem|}}
           <BreadCrumbsItem
-            @item={{this.lastItem}}
+            @item={{lastItem}}
             @displayValue={{this.lastItemValue}}
             @onSelect={{this.onItemSelect}}
             @selectedItem={{@selectedItem}}

--- a/app/components/bread-crumbs.js
+++ b/app/components/bread-crumbs.js
@@ -6,7 +6,7 @@ export default class BreadCrumbsComponent extends Component {
   @tracked doTruncate = true;
 
   get lastItemValue() {
-    return this.itemsList.length - 1 || 1;
+    return this.itemsList.length || 1;
   }
 
   get itemsList() {

--- a/app/components/submission-group.js
+++ b/app/components/submission-group.js
@@ -236,6 +236,10 @@ export default class SubmissionGroupComponent extends Component {
   @action
   onStudentSelect(submissionId) {
     const match = this.submissionThreadHeads.find((s) => s.id === submissionId);
+    if (match?.student === this.currentStudent) {
+      return;
+    }
+
     if (match) {
       this.navigation.toSubmission(match.id, this.args.currentWorkspace?.id);
     }


### PR DESCRIPTION
## Description

Fixes workspace submission navigation issues where moving between revisions for the same student could bounce back to the student’s latest revision. Also fixes Current Revision breadcrumb navigation/display issues for truncated revision lists and ensures mentored revisions are starred consistently.

## Changes

- Updated `app/components/submission-group.js`
  - Prevent same-student Selectize sync from triggering navigation back to the student thread head.
  - Preserve normal student dropdown navigation when selecting a different student.

- Updated breadcrumb components
  - `app/components/bread-crumbs.js`
  - `app/components/bread-crumbs.hbs`
  - `app/components/bread-crumbs-item.js`
  - `app/components/bread-crumbs-item.hbs`

- Fixed truncated breadcrumb behavior:
  - Use the actual last breadcrumb item.
  - Display the correct final revision number.
  - Correct starred breadcrumb state lookup.
  - Compare starred revision items by value instead of object reference so mentored revisions remain marked when revision objects are recreated.

## Testing

UI tested:
- Verified right-arrow navigation can move past same-student revision boundaries.
- Verified Selectize no longer redirects same-student revision navigation back to the latest revision.
- Verified Current Revision numbers are clickable.
- Verified truncated Current Revision breadcrumbs show and select the correct final revision.
- Verified mentored revisions remain marked with a star.

Existing tests pass.
