### PR TITLE
fix(import-step4): preserve selected student chips and close matching dropdown after selection

### DIFF
--- a/app/components/selectize-input.js
+++ b/app/components/selectize-input.js
@@ -93,8 +93,23 @@ export default class SelectizeInputComponent extends Component {
     this.selectizeInstance.clearOptions(true);
     this.selectizeInstance.addOption(this.options || []);
 
-    if (this.items) {
-      this.selectizeInstance.setValue(this.items, true);
+    let nextItems = this.items;
+    if (!Array.isArray(nextItems)) {
+      nextItems = nextItems ? [nextItems] : [];
+    }
+    if (
+      this.args.preserveCurrentItemsOnOptionsUpdate &&
+      nextItems.length === 0
+    ) {
+      nextItems = Array.isArray(this.selectizeInstance.items)
+        ? this.selectizeInstance.items.slice()
+        : [];
+    }
+
+    if (nextItems.length > 0) {
+      this.selectizeInstance.setValue(nextItems, true);
+    } else {
+      this.selectizeInstance.clear(true);
     }
 
     this.selectizeInstance.refreshOptions(false);
@@ -115,6 +130,7 @@ export default class SelectizeInputComponent extends Component {
       maxItems: this.args.maxItems || null,
       maxOptions: this.args.maxOptions || 1000,
       items: this.items || [],
+      closeAfterSelect: this.args.closeAfterSelect === true,
       create: this.args.create || false,
       persist: this.args.persist || false,
       createFilter: this.args.createFilter || null,

--- a/app/templates/components/student-matching-answer.hbs
+++ b/app/templates/components/student-matching-answer.hbs
@@ -27,6 +27,8 @@
       @valueField='id'
       @model='user'
       @placeholder={{this.selectizePlaceholder}}
+      @closeAfterSelect={{true}}
+      @preserveCurrentItemsOnOptionsUpdate={{true}}
       @create={{if this.allowCustomNameEntry this.addStudentName null}}
       @createFilter={{if this.allowCustomNameEntry this.newNameFilter null}}
     />


### PR DESCRIPTION
This PR fixes Step 4 student matching UX regressions in the import flow. Selected students now remain visible when options refresh, and the dropdown closes after each selection to avoid overlapping the selected chips.