### PR TITLE
Improve Import Work end-to-end: class setup loop, student matching reliability, and return-state restoration

### DIFF
--- a/app/components/import-work-container.js
+++ b/app/components/import-work-container.js
@@ -117,7 +117,40 @@ export default class ImportWorkComponent extends Component {
     return null;
   }
 
-  restoreInitialStateFromQuery() {
+  parseDelimitedIds(value) {
+    if (typeof value !== 'string') {
+      return [];
+    }
+    return value
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+
+  async restoreUploadedFilesFromQuery(uploadedFileIds) {
+    const ids = this.parseDelimitedIds(uploadedFileIds);
+    if (!ids.length) {
+      return [];
+    }
+
+    const records = await Promise.all(
+      ids.map(async (id) => {
+        const fromStore = this.store.peekRecord('image', id);
+        if (fromStore) {
+          return fromStore;
+        }
+        try {
+          return await this.store.findRecord('image', id);
+        } catch (_err) {
+          return null;
+        }
+      })
+    );
+
+    return records.filter(Boolean);
+  }
+
+  async restoreInitialStateFromQuery() {
     const maxStep = this.steps.length - 1;
     const parsedStep = Number.parseInt(this.args.initialStep, 10);
     let targetStep =
@@ -149,6 +182,8 @@ export default class ImportWorkComponent extends Component {
       if (selectedSection) {
         this.selectedSection = selectedSection;
       }
+      // If a section was requested in query params, class matching must be on.
+      this.selectedValue = true;
     }
 
     const initialUseClass = this.parseQueryBoolean(this.args.initialUseClass);
@@ -156,11 +191,25 @@ export default class ImportWorkComponent extends Component {
       this.selectedValue = initialUseClass;
     }
 
+    const restoredUploadedFiles = await this.restoreUploadedFilesFromQuery(
+      this.args.initialUploadedFileIds
+    );
+    if (restoredUploadedFiles.length > 0) {
+      this.uploadedFiles = restoredUploadedFiles;
+    }
+
     if (targetStep > 1 && !this.selectedProblem) {
       targetStep = 1;
     }
     if (targetStep > 2 && this.selectedValue && !this.selectedSection) {
       targetStep = 2;
+    }
+    if (targetStep > 3 && this.uploadedFiles.length === 0) {
+      targetStep = 3;
+    }
+    if (targetStep > 3 && this.uploadedFiles.length > 0) {
+      this.loadStudentMatching();
+      return;
     }
 
     this.currentStep = this.steps[targetStep];
@@ -234,7 +283,7 @@ export default class ImportWorkComponent extends Component {
   constructor(owner, args) {
     super(owner, args);
     this.sections = this.args.model?.sections || [];
-    this.restoreInitialStateFromQuery();
+    this.restoreInitialStateFromQuery().catch(() => null);
   }
 
   get users() {
@@ -243,6 +292,23 @@ export default class ImportWorkComponent extends Component {
 
   get folderSets() {
     return this.args.model?.folderSets || [];
+  }
+
+  get uploadedFileIdsParam() {
+    if (!Array.isArray(this.uploadedFiles) || this.uploadedFiles.length === 0) {
+      return null;
+    }
+
+    const ids = this.uploadedFiles
+      .map((file) => this.getRecordId(file))
+      .filter(Boolean)
+      .map((id) => String(id));
+
+    if (ids.length === 0) {
+      return null;
+    }
+
+    return ids.join(',');
   }
 
   doConfirmLeaving(value) {
@@ -350,9 +416,15 @@ export default class ImportWorkComponent extends Component {
     const section = this.selectedSection;
 
     // get section info needed for matching
+    let students;
     this.isFetchingSectionStudents = true;
-    const students = await this.getSectionStudents(section);
-    this.isFetchingSectionStudents = false;
+    try {
+      students = await this.getSectionStudents(section);
+    } catch (_err) {
+      return;
+    } finally {
+      this.isFetchingSectionStudents = false;
+    }
 
     const asArray =
       typeof students?.toArray === 'function'
@@ -366,6 +438,37 @@ export default class ImportWorkComponent extends Component {
     });
     this.studentMap = hash;
     this.currentStep = this.steps[3];
+  }
+
+  @action
+  async refreshSelectedSectionStudents() {
+    const section = this.selectedSection;
+    if (!section) {
+      return;
+    }
+
+    let students;
+    this.isFetchingSectionStudents = true;
+    try {
+      students = await this.getSectionStudents(section);
+    } catch (_err) {
+      return;
+    } finally {
+      this.isFetchingSectionStudents = false;
+    }
+
+    const asArray =
+      typeof students?.toArray === 'function'
+        ? students.toArray()
+        : Array.isArray(students)
+        ? students
+        : [];
+
+    const hash = {};
+    asArray.forEach((user) => {
+      hash[user.id] = user;
+    });
+    this.studentMap = hash;
   }
 
   @action
@@ -409,20 +512,27 @@ export default class ImportWorkComponent extends Component {
   @action
   async loadStudentMatching() {
     const images = Array.isArray(this.uploadedFiles) ? this.uploadedFiles : [];
-    const answers = images.map((image) => {
-      const record = this.store.peekRecord('image', image._id);
-      const url = `/api/images/file/${image._id}`;
-      const imgStr = `<img src='${url}'>`;
-      return {
-        explanation: imgStr,
-        explanationImage: record || image,
-        problem: this.selectedProblem,
-        section: this.selectedSection,
-        isSubmitted: true,
-        students: [],
-        studentNames: [],
-      };
-    });
+    const answers = images
+      .map((image) => {
+        const imageId = this.getRecordId(image);
+        if (!imageId) {
+          return null;
+        }
+
+        const record = this.store.peekRecord('image', imageId);
+        const url = `/api/images/file/${imageId}`;
+        const imgStr = `<img src='${url}'>`;
+        return {
+          explanation: imgStr,
+          explanationImage: record || image,
+          problem: this.selectedProblem,
+          section: this.selectedSection,
+          isSubmitted: true,
+          students: [],
+          studentNames: [],
+        };
+      })
+      .filter(Boolean);
 
     this.answers = answers;
     this.currentStep = this.steps[4];

--- a/app/components/import-work-step3.js
+++ b/app/components/import-work-step3.js
@@ -3,18 +3,6 @@ import Component from '@ember/component';
 export default Component.extend({
   elementId: 'import-work-step3',
 
-  didReceiveAttrs() {
-    if (this.existingAnswers) {
-      this.set('existingAnswers', []);
-    }
-
-    // if (!this.uploadedFiles) {
-    //   this.set('uploadedFiles', []);
-    // }
-
-    this._super(...arguments);
-  },
-
   actions: {
     next() {
       if (this.get('uploadedFiles.length') > 0) {
@@ -45,8 +33,14 @@ export default Component.extend({
       this.uploadedFiles.removeObject(file);
 
       // destroy unnecessary image record
-
-      let peeked = this.store.peekRecord('image', file._id);
+      const fileId =
+        file.id ||
+        file._id ||
+        (typeof file.get === 'function' ? file.get('id') : null);
+      if (!fileId) {
+        return;
+      }
+      let peeked = this.store.peekRecord('image', fileId);
       if (peeked) {
         peeked.destroyRecord();
       }

--- a/app/components/import-work-step4.js
+++ b/app/components/import-work-step4.js
@@ -48,7 +48,9 @@ export default Component.extend({
       record.id ||
       record._id ||
       record.userId ||
-      (typeof record.get === 'function' ? record.get('id') : null)
+      (typeof record.get === 'function'
+        ? record.get('id') || record.get('_id') || record.get('userId')
+        : null)
     );
   },
 
@@ -71,18 +73,15 @@ export default Component.extend({
     if (!id || !this.studentMap) {
       return null;
     }
-    if (this.studentMap[id]) {
-      return this.studentMap[id];
+    const normalizedId = String(id);
+    if (this.studentMap[normalizedId]) {
+      return this.studentMap[normalizedId];
     }
     let mapKeys = Object.keys(this.studentMap);
     for (let key of mapKeys) {
       let student = this.studentMap[key];
-      let candidateId =
-        student?.id ||
-        student?._id ||
-        student?.userId ||
-        (typeof student?.get === 'function' ? student.get('id') : null);
-      if (candidateId === id) {
+      let candidateId = this.getRecordId(student);
+      if (String(candidateId) === normalizedId) {
         return student;
       }
     }
@@ -97,7 +96,7 @@ export default Component.extend({
         (typeof answer?.get === 'function'
           ? answer.get('explanationImage')
           : null);
-      const imageId = image?.id || image?._id;
+      const imageId = this.getRecordId(image);
       const inputId = `select-add-student${imageId || ''}`;
       const inputEl =
         typeof document !== 'undefined'
@@ -187,6 +186,11 @@ export default Component.extend({
   },
 
   actions: {
+    refreshStudents() {
+      if (typeof this.onRefreshStudents === 'function') {
+        this.onRefreshStudents();
+      }
+    },
     addAddedStudentName(name) {
       if (typeof name !== 'string') {
         return;

--- a/app/components/problem-new.js
+++ b/app/components/problem-new.js
@@ -61,8 +61,9 @@ export default class ProblemNewComponent extends Component {
   }
 
   get importQueryParams() {
+    const parsedStep = Number.parseInt(this.args.returnStep, 10);
     const queryParams = {
-      step: 1,
+      step: Number.isInteger(parsedStep) ? parsedStep : 1,
     };
     if (this.args.importSectionId) {
       queryParams.sectionId = this.args.importSectionId;
@@ -76,6 +77,9 @@ export default class ProblemNewComponent extends Component {
     }
     if (this.args.importProblemId) {
       queryParams.problemId = this.args.importProblemId;
+    }
+    if (this.args.importUploadedFileIds) {
+      queryParams.uploadedFileIds = this.args.importUploadedFileIds;
     }
     return queryParams;
   }

--- a/app/components/section-info.hbs
+++ b/app/components/section-info.hbs
@@ -220,7 +220,6 @@
           <p class='error-message'>{{error}}</p>
         {{/each}}
       </div>
-
       <div class='section-info-detail groups'>
         <label for='groups'>Groups:
           {{#unless this.cantEdit}}
@@ -334,3 +333,21 @@
     />
   {{/if}}
 </div>
+{{#if this.showDoneToImport}}
+  <div class='section-info-detail import-return'>
+    <div class='import-spacer' aria-hidden='true'></div>
+    <div class='section-info-import-return'>
+      {{#unless this.canReturnToImport}}
+        <p class='info'>Add at least one student before returning to import.</p>
+      {{/unless}}
+      <button
+        class='primary-button'
+        type='button'
+        disabled={{not this.canReturnToImport}}
+        {{on 'click' this.doneToImport}}
+      >
+        Done Adding Students
+      </button>
+    </div>
+  </div>
+{{/if}}

--- a/app/components/section-info.js
+++ b/app/components/section-info.js
@@ -106,6 +106,39 @@ export default class SectionInfoComponent extends ErrorHandlingComponent {
     return !this.canEdit;
   }
 
+  get showDoneToImport() {
+    return this.args.returnTo === 'import';
+  }
+
+  get studentCount() {
+    return this.studentList?.length || this.args.section?.students?.length || 0;
+  }
+
+  get canReturnToImport() {
+    if (!this.showDoneToImport) {
+      return true;
+    }
+    return this.studentCount > 0;
+  }
+
+  get importReturnQueryParams() {
+    const parsedStep = Number.parseInt(this.args.returnStep, 10);
+    const queryParams = {
+      step: Number.isInteger(parsedStep) ? parsedStep : 2,
+      sectionId: this.args.section?.id || this.args.importSectionId || null,
+      useClass: true,
+    };
+
+    if (this.args.importProblemId) {
+      queryParams.problemId = this.args.importProblemId;
+    }
+    if (this.args.importUploadedFileIds) {
+      queryParams.uploadedFileIds = this.args.importUploadedFileIds;
+    }
+
+    return queryParams;
+  }
+
   clearSelectizeInput(id) {
     if (!id) {
       return;
@@ -254,7 +287,6 @@ export default class SectionInfoComponent extends ErrorHandlingComponent {
       return;
     }
 
-    const originalName = group.name;
     const originalStudents = group.students.toArray();
 
     group.name = name;
@@ -287,7 +319,7 @@ export default class SectionInfoComponent extends ErrorHandlingComponent {
     if (!user) return;
     try {
       group.students.removeObject(user);
-      const res = await group.save();
+      await group.save();
       this.alert.showToast(
         'success',
         `${user.username} removed`,
@@ -331,9 +363,7 @@ export default class SectionInfoComponent extends ErrorHandlingComponent {
       );
     }
   }
-  @action updateGroupDraft(student) {
-    return this.newGroup.students.removeObject(student);
-  }
+
   @action removeStudent(user) {
     if (!user) {
       return;
@@ -347,7 +377,7 @@ export default class SectionInfoComponent extends ErrorHandlingComponent {
 
     section
       .save()
-      .then((section) => {
+      .then(() => {
         this.alert.showToast(
           'success',
           'Student Removed',
@@ -379,7 +409,7 @@ export default class SectionInfoComponent extends ErrorHandlingComponent {
 
     section
       .save()
-      .then((section) => {
+      .then(() => {
         this.alert.showToast(
           'success',
           'Teacher Removed',
@@ -478,7 +508,7 @@ export default class SectionInfoComponent extends ErrorHandlingComponent {
         this.handleErrors(err, 'updateSectionErrors', section);
       });
   }
-  @action addTeacher(val, $item) {
+  @action addTeacher(val) {
     if (!val) {
       return;
     }
@@ -512,5 +542,16 @@ export default class SectionInfoComponent extends ErrorHandlingComponent {
           this.handleErrors(err, 'updateSectionErrors', section);
         });
     }
+  }
+
+  @action
+  doneToImport() {
+    if (!this.canReturnToImport) {
+      return;
+    }
+
+    this.router.transitionTo('import', {
+      queryParams: this.importReturnQueryParams,
+    });
   }
 }

--- a/app/components/section-new.js
+++ b/app/components/section-new.js
@@ -72,8 +72,9 @@ export default class SectionNewComponent extends Component {
   }
 
   get importQueryParams() {
+    const parsedStep = Number.parseInt(this.args.returnStep, 10);
     const queryParams = {
-      step: this.args.returnStep || 1,
+      step: Number.isInteger(parsedStep) ? parsedStep : 1,
     };
     if (this.args.importProblemId) {
       queryParams.problemId = this.args.importProblemId;
@@ -87,6 +88,9 @@ export default class SectionNewComponent extends Component {
       this.args.importUseClass !== ''
     ) {
       queryParams.useClass = this.args.importUseClass;
+    }
+    if (this.args.importUploadedFileIds) {
+      queryParams.uploadedFileIds = this.args.importUploadedFileIds;
     }
     return queryParams;
   }
@@ -149,12 +153,14 @@ export default class SectionNewComponent extends Component {
         null
       );
       if (this.showBackToImport) {
-        this.router.transitionTo('import', {
+        this.router.transitionTo('sections.section', section.id, {
           queryParams: {
-            ...this.importQueryParams,
-            step: 2,
-            sectionId: section.id,
-            useClass: true,
+            returnTo: 'import',
+            returnStep: this.args.returnStep || 2,
+            importProblemId: this.args.importProblemId || null,
+            importSectionId: section.id,
+            importUseClass: true,
+            importUploadedFileIds: this.args.importUploadedFileIds || null,
           },
         });
         return;

--- a/app/components/student-matching-answer.js
+++ b/app/components/student-matching-answer.js
@@ -17,7 +17,8 @@ export default class StudentMatchingAnswerComponent extends Component {
   }
 
   get selectizeInputId() {
-    const id = this.image?.id || this.answer?.id || '';
+    const id =
+      this.getRecordId(this.image) || this.getRecordId(this.answer) || '';
     return `select-add-student${id}`;
   }
 
@@ -92,6 +93,16 @@ export default class StudentMatchingAnswerComponent extends Component {
     return options;
   }
 
+  get allowCustomNameEntry() {
+    return !this.args.selectedSection;
+  }
+
+  get selectizePlaceholder() {
+    return this.allowCustomNameEntry
+      ? 'Search students or type a name'
+      : 'Search class students by username';
+  }
+
   addUnique(arrayRef, value) {
     if (!Array.isArray(arrayRef) || !value) {
       return;
@@ -159,6 +170,12 @@ export default class StudentMatchingAnswerComponent extends Component {
       set(submission, 'students', creators);
       // add or remove string name from studentNames array on answer object
     } else {
+      // In class mode, block new free-text names but still allow removing
+      // previously stored name entries.
+      if (!this.allowCustomNameEntry && !doRemove) {
+        return;
+      }
+
       let creators = this.normalizeArray(submission.studentNames);
       if (doRemove) {
         this.removeValue(creators, userId);
@@ -199,6 +216,9 @@ export default class StudentMatchingAnswerComponent extends Component {
   // used for adding non encompass users which will be added to studentNames array
   @action
   addStudentName(input, cb) {
+    if (!this.allowCustomNameEntry) {
+      return;
+    }
     if (typeof input !== 'string') {
       return;
     }

--- a/app/controllers/import.js
+++ b/app/controllers/import.js
@@ -3,7 +3,13 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class ImportController extends Controller {
-  queryParams = ['step', 'problemId', 'sectionId', 'useClass'];
+  queryParams = [
+    'step',
+    'problemId',
+    'sectionId',
+    'useClass',
+    'uploadedFileIds',
+  ];
 
   @tracked isCompDirty = false;
   @tracked confirmLeaving = false;
@@ -11,6 +17,7 @@ export default class ImportController extends Controller {
   @tracked problemId = null;
   @tracked sectionId = null;
   @tracked useClass = null;
+  @tracked uploadedFileIds = null;
 
   @action
   toWorkspaces(workspace) {

--- a/app/controllers/problems/new.js
+++ b/app/controllers/problems/new.js
@@ -4,13 +4,17 @@ import { tracked } from '@glimmer/tracking';
 export default class ProblemsNewController extends Controller {
   queryParams = [
     'returnTo',
+    'returnStep',
     'importProblemId',
     'importSectionId',
     'importUseClass',
+    'importUploadedFileIds',
   ];
 
   @tracked returnTo = null;
+  @tracked returnStep = null;
   @tracked importProblemId = null;
   @tracked importSectionId = null;
   @tracked importUseClass = null;
+  @tracked importUploadedFileIds = null;
 }

--- a/app/controllers/sections/section.js
+++ b/app/controllers/sections/section.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 
-export default class SectionsNewController extends Controller {
+export default class SectionsSectionController extends Controller {
   queryParams = [
     'returnTo',
     'returnStep',

--- a/app/styles/_section-info.scss
+++ b/app/styles/_section-info.scss
@@ -110,6 +110,30 @@
     margin: 10px 5px;
   }
 
+  .section-info-import-return {
+    flex: 1 0 150px;
+    margin: 8px 0;
+    padding: 12px 20px;
+    text-align: left;
+
+    .info {
+      margin: 0 0 10px;
+      text-align: left;
+    }
+  }
+
+  .section-info-detail.import-return {
+    margin-top: 0;
+    margin-bottom: 0;
+    align-items: flex-start;
+
+    .import-spacer {
+      width: 20%;
+      margin: 8px 0;
+      padding: 5px 20px;
+    }
+  }
+
   label {
     width: 20%;
     margin: 8px 0;

--- a/app/templates/components/import-work-container.hbs
+++ b/app/templates/components/import-work-container.hbs
@@ -72,6 +72,7 @@
             @selectedProblem={{this.selectedProblem}}
             @selectedSection={{this.selectedSection}}
             @selectedValue={{this.selectedValue}}
+            @uploadedFileIdsParam={{this.uploadedFileIdsParam}}
             @onProceed={{this.setSelectedProblem}}
           />
         {{/if}}
@@ -82,6 +83,7 @@
             @selectedProblem={{this.selectedProblem}}
             @selectedSection={{this.selectedSection}}
             @selectedValue={{this.selectedValue}}
+            @uploadedFileIdsParam={{this.uploadedFileIdsParam}}
             @onBack={{this.changeStep}}
             @onProceed={{this.setSelectedSection}}
           />
@@ -94,7 +96,6 @@
             @selectedSection={{this.selectedSection}}
             @onBack={{this.changeStep}}
             @onProceed={{this.setUploadedFiles}}
-            @existingAnswers={{this.answers}}
             @uploadedFiles={{this.uploadedFiles}}
           />
         {{/if}}
@@ -107,9 +108,13 @@
             @selectedProblem={{this.selectedProblem}}
             @studentMap={{this.studentMap}}
             @selectedSection={{this.selectedSection}}
+            @selectedValue={{this.selectedValue}}
+            @uploadedFileIdsParam={{this.uploadedFileIdsParam}}
             @onBack={{this.changeStep}}
             @onProceed={{this.setMatchedStudents}}
             @goToStep={{this.goToStep}}
+            @onRefreshStudents={{this.refreshSelectedSectionStudents}}
+            @isFetchingSectionStudents={{this.isFetchingSectionStudents}}
           />
         {{/if}}
 

--- a/app/templates/components/import-work-step1.hbs
+++ b/app/templates/components/import-work-step1.hbs
@@ -14,7 +14,9 @@
     @route='problems.new'
     @query={{hash
       returnTo='import'
+      returnStep=1
       importProblemId=this.selectedProblem.id
+      importUploadedFileIds=this.uploadedFileIdsParam
       importSectionId=@selectedSection.id
       importUseClass=@selectedValue
     }}

--- a/app/templates/components/import-work-step2.hbs
+++ b/app/templates/components/import-work-step2.hbs
@@ -21,7 +21,8 @@
       returnStep=2
       importProblemId=this.selectedProblem.id
       importSectionId=this.selectedSection.id
-      importUseClass=this.selectedValue
+      importUseClass=true
+      importUploadedFileIds=this.uploadedFileIdsParam
     }}
     class='new-link'
   >here</LinkTo></p>

--- a/app/templates/components/import-work-step4.hbs
+++ b/app/templates/components/import-work-step4.hbs
@@ -1,12 +1,50 @@
 <p class="input-label">Match Students</p>
 
+{{#if @selectedSection}}
+  <p class="sub-input-label">
+    Need to add students to this class?
+    <LinkTo
+      @route='sections.section'
+      @model={{@selectedSection.id}}
+      @query={{hash
+        returnTo='import'
+        returnStep=4
+        importProblemId=@selectedProblem.id
+        importSectionId=@selectedSection.id
+        importUseClass=true
+        importUploadedFileIds=@uploadedFileIdsParam
+      }}
+      class='new-link'
+    >Open class roster</LinkTo>, Continue the flow, come back and then click Refresh Students.
+  </p>
+  <div class='nav-btn-container'>
+    <button
+      class='primary-button cancel-button'
+      type='button'
+      disabled={{@isFetchingSectionStudents}}
+      {{action 'refreshStudents'}}
+    >
+      {{if @isFetchingSectionStudents 'Refreshing...' 'Refresh Students'}}
+    </button>
+  </div>
+{{else if @selectedValue}}
+  <p class="sub-input-label">
+    No class is selected right now. Go back to Step 2, pick a class, then return here.
+  </p>
+{{/if}}
+
 <div class="flex-container">
   <div class="student-list">
-    {{#if this.selectedSection}}
-      <h4 class="section-name">{{this.selectedSection.name}}</h4>
-      {{#each this.displayList as |student|}}
-        <p class="student-name">{{student.username}}</p>
-      {{/each}}
+    {{#if @selectedSection}}
+      <h4 class="section-name">Class: {{@selectedSection.name}}</h4>
+      <p class="student-name">Students:</p>
+      {{#if this.displayList.length}}
+        {{#each this.displayList as |student|}}
+          <p class="student-name">{{student.username}}</p>
+        {{/each}}
+      {{else}}
+        <p class="student-name">No students in this class yet.</p>
+      {{/if}}
     {{else}}
       <p>Not using class for matching.</p>
     {{/if}}

--- a/app/templates/components/student-matching-answer.hbs
+++ b/app/templates/components/student-matching-answer.hbs
@@ -26,9 +26,9 @@
       @searchField='username'
       @valueField='id'
       @model='user'
-      @placeholder='Search students by username'
-      @create={{this.addStudentName}}
-      @createFilter={{this.newNameFilter}}
+      @placeholder={{this.selectizePlaceholder}}
+      @create={{if this.allowCustomNameEntry this.addStudentName null}}
+      @createFilter={{if this.allowCustomNameEntry this.newNameFilter null}}
     />
   </div>
 </div>

--- a/app/templates/import.hbs
+++ b/app/templates/import.hbs
@@ -6,6 +6,7 @@
     @initialProblemId={{this.problemId}}
     @initialSectionId={{this.sectionId}}
     @initialUseClass={{this.useClass}}
+    @initialUploadedFileIds={{this.uploadedFileIds}}
     @store={{this.store}}
     @toWorkspaces={{this.toWorkspaces}}
     @doConfirmLeaving={{this.doConfirmLeaving}}

--- a/app/templates/problems/new.hbs
+++ b/app/templates/problems/new.hbs
@@ -3,8 +3,10 @@
   <ProblemNew
     @organizations={{@model.organizations}}
     @returnTo={{this.returnTo}}
+    @returnStep={{this.returnStep}}
     @importProblemId={{this.importProblemId}}
     @importSectionId={{this.importSectionId}}
     @importUseClass={{this.importUseClass}}
+    @importUploadedFileIds={{this.importUploadedFileIds}}
   />
 </div>

--- a/app/templates/sections/new.hbs
+++ b/app/templates/sections/new.hbs
@@ -8,4 +8,5 @@
   @importProblemId={{this.importProblemId}}
   @importSectionId={{this.importSectionId}}
   @importUseClass={{this.importUseClass}}
+  @importUploadedFileIds={{this.importUploadedFileIds}}
 />

--- a/app/templates/sections/section.hbs
+++ b/app/templates/sections/section.hbs
@@ -3,4 +3,10 @@
     @section={{@model.section}} 
     @cachedProblems={{@model.cachedProblems}} 
     @groups={{@model.groups}} 
+    @returnTo={{this.returnTo}}
+    @returnStep={{this.returnStep}}
+    @importProblemId={{this.importProblemId}}
+    @importSectionId={{this.importSectionId}}
+    @importUseClass={{this.importUseClass}}
+    @importUploadedFileIds={{this.importUploadedFileIds}}
 />


### PR DESCRIPTION
## Description
This PR improves the full import experience when teachers need to leave the flow to set up class rosters, then come back and continue matching submissions without losing progress.

It is not only routing/query-param work. It also includes student-matching behavior fixes, roster refresh behavior, UI updates, and stability fixes that were blocking normal usage.

---

## What users can do now

1. From **Step 4 (Match Students)**, they can open class roster, add students, click Done, and return to import with the right context.
2. Uploaded files are preserved on return (via import return context), so users do not need to re-upload to continue matching.
3. Step 4 now clearly shows:
   - class name,
   - class student list,
   - empty-state message when class has no students.
4. Users can refresh class students in Step 4 after roster edits.
5. In class mode, matching only allows real class students (no misleading “add typed name to class” behavior).
6. In non-class mode, typed-name matching is still supported.
7. “Done Adding Students” in class details is available in import-return mode and is disabled until there is at least one student.

---

## Detailed changes

### A) Import return context + state restoration
- Added `uploadedFileIds` query support in import route/controller.
- Passed initial uploaded-file ids into import container.
- Implemented async restore of uploaded files from query ids (`peekRecord` + `findRecord` fallback).
- Added step-clamping logic to prevent invalid resume states (missing problem/section/files).
- Added `uploadedFileIdsParam` serializer for all return links.

**Files**
- `app/controllers/import.js`
- `app/templates/import.hbs`
- `app/components/import-work-container.js`
- `app/templates/components/import-work-container.hbs`

---

### B) Step 4 class roster loop + student matching UX
- Added “Open class roster” link from Step 4 with import return context.
- Added “Refresh Students” action/state in Step 4.
- Added class/student info panel updates in Step 4.
- Added robust id normalization for matching (`id`/`_id`/proxy getters), preventing undefined-id crashes.
- Prevented creation of new free-text names when class mode is active.
- Preserved ability to remove existing text-name entries to clean stale data.

**Files**
- `app/components/import-work-step4.js`
- `app/templates/components/import-work-step4.hbs`
- `app/components/student-matching-answer.js`
- `app/templates/components/student-matching-answer.hbs`
- `app/components/import-work-container.js`
- `app/templates/components/import-work-container.hbs`

---

### C) Class details “Done” return path and student gating
- Added import-mode-only Done action in class details.
- Added `studentCount`/`canReturnToImport` guard.
- Return query preserves import state (`step/problem/section/useClass/uploadedFileIds`).

**Files**
- `app/components/section-info.js`
- `app/components/section-info.hbs`
- `app/styles/_section-info.scss`
- `app/controllers/sections/section.js` (new)
- `app/templates/sections/section.hbs`

---

### D) Create-new links now preserve import context consistently
- Step 1 (`problems.new`) and Step 2 (`sections.new`) links now carry proper return context.
- Added/propagated `returnStep` + `importUploadedFileIds` through both flows.
- `sections.new` return now routes through section details for roster completion before import return.

**Files**
- `app/templates/components/import-work-step1.hbs`
- `app/templates/components/import-work-step2.hbs`
- `app/components/problem-new.js`
- `app/controllers/problems/new.js`
- `app/templates/problems/new.hbs`
- `app/components/section-new.js`
- `app/controllers/sections/new.js`
- `app/templates/sections/new.hbs`

---

### E) Stability and edge-case fixes
- Removed Step 3 parent-state mutation causing Glimmer render assertion (`answers` write during render).
- Added safe loading-state reset (`try/catch/finally`) for section student fetch paths.
- Guarded Step 3 remove-file logic for missing ids.
- Added local gitignore entries for local-only backend edits.

**Files**
- `app/components/import-work-step3.js`
- `app/templates/components/import-work-container.hbs`
- `app/components/import-work-container.js`
- `.gitignore`

---

## Testing done in this iteration
Manual/UI testing only:
- Step 2 -> Step 3 no tracked-state render assertion.
- Step 4 -> open class roster -> add students -> Done -> return works with context.
- Uploaded files are restored for return path.
- Refresh Students updates Step 4 roster view.
- Class mode blocks new typed-name creation; non-class mode still allows typed names.
- Loading state resets correctly on section-student fetch failures.
- End-to-end flow works as expected 

## Next iteration
- Add integration tests alongside remaining related component-upgrade work