### PR TITLE
refactor(import-step2): Glimmer migration + integration tests

### DIFF
--- a/app/components/import-work-container.js
+++ b/app/components/import-work-container.js
@@ -412,8 +412,20 @@ export default class ImportWorkComponent extends Component {
   }
 
   @action
-  async setSelectedSection() {
-    const section = this.selectedSection;
+  updateStep2Selection(step2Selection = null) {
+    if (!this.utils.isNonEmptyObject(step2Selection)) {
+      return;
+    }
+
+    const { selectedSection = null, selectedValue = false } = step2Selection;
+    this.selectedSection = selectedSection;
+    this.selectedValue = selectedValue === true;
+  }
+
+  @action
+  async setSelectedSection(step2Selection = null) {
+    this.updateStep2Selection(step2Selection);
+    const section = this.selectedValue ? this.selectedSection : null;
 
     // get section info needed for matching
     let students;

--- a/app/components/import-work-step2.js
+++ b/app/components/import-work-step2.js
@@ -1,14 +1,17 @@
-import Component from '@ember/component';
-import { computed } from '@ember/object';
-import { equal } from '@ember/object/computed';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 
-export default Component.extend({
-  elementId: 'import-work-step2',
-  utils: service('utility-methods'),
-  selectingClass: equal('selectedValue', true),
+export default class ImportWorkStep2Component extends Component {
+  @service store;
+  @service('utility-methods') utils;
 
-  useClass: {
+  @tracked selectedValue = false;
+  @tracked selectedSection = null;
+  @tracked missingSection = null;
+
+  useClassOptions = {
     groupName: 'useClass',
     required: true,
     inputs: [
@@ -21,60 +24,108 @@ export default Component.extend({
         label: 'No',
       },
     ],
-  },
+  };
 
-  willDestroyElement: function () {
-    this._super(...arguments);
-    this.set('selectedValue', this.selectedValue);
-  },
+  constructor(owner, args) {
+    super(owner, args);
+    this.selectedValue = args.selectedValue === true;
+    this.selectedSection = args.selectedSection || null;
+  }
 
-  initialSectionItem: computed('selectedSection', function () {
-    const selectedSection = this.selectedSection;
-    if (this.utils.isNonEmptyObject(selectedSection)) {
-      return [selectedSection.id];
+  get selectingClass() {
+    return this.selectedValue === true;
+  }
+
+  get initialSectionItem() {
+    if (this.utils.isNonEmptyObject(this.selectedSection)) {
+      return [this.selectedSection.id];
     }
     return [];
-  }),
+  }
 
-  actions: {
-    updateSelectedValue: function (val) {
-      this.set('selectedValue', val);
-    },
-    setSelectedSection(val, $item) {
-      if (!val) {
-        return;
-      }
+  notifySelectionChanged() {
+    if (typeof this.args.onSelectionChange === 'function') {
+      this.args.onSelectionChange({
+        selectedValue: this.selectedValue,
+        selectedSection: this.selectedSection,
+      });
+    }
+  }
 
-      const isRemoval = this.utils.isNullOrUndefined($item);
-      if (isRemoval) {
-        this.set('selectedSection', null);
-        return;
-      }
+  @action
+  updateSelectedValue(val) {
+    this.selectedValue = val === true;
+    if (!this.selectedValue) {
+      this.selectedSection = null;
+      this.missingSection = null;
+    }
+    this.notifySelectionChanged();
+  }
 
-      const section = this.store.peekRecord('section', val);
-      if (this.utils.isNullOrUndefined(section)) {
-        return;
-      }
+  @action
+  setSelectedSection(val, item) {
+    if (!val) {
+      return;
+    }
 
-      this.set('selectedSection', section);
-      if (this.missingSection) {
-        this.set('missingSection', null);
+    const isRemoval = this.utils.isNullOrUndefined(item);
+    if (isRemoval) {
+      this.selectedSection = null;
+      this.notifySelectionChanged();
+      return;
+    }
+
+    const section = this.store.peekRecord('section', val);
+    if (this.utils.isNullOrUndefined(section)) {
+      return;
+    }
+
+    this.selectedSection = section;
+    if (this.missingSection) {
+      this.missingSection = null;
+    }
+    this.notifySelectionChanged();
+  }
+
+  @action
+  resetMissingSection() {
+    this.missingSection = null;
+  }
+
+  @action
+  next() {
+    if (!this.selectedValue) {
+      this.selectedSection = null;
+      this.missingSection = null;
+      this.notifySelectionChanged();
+      if (typeof this.args.onProceed === 'function') {
+        this.args.onProceed({
+          selectedValue: this.selectedValue,
+          selectedSection: this.selectedSection,
+        });
       }
-    },
-    next() {
-      const selectedValue = this.selectedValue;
-      if (!selectedValue) {
-        this.set('selectedSection', null);
+      return;
+    }
+
+    if (this.utils.isNonEmptyObject(this.selectedSection)) {
+      this.notifySelectionChanged();
+      if (typeof this.args.onProceed === 'function') {
+        this.args.onProceed({
+          selectedValue: this.selectedValue,
+          selectedSection: this.selectedSection,
+        });
       }
-      const section = this.selectedSection;
-      if (this.utils.isNonEmptyObject(section) || !selectedValue) {
-        this.onProceed();
-        return;
-      }
-      this.set('missingSection', true);
-    },
-    back() {
-      this.onBack(-1);
-    },
-  },
-});
+      return;
+    }
+
+    this.missingSection = true;
+  }
+
+  @action
+  back() {
+    this.notifySelectionChanged();
+    if (typeof this.args.onBack === 'function') {
+      this.args.onBack(-1);
+    }
+  }
+}

--- a/app/templates/components/import-work-container.hbs
+++ b/app/templates/components/import-work-container.hbs
@@ -79,11 +79,11 @@
 
         {{#if this.showSelectClass}}
           <ImportWorkStep2
-            @store={{this.store}}
             @selectedProblem={{this.selectedProblem}}
             @selectedSection={{this.selectedSection}}
             @selectedValue={{this.selectedValue}}
             @uploadedFileIdsParam={{this.uploadedFileIdsParam}}
+            @onSelectionChange={{this.updateStep2Selection}}
             @onBack={{this.changeStep}}
             @onProceed={{this.setSelectedSection}}
           />

--- a/app/templates/components/import-work-step2.hbs
+++ b/app/templates/components/import-work-step2.hbs
@@ -8,9 +8,9 @@
   </span>
 </p>
 <Ui::RadioGroup
-  @options={{this.useClass}}
+  @options={{this.useClassOptions}}
   @selectedValue={{this.selectedValue}}
-  @updateValue={{action 'updateSelectedValue'}}
+  @updateValue={{this.updateSelectedValue}}
 />
 
 <p class='sub-input-label'>If you want, you can create a new class
@@ -19,10 +19,10 @@
     @query={{hash
       returnTo='import'
       returnStep=2
-      importProblemId=this.selectedProblem.id
+      importProblemId=@selectedProblem.id
       importSectionId=this.selectedSection.id
       importUseClass=true
-      importUploadedFileIds=this.uploadedFileIdsParam
+      importUploadedFileIds=@uploadedFileIdsParam
     }}
     class='new-link'
   >here</LinkTo></p>
@@ -39,13 +39,12 @@
   </p>
   {{!-- <p class="sub-input-label">If this work was completed by members of a class, select the existing class you would like to use or you can create one {{#link-to 'sections.new' classNames='new-link'}}here{{/link-to}}.</p> --}}
   <SelectizeInput
-    @store={{this.store}}
     @inputId='select-class'
     @isAsync={{true}}
     @maxItems={{1}}
     @initialItems={{this.initialSectionItem}}
-    @onItemAdd={{action 'setSelectedSection'}}
-    @onItemRemove={{action 'setSelectedSection'}}
+    @onItemAdd={{this.setSelectedSection}}
+    @onItemRemove={{this.setSelectedSection}}
     @labelField='name'
     @searchField='name'
     @valueField='id'
@@ -61,16 +60,12 @@
 {{#if this.missingSection}}
   <Ui::ErrorBox
     @error='Please select a class or no class'
-    @resetError={{action (mut this.missingSection) null}}
+    @resetError={{this.resetMissingSection}}
     @showDismiss={{true}}
   />
 {{/if}}
 
 <div class='nav-btn-container'>
-  <button
-    class='primary-button cancel-button'
-    type='button'
-    {{action 'back'}}
-  >Back</button>
-  <button class='primary-button' type='button' {{action 'next'}}>Next</button>
+  <button class='primary-button cancel-button' type='button' {{on 'click' this.back}}>Back</button>
+  <button class='primary-button' type='button' {{on 'click' this.next}}>Next</button>
 </div>

--- a/tests/integration/components/import-work-step2-test.js
+++ b/tests/integration/components/import-work-step2-test.js
@@ -1,0 +1,326 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import Service from '@ember/service';
+import Component from '@glimmer/component';
+
+class UtilityMethodsStub extends Service {
+  isNonEmptyObject(value) {
+    return (
+      !!value && typeof value === 'object' && Object.keys(value).length > 0
+    );
+  }
+
+  isNullOrUndefined(value) {
+    return value === null || value === undefined;
+  }
+}
+
+class SelectizeInputStub extends Component {
+  get isStub() {
+    return true;
+  }
+}
+
+class ErrorBoxStub extends Component {
+  get isStub() {
+    return true;
+  }
+}
+
+module('Integration | Component | import-work-step2', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    const sectionRecord = { id: 'section-1', name: 'Algebra Period 2' };
+    this.sectionRecord = sectionRecord;
+
+    this.owner.register('service:utility-methods', UtilityMethodsStub);
+    this.owner.register(
+      'service:store',
+      class extends Service {
+        peekRecord(modelName, id) {
+          if (modelName === 'section' && id === 'section-1') {
+            return sectionRecord;
+          }
+          return null;
+        }
+      }
+    );
+
+    this.owner.register('component:selectize-input', SelectizeInputStub);
+    this.owner.register(
+      'template:components/selectize-input',
+      hbs`
+        <div class='selectize-input-stub' data-input-id={{@inputId}}>
+          <ul class='stub-initial-items'>
+            {{#each @initialItems as |item|}}
+              <li class='stub-item'>{{item}}</li>
+            {{/each}}
+          </ul>
+          <button
+            type='button'
+            class='stub-add-section'
+            {{on 'click' (fn @onItemAdd 'section-1' (hash added=true))}}
+          >
+            Add Section
+          </button>
+          <button
+            type='button'
+            class='stub-remove-section'
+            {{on 'click' (fn @onItemRemove 'section-1' null)}}
+          >
+            Remove Section
+          </button>
+          <button
+            type='button'
+            class='stub-add-unknown-section'
+            {{on 'click' (fn @onItemAdd 'section-unknown' (hash added=true))}}
+          >
+            Add Unknown Section
+          </button>
+        </div>
+      `
+    );
+
+    this.owner.register('component:ui/error-box', ErrorBoxStub);
+    this.owner.register(
+      'template:components/ui/error-box',
+      hbs`
+        <div class='error-box-stub'>
+          <span class='error-text'>{{@error}}</span>
+          <button
+            type='button'
+            class='dismiss-error'
+            {{on 'click' @resetError}}
+          >
+            Dismiss
+          </button>
+        </div>
+      `
+    );
+  });
+
+  async function renderComponent(context, overrides = {}) {
+    context.setProperties({
+      selectedProblem: { id: 'problem-1', title: 'Linear Functions' },
+      selectedSection: null,
+      selectedValue: false,
+      uploadedFileIdsParam: 'img-1,img-2',
+      proceedPayload: null,
+      proceedCount: 0,
+      selectionPayloads: [],
+      backDirections: [],
+      onProceed: (payload) => {
+        context.proceedPayload = payload;
+        context.proceedCount += 1;
+      },
+      onSelectionChange: (payload) => {
+        context.selectionPayloads = [...context.selectionPayloads, payload];
+      },
+      onBack: (direction) => {
+        context.backDirections = [...context.backDirections, direction];
+      },
+      ...overrides,
+    });
+
+    await render(hbs`
+      <ImportWorkStep2
+        @selectedProblem={{this.selectedProblem}}
+        @selectedSection={{this.selectedSection}}
+        @selectedValue={{this.selectedValue}}
+        @uploadedFileIdsParam={{this.uploadedFileIdsParam}}
+        @onSelectionChange={{this.onSelectionChange}}
+        @onBack={{this.onBack}}
+        @onProceed={{this.onProceed}}
+      />
+    `);
+  }
+
+  test('it passes selected section id into selectize initial items', async function (assert) {
+    await renderComponent(this, {
+      selectedValue: true,
+      selectedSection: { id: 'section-1', name: 'Algebra Period 2' },
+    });
+
+    assert
+      .dom('.selectize-input-stub')
+      .hasAttribute('data-input-id', 'select-class');
+    assert.dom('.stub-item').exists({ count: 1 });
+    assert.dom('.stub-item').hasText('section-1');
+  });
+
+  test('it proceeds with "No class" and clears section before sending payload', async function (assert) {
+    await renderComponent(this, {
+      selectedValue: false,
+      selectedSection: { id: 'section-1', name: 'Legacy Section' },
+    });
+
+    await click('.nav-btn-container .primary-button:not(.cancel-button)');
+
+    assert.strictEqual(this.proceedCount, 1, 'onProceed is called once');
+    assert.false(
+      this.proceedPayload.selectedValue,
+      'payload confirms no class path'
+    );
+    assert.strictEqual(
+      this.proceedPayload.selectedSection,
+      null,
+      'payload clears selected section'
+    );
+    assert.dom('.error-box-stub').doesNotExist();
+  });
+
+  test('it shows validation error when class matching is on without selected class', async function (assert) {
+    await renderComponent(this);
+
+    await click('input[name="useClass"][value="true"]');
+    await click('.nav-btn-container .primary-button:not(.cancel-button)');
+
+    assert.strictEqual(this.proceedCount, 0, 'onProceed is not called');
+    assert.dom('.error-box-stub').exists();
+    assert.dom('.error-text').hasText('Please select a class or no class');
+  });
+
+  test('it selects class from store and proceeds with class payload', async function (assert) {
+    await renderComponent(this);
+
+    await click('input[name="useClass"][value="true"]');
+    await click('.stub-add-section');
+    await click('.nav-btn-container .primary-button:not(.cancel-button)');
+
+    assert.strictEqual(this.proceedCount, 1, 'onProceed is called');
+    assert.true(
+      this.proceedPayload.selectedValue,
+      'payload keeps class matching enabled'
+    );
+    assert.strictEqual(
+      this.proceedPayload.selectedSection,
+      this.sectionRecord,
+      'payload passes selected section record'
+    );
+    assert.dom('.error-box-stub').doesNotExist();
+  });
+
+  test('it clears validation error after class selection', async function (assert) {
+    await renderComponent(this);
+
+    await click('input[name="useClass"][value="true"]');
+    await click('.nav-btn-container .primary-button:not(.cancel-button)');
+    assert.dom('.error-box-stub').exists('error appears after invalid next');
+
+    await click('.stub-add-section');
+    assert
+      .dom('.error-box-stub')
+      .doesNotExist('error is cleared after selecting class');
+  });
+
+  test('it calls onBack with -1', async function (assert) {
+    await renderComponent(this);
+
+    await click('.nav-btn-container .cancel-button');
+
+    assert.deepEqual(this.backDirections, [-1], 'back callback receives -1');
+  });
+
+  test('it sends selection change payloads when toggling class usage', async function (assert) {
+    await renderComponent(this);
+
+    await click('input[name="useClass"][value="true"]');
+    await click('input[name="useClass"][value="false"]');
+
+    assert.strictEqual(this.selectionPayloads.length, 2);
+    assert.true(
+      this.selectionPayloads[0].selectedValue,
+      'first payload enables class usage'
+    );
+    assert.strictEqual(
+      this.selectionPayloads[0].selectedSection,
+      null,
+      'no section selected yet on enable'
+    );
+    assert.false(
+      this.selectionPayloads[1].selectedValue,
+      'second payload disables class usage'
+    );
+    assert.strictEqual(
+      this.selectionPayloads[1].selectedSection,
+      null,
+      'disable payload clears section'
+    );
+  });
+
+  test('it sends selection payload on remove and on back', async function (assert) {
+    await renderComponent(this);
+
+    await click('input[name="useClass"][value="true"]');
+    await click('.stub-add-section');
+    await click('.stub-remove-section');
+    await click('.nav-btn-container .cancel-button');
+
+    assert.strictEqual(this.selectionPayloads.length, 4);
+    assert.strictEqual(
+      this.selectionPayloads[2].selectedSection,
+      null,
+      'remove payload clears selected section'
+    );
+    assert.strictEqual(
+      this.selectionPayloads[3].selectedSection,
+      null,
+      'back payload keeps current cleared selection state'
+    );
+    assert.deepEqual(this.backDirections, [-1], 'back callback still fires');
+  });
+
+  test('it dismisses missing class validation error via Ui::ErrorBox reset callback', async function (assert) {
+    await renderComponent(this);
+
+    await click('input[name="useClass"][value="true"]');
+    await click('.nav-btn-container .primary-button:not(.cancel-button)');
+    assert.dom('.error-box-stub').exists();
+
+    await click('.dismiss-error');
+    assert.dom('.error-box-stub').doesNotExist();
+  });
+
+  test('it shows selectize only when class usage is enabled', async function (assert) {
+    await renderComponent(this);
+
+    assert
+      .dom('.selectize-input-stub')
+      .doesNotExist('selectize hidden when class usage is disabled');
+
+    await click('input[name="useClass"][value="true"]');
+    assert
+      .dom('.selectize-input-stub')
+      .exists('selectize shown when class usage is enabled');
+
+    await click('input[name="useClass"][value="false"]');
+    assert
+      .dom('.selectize-input-stub')
+      .doesNotExist('selectize hidden again when class usage is disabled');
+  });
+
+  test('it ignores unknown section ids and keeps validation blocked', async function (assert) {
+    await renderComponent(this);
+
+    await click('input[name="useClass"][value="true"]');
+    assert.strictEqual(this.selectionPayloads.length, 1);
+
+    await click('.stub-add-unknown-section');
+    assert.strictEqual(
+      this.selectionPayloads.length,
+      1,
+      'unknown id does not emit additional selection payload'
+    );
+
+    await click('.nav-btn-container .primary-button:not(.cancel-button)');
+    assert.strictEqual(
+      this.proceedCount,
+      0,
+      'cannot proceed without valid class'
+    );
+    assert.dom('.error-box-stub').exists();
+  });
+});


### PR DESCRIPTION
### Problem
Import Step 2 had fragile state flow between step component and container, relying on classic patterns and implicit state timing during proceed/back transitions.

### Root Cause
Classic component/action patterns and loosely coupled section/value updates made state handoff less explicit and harder to validate.

### Changes
- Migrated step2 component to Glimmer class with tracked state and `@action`.
- Added explicit selection state callback (`onSelectionChange`) and container sync helper (`updateStep2Selection`).
- Updated proceed/back handling to pass state payloads deterministically.
- Modernized template event bindings and removed unnecessary `@store` pass-through.
- Added integration tests covering core and edge flows.

### Files Changed
- `app/components/import-work-step2.js`
- `app/components/import-work-container.js`
- `app/templates/components/import-work-step2.hbs`
- `app/templates/components/import-work-container.hbs`
- `tests/integration/components/import-work-step2-test.js`

### Validation
- Lint checks pass for changed JS/HBS files.
- Integration test coverage added for Step 2 state and navigation behavior.

### Notes
- This PR is scoped to import flow Step 2 state consistency and modernization only.