### PR TITLE
fix(workspace-submission): fix(workspace-submission): panel-only chevron collapse for selections (no submission pane collapse)

### DIFF
--- a/app/components/workspace-submission.hbs
+++ b/app/components/workspace-submission.hbs
@@ -1,7 +1,6 @@
 <div
   id='workspace-submission-comp'
   class='{{if this.areNoSelections "no-selections"}}
-    {{if this.isSelectionsBoxExpanded "expanded-selections"}}
     {{if this.areSelectionsHidden "selections-hidden"}}
     {{if this.isMakingVmtSelection "vmt-selection"}}
     {{if this.makingSelection "is-selecting"}}'

--- a/app/components/workspace-submission.js
+++ b/app/components/workspace-submission.js
@@ -134,7 +134,7 @@ export default class WorkspaceSubmissionComponent extends Component {
       return 'no-selections';
     }
     if (this.isSelectionsBoxExpanded) {
-      return 'expanded';
+      return 'collapsed';
     }
     return '';
   }
@@ -143,16 +143,16 @@ export default class WorkspaceSubmissionComponent extends Component {
     if (this.isSelectionsBoxExpanded) {
       return {
         imgName: 'chevrons-down.svg',
-        className: 'shrink-selection-box',
-        title: 'collapse',
-        alt: 'Collapse',
+        className: 'expand-selection-box',
+        title: 'show selections',
+        alt: 'Show Selections',
       };
     }
     return {
       imgName: 'chevrons-up.svg',
-      className: 'expand-selection-box',
-      title: 'expand',
-      alt: 'Expand',
+      className: 'shrink-selection-box',
+      title: 'hide selections',
+      alt: 'Hide Selections',
     };
   }
 

--- a/app/styles/_workspace-container.scss
+++ b/app/styles/_workspace-container.scss
@@ -539,16 +539,6 @@
         }
       }
 
-      &.expanded-selections {
-        #submission_selections {
-          height: calc(100% - 40% - 35px - 56px);
-        }
-
-        #al_submission {
-          height: calc(40%);
-        }
-      }
-
       &.selections-hidden {
         #submission_selections {
           visibility: hidden;
@@ -609,6 +599,15 @@
 
       &.no-selections {
         height: 75px;
+      }
+
+      &.collapsed {
+        height: 0;
+        min-height: 0;
+        border-top-width: 0;
+        overflow: hidden;
+        visibility: hidden;
+        pointer-events: none;
       }
 
       .draggable-selection {

--- a/tests/unit/components/workspace-submission-test.js
+++ b/tests/unit/components/workspace-submission-test.js
@@ -540,7 +540,7 @@ module('Unit | Component | workspace-submission', function (hooks) {
       );
     });
 
-    test('selectionBoxClass returns "expanded" when selections box is expanded', function (assert) {
+    test('selectionBoxClass returns "collapsed" when selections box is toggled closed', function (assert) {
       const selection = createSelection('sel-1', 'sub-1', false);
       const component = setupComponent(this, {
         selections: [selection],
@@ -550,8 +550,8 @@ module('Unit | Component | workspace-submission', function (hooks) {
 
       assert.strictEqual(
         component.selectionBoxClass,
-        'expanded',
-        'should return "expanded" class when box is expanded'
+        'collapsed',
+        'should return "collapsed" class when box is hidden'
       );
     });
 
@@ -625,10 +625,14 @@ module('Unit | Component | workspace-submission', function (hooks) {
       );
       assert.strictEqual(
         info.className,
-        'shrink-selection-box',
-        'className should be shrink'
+        'expand-selection-box',
+        'className should be expand'
       );
-      assert.strictEqual(info.title, 'collapse', 'title should be collapse');
+      assert.strictEqual(
+        info.title,
+        'show selections',
+        'title should be show selections'
+      );
     });
 
     test('toggleSelectionInfo returns correct info when collapsed', function (assert) {
@@ -644,10 +648,14 @@ module('Unit | Component | workspace-submission', function (hooks) {
       );
       assert.strictEqual(
         info.className,
-        'expand-selection-box',
-        'className should be expand'
+        'shrink-selection-box',
+        'className should be shrink'
       );
-      assert.strictEqual(info.title, 'expand', 'title should be expand');
+      assert.strictEqual(
+        info.title,
+        'hide selections',
+        'title should be hide selections'
+      );
     });
 
     test('showExpandSelections returns true when selections exist and not hidden', function (assert) {


### PR DESCRIPTION
### Problem
Chevron up/down toggle could collapse/hide submission content due to layout-coupled expanded rules, especially noticeable with image-selection content.

### Root Cause
Old `expanded-selections` root-state CSS changed `#al_submission` height using percentage split logic, coupling panel toggle with main content layout.

### Changes
- Removed root expanded class coupling in template.
- Switched component panel class semantics to `collapsed`.
- Replaced expanded split-height CSS with panel-only collapse styles.
- Updated unit tests for new behavior and labels.

### Files Changed
- `app/components/workspace-submission.js`
- `app/components/workspace-submission.hbs`
- `app/styles/_workspace-container.scss`
- `tests/unit/components/workspace-submission-test.js`

### Validation
- Local manual testing:
  - Chevron toggle repeatedly with text/image selections.
  - Submission content remains visible/stable.
  - No full-pane disappearance on toggle.
- Existing eye hide/show behavior remains stable.