### PR TITLE
fix(selection-ui): stabilize selection startup and remove hide/show layout jump

### DIFF
--- a/app/components/selectable-area.js
+++ b/app/components/selectable-area.js
@@ -9,6 +9,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class SelectableAreaComponent extends Component {
+  maxInitRetries = 60;
   @tracked currSubId = this.args.model?.id || null;
   @tracked selecting = this.args.makingSelection || false;
   @tracked showing = this.args.showingSelections || false;
@@ -26,15 +27,45 @@ export default class SelectableAreaComponent extends Component {
     this.setupTagging();
   }
 
+  scheduleInitRetry(nextRetryCount) {
+    if (typeof window !== 'undefined' && window.requestAnimationFrame) {
+      window.requestAnimationFrame(() =>
+        this.tryInitializeSelectionTools(nextRetryCount)
+      );
+      return;
+    }
+
+    setTimeout(() => this.tryInitializeSelectionTools(nextRetryCount), 16);
+  }
+
   @action
   initializeSelectionTools() {
+    this.tryInitializeSelectionTools(0);
+  }
+
+  tryInitializeSelectionTools(retryCount = 0) {
     if (this._toolsInitialized) return;
 
     const containerId = 'submission_container';
     const scrollableContainer = 'al_submission';
     const container = document.getElementById(containerId);
+    const currentImageCount = container?.querySelectorAll('img').length || 0;
+    const shouldWaitForImageNodes =
+      this.args.makingSelection &&
+      currentImageCount === 0 &&
+      retryCount < this.maxInitRetries;
+
+    if (!container && retryCount < this.maxInitRetries) {
+      this.scheduleInitRetry(retryCount + 1);
+      return;
+    }
 
     if (!container) return;
+
+    if (shouldWaitForImageNodes) {
+      this.scheduleInitRetry(retryCount + 1);
+      return;
+    }
 
     this._toolsInitialized = true;
 

--- a/app/styles/_workspace-container.scss
+++ b/app/styles/_workspace-container.scss
@@ -551,10 +551,8 @@
 
       &.selections-hidden {
         #submission_selections {
-          display: none;
-        }
-        #al_submission {
-          height: calc(100% - 56px - 28px - 27px);
+          visibility: hidden;
+          pointer-events: none;
         }
       }
     }


### PR DESCRIPTION
## Description
This PR fixes two Workspace Submission UI issues:

1. **Selection startup timing**
   - Selection tools were initializing before image nodes were present on refresh.
   - Added bounded retry-based initialization so image-tagging binds only after images are rendered.

2. **Hide/show selections layout jump**
   - Eye-toggle was causing reflow due to `display: none` on selections panel.
   - Replaced with non-reflow hiding (`visibility: hidden`, `pointer-events: none`) and removed conflicting height override.

## Files Changed
- `app/components/selectable-area.js`
- `app/styles/_workspace-container.scss`

## UI Tested
- Reloaded page with Selecting enabled by default.
- Verified selection works immediately without deselect/reselect.
- Toggled eye hide/show repeatedly.
- Verified no vertical layout jump and no broken interaction after toggle.
