### PR TITLE
 Import Work Step 4 Modernization + Tests

### DIFF
--- a/app/components/import-work-step4.js
+++ b/app/components/import-work-step4.js
@@ -1,44 +1,58 @@
-import Component from '@ember/component';
-import { computed, set } from '@ember/object';
+import Component from '@glimmer/component';
+import { action, set } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 
-export default Component.extend({
-  elementId: 'import-work-step4',
-  utils: service('utility-methods'),
-  alert: service('sweet-alert'),
+export default class ImportWorkStep4Component extends Component {
+  @service('utility-methods') utils;
+  @service('sweet-alert') alert;
 
-  addedStudentNames: [],
+  @tracked addedStudentNames = [];
+  @tracked isMatchingIncompleteError = null;
+  @tracked isReadyToReviewAnswers = false;
 
-  init() {
-    this._super(...arguments);
-    this.set('newNameFilter', this.addStudentNameFilter.bind(this));
-  },
+  get answers() {
+    return Array.isArray(this.args.answers) ? this.args.answers : [];
+  }
 
-  displayList: computed('studentMap', function () {
+  get selectedSection() {
+    return this.args.selectedSection || null;
+  }
+
+  get selectedValue() {
+    return this.args.selectedValue === true;
+  }
+
+  get studentMap() {
+    return this.args.studentMap || null;
+  }
+
+  get displayList() {
     if (!this.studentMap) {
       return [];
     }
     return Object.keys(this.studentMap).map((key) => this.studentMap[key]);
-  }),
+  }
 
-  addStudentNameFilter: function (name) {
+  @action
+  addStudentNameFilter(name) {
     if (typeof name !== 'string') {
-      return;
+      return false;
     }
     let trimmed = name.trim();
     let names = this.addedStudentNames;
     return trimmed.length > 1 && !names.includes(trimmed);
-  },
+  }
 
   normalizeArray(val) {
     if (Array.isArray(val)) {
       return val;
     }
-    if (typeof val?.toArray === 'function') {
-      return val.toArray();
+    if (typeof val?.slice === 'function') {
+      return val.slice();
     }
     return [];
-  },
+  }
 
   getRecordId(record) {
     if (!record) {
@@ -52,7 +66,7 @@ export default Component.extend({
         ? record.get('id') || record.get('_id') || record.get('userId')
         : null)
     );
-  },
+  }
 
   areArraysEqual(left, right) {
     if (!Array.isArray(left) || !Array.isArray(right)) {
@@ -67,7 +81,7 @@ export default Component.extend({
       }
     }
     return true;
-  },
+  }
 
   getStudentById(id) {
     if (!id || !this.studentMap) {
@@ -86,11 +100,10 @@ export default Component.extend({
       }
     }
     return null;
-  },
+  }
 
   syncAnswerMatchesFromUI() {
-    let answers = Array.isArray(this.answers) ? this.answers : [];
-    answers.forEach((answer) => {
+    this.answers.forEach((answer) => {
       const image =
         answer?.explanationImage ||
         (typeof answer?.get === 'function'
@@ -159,81 +172,94 @@ export default Component.extend({
         set(answer, 'studentNames', studentNames);
       }
     });
-  },
+  }
 
   isReadyToProceed() {
-    let answers = this.answers;
     return (
-      Array.isArray(answers) &&
-      answers.length > 0 &&
-      answers.every((ans) => {
+      this.answers.length > 0 &&
+      this.answers.every((ans) => {
         return (
           this.normalizeArray(ans.students).length > 0 ||
           this.normalizeArray(ans.studentNames).length > 0
         );
       })
     );
-  },
+  }
 
   updateMatchingStatus() {
     this.syncAnswerMatchesFromUI();
     let isReady = this.isReadyToProceed();
     if (isReady && this.isMatchingIncompleteError) {
-      this.set('isMatchingIncompleteError', null);
+      this.isMatchingIncompleteError = null;
     }
-    this.set('isReadyToReviewAnswers', isReady);
+    this.isReadyToReviewAnswers = isReady;
     return isReady;
-  },
+  }
 
-  actions: {
-    refreshStudents() {
-      if (typeof this.onRefreshStudents === 'function') {
-        this.onRefreshStudents();
-      }
-    },
-    addAddedStudentName(name) {
-      if (typeof name !== 'string') {
-        return;
-      }
+  @action
+  resetMatchingIncompleteError() {
+    this.isMatchingIncompleteError = null;
+  }
 
-      let trimmed = name.trim();
-      if (!trimmed) {
-        return;
-      }
+  @action
+  refreshStudents() {
+    if (typeof this.args.onRefreshStudents === 'function') {
+      this.args.onRefreshStudents();
+    }
+  }
 
-      let names = this.normalizeArray(this.addedStudentNames);
-      if (names.includes(trimmed)) {
-        return;
-      }
+  @action
+  addAddedStudentName(name) {
+    if (typeof name !== 'string') {
+      return;
+    }
 
-      this.set('addedStudentNames', [...names, trimmed]);
-    },
-    checkStatus: function () {
-      return this.updateMatchingStatus();
-    },
-    next() {
-      let isReady = this.updateMatchingStatus();
-      if (isReady) {
-        if (typeof this.onProceed === 'function') {
-          this.onProceed();
-        }
-        if (typeof this.goToStep === 'function') {
-          this.goToStep(5);
-        }
-      } else {
-        this.set('isMatchingIncompleteError', true);
-        this.alert.showToast(
-          'error',
-          'Please match at least one student/name for each submission',
-          'bottom-end',
-          3000,
-          false,
-          null
-        );
+    let trimmed = name.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    let names = this.normalizeArray(this.addedStudentNames);
+    if (names.includes(trimmed)) {
+      return;
+    }
+
+    this.addedStudentNames = [...names, trimmed];
+  }
+
+  @action
+  checkStatus() {
+    return this.updateMatchingStatus();
+  }
+
+  @action
+  next() {
+    let isReady = this.updateMatchingStatus();
+    if (isReady) {
+      if (typeof this.args.onProceed === 'function') {
+        this.args.onProceed();
       }
-    },
-    back() {
-      this.onBack(-1);
-    },
-  },
-});
+      if (typeof this.args.goToStep === 'function') {
+        this.args.goToStep(5);
+      }
+      return;
+    }
+
+    this.isMatchingIncompleteError = true;
+    this.alert.showToast(
+      'error',
+      'Please match at least one student/name for each submission',
+      'bottom-end',
+      3000,
+      false,
+      null
+    );
+  }
+
+  @action
+  back() {
+    if (typeof this.args.onBack === 'function') {
+      this.args.onBack(-1);
+    }
+  }
+}

--- a/app/templates/components/import-work-container.hbs
+++ b/app/templates/components/import-work-container.hbs
@@ -102,7 +102,6 @@
 
         {{#if this.showMatchStudents}}
           <ImportWorkStep4
-            @store={{this.store}}
             @uploadedFiles={{this.uploadedFiles}}
             @answers={{this.answers}}
             @selectedProblem={{this.selectedProblem}}

--- a/app/templates/components/import-work-step4.hbs
+++ b/app/templates/components/import-work-step4.hbs
@@ -1,80 +1,81 @@
-<p class="input-label">Match Students</p>
+<div id='import-work-step4'>
+  <p class="input-label">Match Students</p>
 
-{{#if @selectedSection}}
-  <p class="sub-input-label">
-    Need to add students to this class?
-    <LinkTo
-      @route='sections.section'
-      @model={{@selectedSection.id}}
-      @query={{hash
-        returnTo='import'
-        returnStep=4
-        importProblemId=@selectedProblem.id
-        importSectionId=@selectedSection.id
-        importUseClass=true
-        importUploadedFileIds=@uploadedFileIdsParam
-      }}
-      class='new-link'
-    >Open class roster</LinkTo>, Continue the flow, come back and then click Refresh Students.
-  </p>
-  <div class='nav-btn-container'>
-    <button
-      class='primary-button cancel-button'
-      type='button'
-      disabled={{@isFetchingSectionStudents}}
-      {{action 'refreshStudents'}}
-    >
-      {{if @isFetchingSectionStudents 'Refreshing...' 'Refresh Students'}}
-    </button>
-  </div>
-{{else if @selectedValue}}
-  <p class="sub-input-label">
-    No class is selected right now. Go back to Step 2, pick a class, then return here.
-  </p>
-{{/if}}
+  {{#if @selectedSection}}
+    <p class="sub-input-label">
+      Need to add students to this class?
+      <LinkTo
+        @route='sections.section'
+        @model={{@selectedSection.id}}
+        @query={{hash
+          returnTo='import'
+          returnStep=4
+          importProblemId=@selectedProblem.id
+          importSectionId=@selectedSection.id
+          importUseClass=true
+          importUploadedFileIds=@uploadedFileIdsParam
+        }}
+        class='new-link'
+      >Open class roster</LinkTo>, Continue the flow, come back and then click Refresh Students.
+    </p>
+    <div class='nav-btn-container'>
+      <button
+        class='primary-button cancel-button'
+        type='button'
+        disabled={{@isFetchingSectionStudents}}
+        {{on 'click' this.refreshStudents}}
+      >
+        {{if @isFetchingSectionStudents 'Refreshing...' 'Refresh Students'}}
+      </button>
+    </div>
+  {{else if @selectedValue}}
+    <p class="sub-input-label">
+      No class is selected right now. Go back to Step 2, pick a class, then return here.
+    </p>
+  {{/if}}
 
-<div class="flex-container">
-  <div class="student-list">
-    {{#if @selectedSection}}
-      <h4 class="section-name">Class: {{@selectedSection.name}}</h4>
-      <p class="student-name">Students:</p>
-      {{#if this.displayList.length}}
-        {{#each this.displayList as |student|}}
-          <p class="student-name">{{student.username}}</p>
-        {{/each}}
+  <div class="flex-container">
+    <div class="student-list">
+      {{#if @selectedSection}}
+        <h4 class="section-name">Class: {{@selectedSection.name}}</h4>
+        <p class="student-name">Students:</p>
+        {{#if this.displayList.length}}
+          {{#each this.displayList as |student|}}
+            <p class="student-name">{{student.username}}</p>
+          {{/each}}
+        {{else}}
+          <p class="student-name">No students in this class yet.</p>
+        {{/if}}
       {{else}}
-        <p class="student-name">No students in this class yet.</p>
+        <p>Not using class for matching.</p>
       {{/if}}
-    {{else}}
-      <p>Not using class for matching.</p>
-    {{/if}}
+    </div>
+
+    <div class="matching-container">
+      {{#each this.answers as |answer|}}
+        <StudentMatchingAnswer
+          @answer={{answer}}
+          @selectedSection={{this.selectedSection}}
+          @checkStatus={{this.checkStatus}}
+          @studentMap={{this.studentMap}}
+          @addedStudentNames={{this.addedStudentNames}}
+          @newNameFilter={{this.addStudentNameFilter}}
+          @onAddStudentName={{this.addAddedStudentName}}
+        />
+      {{/each}}
+    </div>
   </div>
 
-  <div class="matching-container">
-    {{#each this.answers as |answer|}}
-      <StudentMatchingAnswer
-        @store={{this.store}}
-        @answer={{answer}}
-        @selectedSection={{this.selectedSection}}
-        @checkStatus={{action "checkStatus"}}
-        @studentMap={{this.studentMap}}
-        @addedStudentNames={{this.addedStudentNames}}
-        @newNameFilter={{this.newNameFilter}}
-        @onAddStudentName={{action "addAddedStudentName"}}
-      />
-    {{/each}}
+  <div class="nav-btn-container">
+    <button class="primary-button cancel-button" type="button" {{on 'click' this.back}}>Back</button>
+    <button class="primary-button" type="button" {{on 'click' this.next}}>Next</button>
   </div>
-</div>
 
-<div class="nav-btn-container">
-  <button class="primary-button cancel-button" type="button" {{action "back"}}>Back</button>
-  <button class="primary-button" type="button" {{action "next"}}>Next</button>
+  {{#if this.isMatchingIncompleteError}}
+    <Ui::ErrorBox
+      @error='Please match at least one student/name for each submission before continuing'
+      @showDismiss={{true}}
+      @resetError={{this.resetMatchingIncompleteError}}
+    />
+  {{/if}}
 </div>
-
-{{#if this.isMatchingIncompleteError}}
-  <Ui::ErrorBox
-    @error='Please match at least one student/name for each submission before continuing'
-    @showDismiss={{true}}
-    @resetError={{action (mut this.isMatchingIncompleteError) null}}
-  />
-{{/if}}

--- a/tests/integration/components/import-work-step4-test.js
+++ b/tests/integration/components/import-work-step4-test.js
@@ -1,0 +1,291 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import Service from '@ember/service';
+import Component from '@glimmer/component';
+
+const MONGO_ID = '507f1f77bcf86cd799439011';
+
+class UtilityMethodsStub extends Service {
+  isValidMongoId(value) {
+    return typeof value === 'string' && /^[a-f\d]{24}$/i.test(value);
+  }
+}
+
+class SweetAlertStub extends Service {
+  toastCalls = [];
+
+  showToast(...args) {
+    this.toastCalls.push(args);
+  }
+}
+
+class StudentMatchingAnswerStub extends Component {
+  get isStub() {
+    return true;
+  }
+}
+
+class ErrorBoxStub extends Component {
+  get isStub() {
+    return true;
+  }
+}
+
+module('Integration | Component | import-work-step4', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.owner.register('service:utility-methods', UtilityMethodsStub);
+    this.owner.register('service:sweet-alert', SweetAlertStub);
+
+    this.owner.register(
+      'component:student-matching-answer',
+      StudentMatchingAnswerStub
+    );
+    this.owner.register(
+      'template:components/student-matching-answer',
+      hbs`
+        <div class='student-matching-answer-stub' data-answer-id={{@answer.id}}>
+          <input
+            class='student-match-input'
+            id='select-add-student{{@answer.explanationImage.id}}'
+            value={{@answer.seedSelectValue}}
+          />
+        </div>
+      `
+    );
+
+    this.owner.register('component:ui/error-box', ErrorBoxStub);
+    this.owner.register(
+      'template:components/ui/error-box',
+      hbs`
+        <div class='error-box-stub'>
+          <span class='error-text'>{{@error}}</span>
+          <button
+            type='button'
+            class='dismiss-error'
+            {{on 'click' @resetError}}
+          >
+            Dismiss
+          </button>
+        </div>
+      `
+    );
+
+    this.defaultAnswer = {
+      id: 'answer-1',
+      explanationImage: {
+        id: 'img-1',
+        imageData: 'data:image/png;base64,AAA',
+        fileNameDisplay: 'work-1.png',
+      },
+      students: [],
+      studentNames: [],
+      seedSelectValue: '',
+    };
+  });
+
+  async function renderComponent(context, overrides = {}) {
+    const answers = overrides.answers || [context.defaultAnswer];
+    const studentMap = overrides.studentMap || {
+      [MONGO_ID]: { id: MONGO_ID, username: 'existing_student' },
+    };
+
+    context.setProperties({
+      selectedProblem: { id: 'problem-1', title: 'Linear Functions' },
+      selectedSection: null,
+      selectedValue: false,
+      uploadedFileIdsParam: 'img-1,img-2',
+      answers,
+      studentMap,
+      isFetchingSectionStudents: false,
+      proceedCount: 0,
+      backDirections: [],
+      goToSteps: [],
+      refreshCount: 0,
+      onProceed: () => {
+        context.proceedCount += 1;
+      },
+      onBack: (direction) => {
+        context.backDirections = [...context.backDirections, direction];
+      },
+      goToStep: (stepValue) => {
+        context.goToSteps = [...context.goToSteps, stepValue];
+      },
+      onRefreshStudents: () => {
+        context.refreshCount += 1;
+      },
+      ...overrides,
+    });
+
+    await render(hbs`
+      <ImportWorkStep4
+        @answers={{this.answers}}
+        @selectedProblem={{this.selectedProblem}}
+        @studentMap={{this.studentMap}}
+        @selectedSection={{this.selectedSection}}
+        @selectedValue={{this.selectedValue}}
+        @uploadedFileIdsParam={{this.uploadedFileIdsParam}}
+        @onBack={{this.onBack}}
+        @onProceed={{this.onProceed}}
+        @goToStep={{this.goToStep}}
+        @onRefreshStudents={{this.onRefreshStudents}}
+        @isFetchingSectionStudents={{this.isFetchingSectionStudents}}
+      />
+    `);
+  }
+
+  test('it renders class roster details when a class is selected', async function (assert) {
+    await renderComponent(this, {
+      selectedSection: { id: 'section-1', name: 'Algebra 1' },
+      studentMap: {
+        [MONGO_ID]: { id: MONGO_ID, username: 'amy_student' },
+      },
+    });
+
+    assert.dom('.section-name').hasText('Class: Algebra 1');
+    assert.dom('.student-list').includesText('amy_student');
+    assert
+      .dom('.primary-button.cancel-button')
+      .includesText('Refresh Students');
+  });
+
+  test('it shows no-class guidance when class mode is enabled but no class is selected', async function (assert) {
+    await renderComponent(this, {
+      selectedValue: true,
+      selectedSection: null,
+    });
+
+    assert
+      .dom('.sub-input-label')
+      .includesText('No class is selected right now');
+  });
+
+  test('it calls refresh callback from the refresh students button', async function (assert) {
+    await renderComponent(this, {
+      selectedSection: { id: 'section-1', name: 'Algebra 1' },
+    });
+
+    await click('.primary-button.cancel-button');
+
+    assert.strictEqual(this.refreshCount, 1, 'refresh callback is invoked');
+  });
+
+  test('it calls onBack with -1 from Back button', async function (assert) {
+    await renderComponent(this);
+
+    await click('.nav-btn-container:last-of-type .cancel-button');
+
+    assert.deepEqual(this.backDirections, [-1], 'back callback receives -1');
+  });
+
+  test('it blocks proceed and shows error/toast when matching is incomplete', async function (assert) {
+    await renderComponent(this, {
+      answers: [
+        {
+          ...this.defaultAnswer,
+          seedSelectValue: '',
+          students: [],
+          studentNames: [],
+        },
+      ],
+    });
+
+    await click(
+      '.nav-btn-container:last-of-type .primary-button:not(.cancel-button)'
+    );
+
+    const alertService = this.owner.lookup('service:sweet-alert');
+
+    assert.strictEqual(this.proceedCount, 0, 'onProceed is not called');
+    assert.deepEqual(this.goToSteps, [], 'goToStep is not called');
+    assert.strictEqual(
+      alertService.toastCalls.length,
+      1,
+      'toast is shown once'
+    );
+    assert.strictEqual(
+      alertService.toastCalls[0][1],
+      'Please match at least one student/name for each submission',
+      'toast message matches expected copy'
+    );
+    assert.dom('.error-box-stub').exists('error box is displayed');
+  });
+
+  test('it dismisses matching error via Ui::ErrorBox reset callback', async function (assert) {
+    await renderComponent(this, {
+      answers: [
+        {
+          ...this.defaultAnswer,
+          seedSelectValue: '',
+        },
+      ],
+    });
+
+    await click(
+      '.nav-btn-container:last-of-type .primary-button:not(.cancel-button)'
+    );
+    assert.dom('.error-box-stub').exists();
+
+    await click('.dismiss-error');
+    assert.dom('.error-box-stub').doesNotExist();
+  });
+
+  test('it proceeds and advances to step 5 when a plain-text match is present', async function (assert) {
+    const answer = {
+      ...this.defaultAnswer,
+      seedSelectValue: 'Typed Student',
+    };
+
+    await renderComponent(this, {
+      answers: [answer],
+    });
+
+    await click(
+      '.nav-btn-container:last-of-type .primary-button:not(.cancel-button)'
+    );
+
+    assert.strictEqual(this.proceedCount, 1, 'onProceed is called once');
+    assert.deepEqual(this.goToSteps, [5], 'flow advances to step 5');
+    assert.deepEqual(
+      answer.studentNames,
+      ['Typed Student'],
+      'answer receives typed student name during sync'
+    );
+    assert.dom('.error-box-stub').doesNotExist();
+  });
+
+  test('it maps mongo id values to selected students during sync', async function (assert) {
+    const answer = {
+      ...this.defaultAnswer,
+      seedSelectValue: MONGO_ID,
+    };
+    const selectedStudent = { id: MONGO_ID, username: 'existing_student' };
+
+    await renderComponent(this, {
+      answers: [answer],
+      studentMap: {
+        [MONGO_ID]: selectedStudent,
+      },
+    });
+
+    await click(
+      '.nav-btn-container:last-of-type .primary-button:not(.cancel-button)'
+    );
+
+    assert.strictEqual(this.proceedCount, 1);
+    assert.strictEqual(
+      answer.students.length,
+      1,
+      'student is mapped to answer'
+    );
+    assert.strictEqual(
+      answer.students[0],
+      selectedStudent,
+      'mapped student object comes from studentMap'
+    );
+    assert.deepEqual(answer.studentNames, [], 'no plain-text names remain');
+  });
+});


### PR DESCRIPTION
## Description
This PR modernizes Bulk Upload Step 4 to Octane/Glimmer patterns and adds integration coverage for the matching workflow.

## What Changed
- `app/components/import-work-step4.js`
  - Migrated from classic `Component.extend` to Glimmer class.
  - Converted computed/action hash patterns to getters and `@action` methods.
  - Kept matching logic behavior intact (`syncAnswerMatchesFromUI`, proceed validation, toast/error path).
  - Updated collection normalization to `slice()`-compatible handling.
- `app/templates/components/import-work-step4.hbs`
  - Replaced legacy `{{action}}` and `action (mut ...)` usage with modern bindings.
  - Added explicit wrapper `<div id='import-work-step4'>` to preserve existing styling behavior previously tied to classic `elementId`.
  - Updated child callback bindings to direct action references.
- `app/templates/components/import-work-container.hbs`
  - Removed unnecessary `@store` prop drilling into Step 4.
- `tests/integration/components/import-work-step4-test.js`
  - Added 8 integration tests covering class/no-class UI states, refresh/back callbacks, proceed success/failure, error reset, and ID/name matching paths.
  - Added test stubs for `student-matching-answer`, `ui/error-box`, `utility-methods`, and `sweet-alert`.

## Testing (UI + Integration)
- UI
  - Verified Step 4 renders class roster context when section is selected.
  - Verified no-class guidance state when class mode is enabled without a selected class.
  - Verified refresh/back/next interactions and error display/reset behavior.
- Integration
  - Added and linted 8 new Step 4 integration tests.
  - All tests pass 