### PR TITLE
Upgrade/import step 5

### DIFF
--- a/app/components/import-work-step5.js
+++ b/app/components/import-work-step5.js
@@ -1,71 +1,107 @@
-import Component from '@ember/component';
-import { computed } from '@ember/object';
-import { equal } from '@ember/object/computed';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 
-export default Component.extend({
-  tagName: '',
-  creatingWs: equal('doCreateWs', true),
-  creatingAssignment: equal('createAssignmentValue', true),
-  utils: service('utility-methods'),
-  alert: service('sweet-alert'),
-  workspaceOwner: null,
-  workspaceMode: null,
-  folderSet: null,
-  assignmentName: null,
-  createWs: computed(function () {
-    return {
-      groupName: 'createWs',
-      required: true,
-      inputs: [
-        {
-          value: true,
-          label: 'Yes',
-        },
-        {
-          value: false,
-          label: 'No',
-        },
-      ],
-    };
-  }),
-  createAssignment: computed(function () {
-    return {
-      groupName: 'createAssignment',
-      required: true,
-      inputs: [
-        {
-          value: true,
-          label: 'Yes',
-        },
-        {
-          value: false,
-          label: 'No',
-        },
-      ],
-    };
-  }),
-  ownerOptions: computed('users.[]', function () {
-    if (this.users) {
-      return this.users.map((user) => {
-        const getValue =
-          typeof user?.get === 'function'
-            ? (prop) => user.get(prop)
-            : (prop) => user?.[prop];
-        return {
-          id: getValue('id') || getValue('_id') || getValue('userId'),
-          username: getValue('username') || '',
-        };
-      });
-    }
-    return [];
-  }),
+export default class ImportWorkStep5Component extends Component {
+  @service store;
+  @service('utility-methods') utils;
+  @service('sweet-alert') alert;
 
-  folderSetOptions: computed('folderSets.[]', function () {
-    if (!Array.isArray(this.folderSets)) {
+  @tracked doCreateWs = false;
+  @tracked createAssignmentValue = false;
+  @tracked selectedOwner = null;
+  @tracked selectedFolderSet = null;
+  @tracked selectedMode = 'private';
+  @tracked workspaceName = null;
+  @tracked assignmentName = null;
+  @tracked missingNameError = null;
+  @tracked missingOwnerError = null;
+  @tracked missingAssignmentError = null;
+  @tracked createWorkspaceError = null;
+
+  createWsOptions = {
+    groupName: 'createWs',
+    required: true,
+    inputs: [
+      {
+        value: true,
+        label: 'Yes',
+      },
+      {
+        value: false,
+        label: 'No',
+      },
+    ],
+  };
+
+  createAssignmentOptions = {
+    groupName: 'createAssignment',
+    required: true,
+    inputs: [
+      {
+        value: true,
+        label: 'Yes',
+      },
+      {
+        value: false,
+        label: 'No',
+      },
+    ],
+  };
+
+  constructor(owner, args) {
+    super(owner, args);
+    this.doCreateWs = this.normalizeBooleanValue(args.doCreateWs);
+    this.createAssignmentValue = this.normalizeBooleanValue(
+      args.createAssignmentValue
+    );
+    this.selectedOwner = args.selectedOwner || null;
+    this.selectedFolderSet = args.selectedFolderSet || null;
+    this.selectedMode = args.selectedMode || 'private';
+    this.workspaceName = this.normalizeTextValue(args.workspaceName);
+    this.assignmentName = this.normalizeTextValue(args.assignmentName);
+  }
+
+  get creatingWs() {
+    return this.doCreateWs === true;
+  }
+
+  get creatingAssignment() {
+    return this.createAssignmentValue === true;
+  }
+
+  get currentUser() {
+    return this.args.currentUser || null;
+  }
+
+  get selectedSection() {
+    return this.args.selectedSection || null;
+  }
+
+  get ownerOptions() {
+    let users = this.args.users;
+    if (!users) {
       return [];
     }
-    return this.folderSets.map((folderSet) => {
+    return users.map((user) => {
+      const getValue =
+        typeof user?.get === 'function'
+          ? (prop) => user.get(prop)
+          : (prop) => user?.[prop];
+      return {
+        id: getValue('id') || getValue('_id') || getValue('userId'),
+        username: getValue('username') || '',
+      };
+    });
+  }
+
+  get folderSetOptions() {
+    let folderSets = this.args.folderSets;
+    if (!Array.isArray(folderSets)) {
+      return [];
+    }
+    return folderSets.map((folderSet) => {
       const getValue =
         typeof folderSet?.get === 'function'
           ? (prop) => folderSet.get(prop)
@@ -75,9 +111,10 @@ export default Component.extend({
         name: getValue('name') || '',
       };
     });
-  }),
-  modeInputs: computed('currentUser.{isStudent,isAdmin}', function () {
-    let res = {
+  }
+
+  get modeInputs() {
+    const base = {
       groupName: 'mode',
       required: true,
       inputs: [
@@ -102,37 +139,65 @@ export default Component.extend({
     };
 
     if (this.currentUser?.isStudent || !this.currentUser?.isAdmin) {
-      return res;
+      return base;
     }
 
-    res.inputs.push({
-      value: 'internet',
-      label: 'Internet',
-      moreInfo:
-        'Workspace will be accesible to any user with a link to the workspace',
-    });
-    return res;
-  }),
+    return {
+      ...base,
+      inputs: [
+        ...base.inputs,
+        {
+          value: 'internet',
+          label: 'Internet',
+          moreInfo:
+            'Workspace will be accesible to any user with a link to the workspace',
+        },
+      ],
+    };
+  }
 
-  initialOwnerItem: computed('selectedOwner', 'utils', function () {
-    const selectedOwner = this.selectedOwner;
-    if (selectedOwner && this.utils.isNonEmptyObject(selectedOwner)) {
-      return [selectedOwner.id];
-    }
-    return [];
-  }),
-
-  initialFolderSetItem: computed('selectedFolderSet', 'utils', function () {
-    const selectedFolderSet = this.selectedFolderSet;
-    if (this.utils.isNonEmptyObject(selectedFolderSet)) {
-      return [selectedFolderSet.id];
+  get initialOwnerItem() {
+    if (this.utils.isNonEmptyObject(this.selectedOwner)) {
+      const id = this.getRecordId(this.selectedOwner);
+      return id ? [id] : [];
     }
     return [];
-  }),
+  }
+
+  get initialFolderSetItem() {
+    if (this.utils.isNonEmptyObject(this.selectedFolderSet)) {
+      const id = this.getRecordId(this.selectedFolderSet);
+      return id ? [id] : [];
+    }
+    return [];
+  }
+
+  getRecordId(record) {
+    if (!record) {
+      return null;
+    }
+    return (
+      record.id ||
+      record._id ||
+      record.userId ||
+      (typeof record.get === 'function'
+        ? record.get('id') || record.get('_id') || record.get('userId')
+        : null)
+    );
+  }
+
+  isSameRecord(left, right) {
+    const leftId = this.getRecordId(left);
+    const rightId = this.getRecordId(right);
+    if (leftId && rightId) {
+      return String(leftId) === String(rightId);
+    }
+    return left === right;
+  }
 
   normalizeTextValue(value) {
     return typeof value === 'string' ? value.trim() : value;
-  },
+  }
 
   normalizeBooleanValue(value) {
     if (typeof value === 'boolean') {
@@ -148,7 +213,7 @@ export default Component.extend({
       );
     }
     return false;
-  },
+  }
 
   buildReviewPayload(overrides = {}) {
     const doCreateWs =
@@ -195,120 +260,161 @@ export default Component.extend({
       folderSet: doCreateWs ? selectedFolderSet || null : null,
       assignmentName: createAssignmentValue ? assignmentName || null : null,
     };
-  },
+  }
 
-  actions: {
-    updateDoCreateWs: function (val) {
-      this.set('doCreateWs', val);
-    },
-    updateSelectedMode: function (val) {
-      this.set('selectedMode', val);
-    },
-    updateCreateAssignmentValue: function (val) {
-      this.set('createAssignmentValue', val);
-    },
-    updateSelectizeSingle(val, $item, propToUpdate, model) {
-      if (this.utils.isNullOrUndefined($item)) {
-        this.set(propToUpdate, null);
+  setSelectionProp(propToUpdate, value) {
+    if (propToUpdate === 'selectedOwner') {
+      if (this.isSameRecord(this.selectedOwner, value)) {
         return;
       }
-      let record = this.store.peekRecord(model, val);
-      if (!record) {
+      this.selectedOwner = value;
+      return;
+    }
+
+    if (propToUpdate === 'selectedFolderSet') {
+      if (this.isSameRecord(this.selectedFolderSet, value)) {
         return;
       }
-      this.set(propToUpdate, record);
-    },
-    createWorkspace() {
-      const workspaceName = this.normalizeTextValue(this.workspaceName);
-      this.set('workspaceName', workspaceName);
-      this.set('workspaceOwner', this.selectedOwner || null);
-      this.set('workspaceMode', this.selectedMode || 'private');
-      this.set('folderSet', this.selectedFolderSet || null);
-      if (!workspaceName || !this.selectedOwner) {
-        if (!workspaceName) {
-          this.set(
-            'missingNameError',
-            'Please provide a name for your workspace'
-          );
-        } else {
-          this.set('missingNameError', null);
-        }
-        if (!this.selectedOwner) {
-          this.set(
-            'missingOwnerError',
-            'Please provide an owner for your workspace'
-          );
-        } else {
-          this.set('missingOwnerError', null);
-        }
-        this.alert.showToast(
-          'error',
-          'Workspace name and owner are required to continue',
-          'bottom-end',
-          3000,
-          false,
-          null
-        );
-        return;
+      this.selectedFolderSet = value;
+    }
+  }
+
+  @action
+  updateDoCreateWs(val) {
+    this.doCreateWs = this.normalizeBooleanValue(val);
+  }
+
+  @action
+  updateSelectedMode(val) {
+    this.selectedMode = val || 'private';
+  }
+
+  @action
+  updateCreateAssignmentValue(val) {
+    this.createAssignmentValue = this.normalizeBooleanValue(val);
+  }
+
+  @action
+  updateSelectizeSingle(val, item, propToUpdate, model) {
+    const isRemoval = this.utils.isNullOrUndefined(item);
+    if (isRemoval) {
+      this.setSelectionProp(propToUpdate, null);
+      return;
+    }
+
+    if (!model || !val) {
+      return;
+    }
+
+    const record = this.store.peekRecord(model, val);
+    if (!record) {
+      return;
+    }
+
+    this.setSelectionProp(propToUpdate, record);
+  }
+
+  @action
+  resetMissingNameError() {
+    this.missingNameError = null;
+  }
+
+  @action
+  resetMissingOwnerError() {
+    this.missingOwnerError = null;
+  }
+
+  @action
+  resetMissingAssignmentError() {
+    this.missingAssignmentError = null;
+  }
+
+  @action
+  createWorkspace() {
+    const workspaceName = this.normalizeTextValue(this.workspaceName);
+    this.workspaceName = workspaceName;
+    this.createWorkspaceError = null;
+
+    if (this.selectedOwner) {
+      this.missingOwnerError = null;
+    }
+    if (workspaceName) {
+      this.missingNameError = null;
+    }
+
+    if (!workspaceName || !this.selectedOwner) {
+      if (!workspaceName) {
+        this.missingNameError = 'Please provide a name for your workspace';
+      }
+      if (!this.selectedOwner) {
+        this.missingOwnerError = 'Please provide an owner for your workspace';
+      }
+
+      this.alert.showToast(
+        'error',
+        'Workspace name and owner are required to continue',
+        'bottom-end',
+        3000,
+        false,
+        null
+      );
+      return;
+    }
+
+    if (typeof this.args.onProceed === 'function') {
+      this.args.onProceed(this.buildReviewPayload({ doCreateWs: true }));
+    }
+  }
+
+  @action
+  next() {
+    let hasAssignmentError = false;
+
+    if (this.createAssignmentValue) {
+      let assignmentName = this.normalizeTextValue(this.assignmentName);
+      this.assignmentName = assignmentName;
+
+      if (!assignmentName) {
+        this.missingAssignmentError =
+          'Please provide a name for your assignment';
+        hasAssignmentError = true;
       } else {
-        this.set('missingNameError', null);
-        this.set('missingOwnerError', null);
-        this.set('createWorkspaceError', null);
-        if (typeof this.onProceed === 'function') {
-          this.onProceed(this.buildReviewPayload({ doCreateWs: true }));
-        }
+        this.missingAssignmentError = null;
       }
-    },
+    } else {
+      this.assignmentName = null;
+      this.missingAssignmentError = null;
+    }
 
-    next() {
-      let hasAssignmentError = false;
-      if (this.createAssignmentValue) {
-        let assignmentName =
-          typeof this.assignmentName === 'string'
-            ? this.assignmentName.trim()
-            : this.assignmentName;
+    if (hasAssignmentError) {
+      this.alert.showToast(
+        'error',
+        'Assignment name is required to continue',
+        'bottom-end',
+        3000,
+        false,
+        null
+      );
+      return;
+    }
 
-        if (!assignmentName) {
-          this.set(
-            'missingAssignmentError',
-            'Please provide a name for your assignment'
-          );
-          hasAssignmentError = true;
-        } else {
-          this.set('missingAssignmentError', null);
-        }
-        this.set('assignmentName', assignmentName);
-      } else {
-        this.set('missingAssignmentError', null);
-        this.set('assignmentName', null);
-      }
+    if (this.doCreateWs) {
+      this.createWorkspace();
+      return;
+    }
 
-      if (hasAssignmentError) {
-        this.alert.showToast(
-          'error',
-          'Assignment name is required to continue',
-          'bottom-end',
-          3000,
-          false,
-          null
-        );
-        return;
-      }
+    this.missingNameError = null;
+    this.missingOwnerError = null;
+    this.createWorkspaceError = null;
+    if (typeof this.args.onProceed === 'function') {
+      this.args.onProceed(this.buildReviewPayload({ doCreateWs: false }));
+    }
+  }
 
-      if (this.doCreateWs) {
-        this.send('createWorkspace');
-      } else {
-        this.set('missingNameError', null);
-        this.set('missingOwnerError', null);
-        this.set('createWorkspaceError', null);
-        if (typeof this.onProceed === 'function') {
-          this.onProceed(this.buildReviewPayload({ doCreateWs: false }));
-        }
-      }
-      //check for assignment and set assignmentName
-    },
-    back() {
-      this.onBack(-1);
-    },
-  },
-});
+  @action
+  back() {
+    if (typeof this.args.onBack === 'function') {
+      this.args.onBack(-1);
+    }
+  }
+}

--- a/app/templates/components/import-work-container.hbs
+++ b/app/templates/components/import-work-container.hbs
@@ -127,7 +127,6 @@
             @doCreateWs={{this.doCreateWs}}
             @selectedMode={{this.selectedMode}}
             @folderSets={{this.folderSets}}
-            @store={{this.store}}
             @uploadedFiles={{this.uploadedFiles}}
             @answers={{this.answers}}
             @selectedProblem={{this.selectedProblem}}

--- a/app/templates/components/import-work-step5.hbs
+++ b/app/templates/components/import-work-step5.hbs
@@ -9,9 +9,9 @@
   </span>
   </p>
   <Ui::RadioGroup
-    @options={{this.createWs}}
+    @options={{this.createWsOptions}}
     @selectedValue={{this.doCreateWs}}
-    @updateValue={{action 'updateDoCreateWs'}}
+    @updateValue={{this.updateDoCreateWs}}
   />
 
   {{#if this.creatingWs}}
@@ -41,7 +41,7 @@
             <Ui::ErrorBox
               @error={{this.missingNameError}}
               @showDismiss={{true}}
-              @resetError={{action (mut this.missingNameError) null}}
+              @resetError={{this.resetMissingNameError}}
             />
           </div>
         {{/if}}
@@ -60,13 +60,12 @@
           </span>
         </p>
         <SelectizeInput
-          @store={{this.store}}
           @inputId='owner-select'
           @initialOptions={{this.ownerOptions}}
           @initialItems={{this.initialOwnerItem}}
           @maxItems={{1}}
-          @onItemAdd={{action 'updateSelectizeSingle'}}
-          @onItemRemove={{action 'updateSelectizeSingle'}}
+          @onItemAdd={{this.updateSelectizeSingle}}
+          @onItemRemove={{this.updateSelectizeSingle}}
           @labelField='username'
           @valueField='id'
           @searchField='username'
@@ -79,7 +78,7 @@
             <Ui::ErrorBox
               @error={{this.missingOwnerError}}
               @showDismiss={{true}}
-              @resetError={{action (mut this.missingOwnerError) null}}
+              @resetError={{this.resetMissingOwnerError}}
             />
           </div>
         {{/if}}
@@ -98,7 +97,7 @@
         <Ui::RadioGroup
           @options={{this.modeInputs}}
           @selectedValue={{this.selectedMode}}
-          @updateValue={{action 'updateSelectedMode'}}
+          @updateValue={{this.updateSelectedMode}}
         />
       </div>
 
@@ -113,13 +112,12 @@
           </span>
         </p>
         <SelectizeInput
-          @store={{this.store}}
           @inputId='folderset-select'
           @initialOptions={{this.folderSetOptions}}
           @maxItems={{1}}
           @initialItems={{this.initialFolderSetItem}}
-          @onItemAdd={{action 'updateSelectizeSingle'}}
-          @onItemRemove={{action 'updateSelectizeSingle'}}
+          @onItemAdd={{this.updateSelectizeSingle}}
+          @onItemRemove={{this.updateSelectizeSingle}}
           @labelField='name'
           @valueField='id'
           @searchField='name'
@@ -146,9 +144,9 @@
           </span>
         </p>
         <Ui::RadioGroup
-          @options={{this.createAssignment}}
+          @options={{this.createAssignmentOptions}}
           @selectedValue={{this.createAssignmentValue}}
-          @updateValue={{action 'updateCreateAssignmentValue'}}
+          @updateValue={{this.updateCreateAssignmentValue}}
         />
       </div>
     {{/if}}
@@ -180,7 +178,7 @@
             <Ui::ErrorBox
               @error={{this.missingAssignmentError}}
               @showDismiss={{true}}
-              @resetError={{action (mut this.missingAssignmentError) null}}
+              @resetError={{this.resetMissingAssignmentError}}
             />
           </div>
         {{/if}}
@@ -192,13 +190,13 @@
     <button
       class='primary-button cancel-button'
       type='button'
-      {{action 'back'}}
+      {{on 'click' this.back}}
     >Back</button>
     <button
       class='primary-button'
       data-test='next'
       type='button'
-      {{action 'next'}}
+      {{on 'click' this.next}}
     >Next</button>
   </div>
 </div>

--- a/tests/integration/components/import-work-step5-test.js
+++ b/tests/integration/components/import-work-step5-test.js
@@ -1,0 +1,368 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, fillIn, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import Service from '@ember/service';
+import Component from '@glimmer/component';
+
+class UtilityMethodsStub extends Service {
+  isNonEmptyObject(value) {
+    return (
+      !!value && typeof value === 'object' && Object.keys(value).length > 0
+    );
+  }
+
+  isNullOrUndefined(value) {
+    return value === null || value === undefined;
+  }
+}
+
+class SweetAlertStub extends Service {
+  toastCalls = [];
+
+  showToast(...args) {
+    this.toastCalls.push(args);
+  }
+}
+
+class SelectizeInputStub extends Component {
+  get isStub() {
+    return true;
+  }
+}
+
+class ErrorBoxStub extends Component {
+  get isStub() {
+    return true;
+  }
+}
+
+module('Integration | Component | import-work-step5', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    const ownerRecord = { id: 'user-1', username: 'teacher_owner' };
+    const folderSetRecord = { id: 'folder-set-1', name: 'Default Folders' };
+    this.ownerRecord = ownerRecord;
+    this.folderSetRecord = folderSetRecord;
+
+    this.owner.register('service:utility-methods', UtilityMethodsStub);
+    this.owner.register('service:sweet-alert', SweetAlertStub);
+    this.owner.register(
+      'service:store',
+      class extends Service {
+        peekRecord(modelName, id) {
+          if (modelName === 'user' && id === 'user-1') {
+            return ownerRecord;
+          }
+          if (modelName === 'folder-set' && id === 'folder-set-1') {
+            return folderSetRecord;
+          }
+          return null;
+        }
+      }
+    );
+
+    this.owner.register('component:selectize-input', SelectizeInputStub);
+    this.owner.register(
+      'template:components/selectize-input',
+      hbs`
+        <div class='selectize-input-stub' data-input-id={{@inputId}}>
+          <ul class='stub-initial-items'>
+            {{#each @initialItems as |item|}}
+              <li class='stub-item'>{{item}}</li>
+            {{/each}}
+          </ul>
+          <button
+            type='button'
+            class='stub-add-item'
+            data-input-id={{@inputId}}
+            {{on
+              'click'
+              (fn
+                @onItemAdd
+                (if (is-equal @inputId 'owner-select') 'user-1' 'folder-set-1')
+                (hash added=true)
+                @propToUpdate
+                @model
+              )
+            }}
+          >
+            Add
+          </button>
+          <button
+            type='button'
+            class='stub-remove-item'
+            data-input-id={{@inputId}}
+            {{on
+              'click'
+              (fn
+                @onItemRemove
+                (if (is-equal @inputId 'owner-select') 'user-1' 'folder-set-1')
+                null
+                @propToUpdate
+                @model
+              )
+            }}
+          >
+            Remove
+          </button>
+        </div>
+      `
+    );
+
+    this.owner.register('component:ui/error-box', ErrorBoxStub);
+    this.owner.register(
+      'template:components/ui/error-box',
+      hbs`
+        <div class='error-box-stub'>
+          <span class='error-text'>{{@error}}</span>
+          <button
+            type='button'
+            class='dismiss-error'
+            {{on 'click' @resetError}}
+          >
+            Dismiss
+          </button>
+        </div>
+      `
+    );
+  });
+
+  async function renderComponent(context, overrides = {}) {
+    context.setProperties({
+      currentUser: { id: 'teacher-1', isStudent: false, isAdmin: false },
+      users: [{ id: 'user-1', username: 'teacher_owner' }],
+      selectedOwner: null,
+      selectedFolderSet: null,
+      createAssignmentValue: false,
+      doCreateWs: false,
+      selectedMode: 'private',
+      folderSets: [{ id: 'folder-set-1', name: 'Default Folders' }],
+      selectedSection: { id: 'section-1', name: 'Algebra 1' },
+      workspaceName: null,
+      assignmentName: null,
+      proceedPayload: null,
+      proceedCount: 0,
+      backDirections: [],
+      onProceed: (payload) => {
+        context.proceedPayload = payload;
+        context.proceedCount += 1;
+      },
+      onBack: (direction) => {
+        context.backDirections = [...context.backDirections, direction];
+      },
+      ...overrides,
+    });
+
+    await render(hbs`
+      <ImportWorkStep5
+        @currentUser={{this.currentUser}}
+        @users={{this.users}}
+        @selectedOwner={{this.selectedOwner}}
+        @selectedFolderSet={{this.selectedFolderSet}}
+        @createAssignmentValue={{this.createAssignmentValue}}
+        @doCreateWs={{this.doCreateWs}}
+        @selectedMode={{this.selectedMode}}
+        @folderSets={{this.folderSets}}
+        @selectedSection={{this.selectedSection}}
+        @workspaceName={{this.workspaceName}}
+        @assignmentName={{this.assignmentName}}
+        @onBack={{this.onBack}}
+        @onProceed={{this.onProceed}}
+      />
+    `);
+  }
+
+  test('it passes selected owner and folder set ids into initial selectize items', async function (assert) {
+    await renderComponent(this, {
+      selectedOwner: { id: 'user-1', username: 'teacher_owner' },
+      selectedFolderSet: { id: 'folder-set-1', name: 'Default Folders' },
+      doCreateWs: true,
+    });
+
+    assert
+      .dom('.selectize-input-stub[data-input-id="owner-select"] .stub-item')
+      .hasText('user-1');
+    assert
+      .dom('.selectize-input-stub[data-input-id="folderset-select"] .stub-item')
+      .hasText('folder-set-1');
+  });
+
+  test('it calls onBack with -1 from Back button', async function (assert) {
+    await renderComponent(this);
+
+    await click('.nav-btn-container .cancel-button');
+
+    assert.deepEqual(this.backDirections, [-1], 'back callback receives -1');
+  });
+
+  test('it proceeds with no-workspace payload when create workspace is set to no', async function (assert) {
+    await renderComponent(this, {
+      doCreateWs: true,
+      workspaceName: 'Legacy Name',
+      selectedOwner: { id: 'user-1', username: 'teacher_owner' },
+    });
+
+    await click('input[name="createWs"][value="false"]');
+    await click('.nav-btn-container .primary-button:not(.cancel-button)');
+
+    assert.strictEqual(this.proceedCount, 1, 'onProceed is called once');
+    assert.false(this.proceedPayload.doCreateWs, 'workspace creation is off');
+    assert.strictEqual(
+      this.proceedPayload.workspaceName,
+      null,
+      'workspace name is cleared in payload'
+    );
+    assert.strictEqual(
+      this.proceedPayload.workspaceOwner,
+      null,
+      'workspace owner is cleared in payload'
+    );
+    assert.strictEqual(
+      this.proceedPayload.folderSet,
+      null,
+      'folder set is cleared in payload'
+    );
+  });
+
+  test('it blocks proceed and shows name/owner validation when create workspace is enabled with missing fields', async function (assert) {
+    await renderComponent(this);
+
+    await click('input[name="createWs"][value="true"]');
+    await click('.nav-btn-container .primary-button:not(.cancel-button)');
+
+    const alertService = this.owner.lookup('service:sweet-alert');
+
+    assert.strictEqual(this.proceedCount, 0, 'onProceed is not called');
+    assert.dom('.error-box-stub').exists({ count: 2 });
+    const errorTexts = [...document.querySelectorAll('.error-text')].map(
+      (element) => element.textContent.trim()
+    );
+    assert.true(
+      errorTexts.includes('Please provide a name for your workspace'),
+      'name validation error is shown'
+    );
+    assert.true(
+      errorTexts.includes('Please provide an owner for your workspace'),
+      'owner validation error is shown'
+    );
+    assert.strictEqual(
+      alertService.toastCalls.length,
+      1,
+      'validation toast is shown once'
+    );
+    assert.strictEqual(
+      alertService.toastCalls[0][1],
+      'Workspace name and owner are required to continue',
+      'toast message matches expected copy'
+    );
+  });
+
+  test('it dismisses workspace validation errors via Ui::ErrorBox reset callbacks', async function (assert) {
+    await renderComponent(this);
+
+    await click('input[name="createWs"][value="true"]');
+    await click('.nav-btn-container .primary-button:not(.cancel-button)');
+    assert.dom('.error-box-stub').exists({ count: 2 });
+
+    await click('.dismiss-error');
+    assert.dom('.error-box-stub').exists({ count: 1 });
+  });
+
+  test('it proceeds with create-workspace payload when workspace data is valid', async function (assert) {
+    await renderComponent(this);
+
+    await click('input[name="createWs"][value="true"]');
+    await fillIn('#ws-new-name', '  Imported Workspace  ');
+    await click(
+      '.selectize-input-stub[data-input-id="owner-select"] .stub-add-item'
+    );
+    await click(
+      '.selectize-input-stub[data-input-id="folderset-select"] .stub-add-item'
+    );
+    await click('input[name="mode"][value="org"]');
+    await click('.nav-btn-container .primary-button:not(.cancel-button)');
+
+    assert.strictEqual(this.proceedCount, 1, 'onProceed is called once');
+    assert.true(this.proceedPayload.doCreateWs, 'workspace creation is on');
+    assert.strictEqual(
+      this.proceedPayload.workspaceName,
+      'Imported Workspace',
+      'workspace name is trimmed'
+    );
+    assert.strictEqual(
+      this.proceedPayload.workspaceOwner,
+      this.ownerRecord,
+      'owner record is included in payload'
+    );
+    assert.strictEqual(
+      this.proceedPayload.folderSet,
+      this.folderSetRecord,
+      'folder set record is included in payload'
+    );
+    assert.strictEqual(
+      this.proceedPayload.workspaceMode,
+      'org',
+      'mode selection is propagated'
+    );
+  });
+
+  test('it blocks proceed when assignment creation is enabled without assignment name', async function (assert) {
+    await renderComponent(this);
+
+    await click('input[name="createAssignment"][value="true"]');
+    await click('.nav-btn-container .primary-button:not(.cancel-button)');
+
+    const alertService = this.owner.lookup('service:sweet-alert');
+
+    assert.strictEqual(this.proceedCount, 0, 'onProceed is not called');
+    assert.dom('.error-box-stub').exists({ count: 1 });
+    assert
+      .dom('.error-text')
+      .hasText('Please provide a name for your assignment');
+    assert.strictEqual(
+      alertService.toastCalls.length,
+      1,
+      'assignment validation toast is shown'
+    );
+    assert.strictEqual(
+      alertService.toastCalls[0][1],
+      'Assignment name is required to continue',
+      'toast message matches expected copy'
+    );
+  });
+
+  test('it proceeds with assignment payload when assignment name is present', async function (assert) {
+    await renderComponent(this);
+
+    await click('input[name="createAssignment"][value="true"]');
+    await fillIn('#assignment-name', '  Assignment A  ');
+    await click('.nav-btn-container .primary-button:not(.cancel-button)');
+
+    assert.strictEqual(this.proceedCount, 1, 'onProceed is called once');
+    assert.true(
+      this.proceedPayload.createAssignmentValue,
+      'assignment flag is true'
+    );
+    assert.strictEqual(
+      this.proceedPayload.assignmentName,
+      'Assignment A',
+      'assignment name is trimmed in payload'
+    );
+    assert.false(
+      this.proceedPayload.doCreateWs,
+      'workspace creation remains off'
+    );
+  });
+
+  test('it hides assignment controls for students', async function (assert) {
+    await renderComponent(this, {
+      currentUser: { id: 'student-1', isStudent: true, isAdmin: false },
+    });
+
+    assert
+      .dom('input[name="createAssignment"]')
+      .doesNotExist('assignment radio group is hidden for students');
+  });
+});


### PR DESCRIPTION
### Description
This PR upgrades **Import Work Step 5** (`Create Workspace`) to modern Ember and adds targeted integration coverage.

### Changes
- Migrated `import-work-step5` from classic Ember patterns to a Glimmer component class:
  - `Component.extend` -> class-based component
  - computed/equal macro usage -> getters/tracked state
  - legacy `actions` hash -> `@action` methods
  - `this.set`/`this.send` usage removed
- Modernized Step 5 template bindings:
  - replaced legacy `{{action}}` usage with direct callback bindings and `{{on}}`
  - replaced `mut`-style error resets with explicit reset handlers
- Removed unnecessary Step 5 `@store` argument from parent invocation in `import-work-container`, using service injection in Step 5.
- Added new Step 5 integration test module:
  - validates workspace/assignment branching
  - validates error/toast paths
  - validates payload normalization (trimmed values, null-cleared fields)
  - validates role-based assignment control visibility for students

### Testing (UI + Integration)

#### UI
- Verified Step 5 workspace toggle path (`Yes` / `No`) and Next behavior.
- Verified owner/folder set selection flow and payload continuity.
- Verified assignment toggle flow and validation message behavior.
- Verified Back/Next navigation continuity from Step 5 to review flow.

#### Integration
- Added integration tests** in:
  - `tests/integration/components/import-work-step5-test.js`
  - All tests pass