### PR TITLE
Upgrade/import step 6 to modern Ember and adds targeted integration tests 

### DIFF
--- a/app/components/import-work-step6.js
+++ b/app/components/import-work-step6.js
@@ -1,58 +1,114 @@
-import Component from '@ember/component';
-import { computed } from '@ember/object';
-import { or } from '@ember/object/computed';
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
 
-export default Component.extend({
-  tagName: '',
+export default class ImportWorkStep6Component extends Component {
+  get selectedProblem() {
+    return this.args.selectedProblem || null;
+  }
 
-  shouldHideButtons: computed(
-    'isUploadingAnswer',
-    'isCreatingWorkspace',
-    'savingAssignment',
-    'uploadedAnswers',
-    function () {
-      if (
-        this.isUploadingAnswer ||
-        this.isCreatingWorkspace ||
-        this.savingAssignment ||
-        this.uploadedAnswers
-      ) {
-        return true;
-      } else {
-        return false;
-      }
+  get selectedSection() {
+    return this.args.selectedSection || null;
+  }
+
+  get submissionCount() {
+    return this.args.submissionCount || 0;
+  }
+
+  get workspaceName() {
+    return this.args.workspaceName || null;
+  }
+
+  get workspaceOwner() {
+    return this.args.workspaceOwner || null;
+  }
+
+  get workspaceMode() {
+    return this.args.workspaceMode || null;
+  }
+
+  get folderSet() {
+    return this.args.folderSet || null;
+  }
+
+  get assignmentName() {
+    return this.args.assignmentName || null;
+  }
+
+  get savingAssignment() {
+    return this.args.savingAssignment === true;
+  }
+
+  get isUploadingAnswer() {
+    return this.args.isUploadingAnswer === true;
+  }
+
+  get isCreatingWorkspace() {
+    return this.args.isCreatingWorkspace === true;
+  }
+
+  get uploadedAnswers() {
+    return this.args.uploadedAnswers === true;
+  }
+
+  get createdWorkspace() {
+    return this.args.createdWorkspace || null;
+  }
+
+  get createWorkspaceError() {
+    return this.args.createWorkspaceError || null;
+  }
+
+  get createdAssignment() {
+    return this.args.createdAssignment || null;
+  }
+
+  get showLoadingMessage() {
+    return (
+      this.isUploadingAnswer ||
+      this.isCreatingWorkspace ||
+      this.savingAssignment
+    );
+  }
+
+  get shouldHideButtons() {
+    return (
+      this.isUploadingAnswer ||
+      this.isCreatingWorkspace ||
+      this.savingAssignment ||
+      this.uploadedAnswers
+    );
+  }
+
+  get workspaceLink() {
+    const createdWorkspace = this.createdWorkspace;
+    const workspaceId = createdWorkspace?._id;
+    if (!workspaceId) {
+      return '/#/workspaces';
     }
-  ),
 
-  workspaceLink: computed(
-    'isCreatingWorkspace',
-    'createdWorkspace',
-    function () {
-      const createdWorkspace = this.createdWorkspace;
-      const workspaceId = createdWorkspace?._id;
-      if (!workspaceId) {
-        return '/#/workspaces';
-      }
-      const firstSubmissionId = createdWorkspace?.submissions?.[0];
-      if (!firstSubmissionId) {
-        return `/#/workspaces/${workspaceId}/work`;
-      }
-      return `/#/workspaces/${workspaceId}/submissions/${firstSubmissionId}`;
+    const firstSubmissionId = createdWorkspace?.submissions?.[0];
+    if (!firstSubmissionId) {
+      return `/#/workspaces/${workspaceId}/work`;
     }
-  ),
 
-  showLoadingMessage: or(
-    'isUploadingAnswer',
-    'isCreatingWorkspace',
-    'savingAssignment'
-  ),
+    return `/#/workspaces/${workspaceId}/submissions/${firstSubmissionId}`;
+  }
 
-  actions: {
-    next() {
-      this.onProceed();
-    },
-    back() {
-      this.onBack(-1);
-    },
-  },
-});
+  get createDate() {
+    return this.args.createDate || null;
+  }
+
+  @action
+  next() {
+    if (typeof this.args.onProceed === 'function') {
+      this.args.onProceed();
+    }
+  }
+
+  @action
+  back() {
+    if (typeof this.args.onBack === 'function') {
+      this.args.onBack(-1);
+    }
+  }
+}

--- a/app/templates/components/import-work-container.hbs
+++ b/app/templates/components/import-work-container.hbs
@@ -143,7 +143,6 @@
 
         {{#if this.showReview}}
           <ImportWorkStep6
-            @store={{this.store}}
             @uploadedFiles={{this.uploadedFiles}}
             @answers={{this.answers}}
             @selectedProblem={{this.selectedProblem}}

--- a/app/templates/components/import-work-step6.hbs
+++ b/app/templates/components/import-work-step6.hbs
@@ -8,7 +8,7 @@
       <p class="input-label">Import Summary</p>
       {{#if this.uploadedAnswers}}
         <p class="success-info animated fadeIn"><b>{{this.submissionCount}} submissions</b> have successfully been created as answers for <b>{{this.selectedProblem.title}}</b></p>
-        <p class="info  animated fadeIn">You can create a workspace from these submissions <LinkTo @route="workspaces.new" target="_blank" rel="noopener noreferrer">here</LinkTo></p>
+        <p class="info animated fadeIn">You can create a workspace from these submissions <LinkTo @route="workspaces.new" target="_blank" rel="noopener noreferrer">here</LinkTo></p>
       {{else}}
         <p class="info"><b>{{this.submissionCount}} submissions</b> will be created in EnCoMPASS as answers for <b>{{this.selectedProblem.title}}</b></p>
         <p class="info">Please review Summary info on the left to make sure everything is accurate</p>
@@ -29,7 +29,7 @@
           <Ui::ErrorBox
             @error={{this.createWorkspaceError}}
             @showDismiss={{true}}
-            @resetError={{this.onResetWorkspaceError}}
+            @resetError={{@onResetWorkspaceError}}
           />
         </div>
       {{/if}}
@@ -47,7 +47,7 @@
             <div class="item-card privacy">
               <span class="privacy-icon">
                 <span class="info-text-tip simptip-position-right simptip-smooth" data-tooltip={{this.workspaceMode}}>
-                  {{{public-private this.workspaceMode}}}
+                  {{public-private this.workspaceMode}}
                 </span>
               </span>
               <span class="date">{{format-date this.createDate 'L'}}</span>
@@ -134,8 +134,8 @@
 
   {{#unless this.shouldHideButtons}}
     <div class="nav-btn-container">
-      <button class="primary-button cancel-button" type="button" {{action "back"}}>Back</button>
-      <button class="primary-button" type="button" {{action "next"}}>Create</button>
+      <button class="primary-button cancel-button" type="button" {{on "click" this.back}}>Back</button>
+      <button class="primary-button" type="button" {{on "click" this.next}}>Create</button>
     </div>
   {{/unless}}
 </div>

--- a/tests/integration/components/import-work-step6-test.js
+++ b/tests/integration/components/import-work-step6-test.js
@@ -1,0 +1,248 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import Component from '@glimmer/component';
+
+class ErrorBoxStub extends Component {
+  get isStub() {
+    return true;
+  }
+}
+
+module('Integration | Component | import-work-step6', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.owner.register('component:ui/error-box', ErrorBoxStub);
+    this.owner.register(
+      'template:components/ui/error-box',
+      hbs`
+        <div class='error-box-stub'>
+          <span class='error-text'>{{@error}}</span>
+          <button
+            type='button'
+            class='dismiss-error'
+            {{on 'click' @resetError}}
+          >
+            Dismiss
+          </button>
+        </div>
+      `
+    );
+  });
+
+  async function renderComponent(context, overrides = {}) {
+    context.setProperties({
+      selectedProblem: { id: 'problem-1', title: 'Linear Functions' },
+      selectedSection: { id: 'section-1', name: 'Algebra 1' },
+      submissionCount: 4,
+      workspaceName: null,
+      workspaceOwner: { id: 'user-1', username: 'teacher_owner' },
+      workspaceMode: 'private',
+      folderSet: null,
+      assignmentName: null,
+      savingAssignment: false,
+      isUploadingAnswer: false,
+      isCreatingWorkspace: false,
+      uploadedAnswers: false,
+      createdWorkspace: null,
+      createWorkspaceError: null,
+      createdAssignment: null,
+      createDate: new Date('2026-05-27T00:00:00.000Z'),
+      proceedCount: 0,
+      backDirections: [],
+      resetWorkspaceErrorCount: 0,
+      onProceed: () => {
+        context.proceedCount += 1;
+      },
+      onBack: (direction) => {
+        context.backDirections = [...context.backDirections, direction];
+      },
+      onResetWorkspaceError: () => {
+        context.resetWorkspaceErrorCount += 1;
+      },
+      ...overrides,
+    });
+
+    await render(hbs`
+      <ImportWorkStep6
+        @selectedProblem={{this.selectedProblem}}
+        @selectedSection={{this.selectedSection}}
+        @submissionCount={{this.submissionCount}}
+        @workspaceName={{this.workspaceName}}
+        @workspaceOwner={{this.workspaceOwner}}
+        @workspaceMode={{this.workspaceMode}}
+        @folderSet={{this.folderSet}}
+        @assignmentName={{this.assignmentName}}
+        @savingAssignment={{this.savingAssignment}}
+        @isUploadingAnswer={{this.isUploadingAnswer}}
+        @isCreatingWorkspace={{this.isCreatingWorkspace}}
+        @uploadedAnswers={{this.uploadedAnswers}}
+        @createdWorkspace={{this.createdWorkspace}}
+        @createWorkspaceError={{this.createWorkspaceError}}
+        @createdAssignment={{this.createdAssignment}}
+        @createDate={{this.createDate}}
+        @onBack={{this.onBack}}
+        @onProceed={{this.onProceed}}
+        @onResetWorkspaceError={{this.onResetWorkspaceError}}
+      />
+    `);
+  }
+
+  test('it renders import summary and buttons by default', async function (assert) {
+    await renderComponent(this);
+
+    assert.dom('.import-review.summary').includesText('Import Summary');
+    assert
+      .dom('.import-review.summary')
+      .includesText('will be created in EnCoMPASS as answers');
+    assert.dom('.nav-btn-container .cancel-button').exists();
+    assert
+      .dom('.nav-btn-container .primary-button:not(.cancel-button)')
+      .hasText('Create');
+  });
+
+  test('it calls onBack and onProceed from footer buttons', async function (assert) {
+    await renderComponent(this);
+
+    await click('.nav-btn-container .cancel-button');
+    await click('.nav-btn-container .primary-button:not(.cancel-button)');
+
+    assert.deepEqual(this.backDirections, [-1], 'back callback receives -1');
+    assert.strictEqual(this.proceedCount, 1, 'proceed callback called once');
+  });
+
+  test('it shows answer upload loading state and hides buttons', async function (assert) {
+    await renderComponent(this, {
+      isUploadingAnswer: true,
+      submissionCount: 7,
+    });
+
+    assert
+      .dom('#import-work-step6')
+      .includesText('Please wait, creating 7 submissions');
+    assert
+      .dom('.import-review.summary')
+      .doesNotIncludeText('Import Summary', 'summary header hidden');
+    assert.dom('.nav-btn-container').doesNotExist('buttons are hidden');
+  });
+
+  test('it shows workspace creation loading state and hides buttons', async function (assert) {
+    await renderComponent(this, {
+      isCreatingWorkspace: true,
+    });
+
+    assert
+      .dom('#import-work-step6')
+      .includesText('Please wait, creating workspace');
+    assert.dom('.nav-btn-container').doesNotExist('buttons are hidden');
+  });
+
+  test('it shows assignment creation loading state and hides buttons', async function (assert) {
+    await renderComponent(this, {
+      savingAssignment: true,
+    });
+
+    assert
+      .dom('#import-work-step6')
+      .includesText('Please wait, creating assignment');
+    assert.dom('.nav-btn-container').doesNotExist('buttons are hidden');
+  });
+
+  test('it shows uploaded-answers success summary and hides buttons', async function (assert) {
+    await renderComponent(this, {
+      uploadedAnswers: true,
+      submissionCount: 6,
+    });
+
+    assert
+      .dom('.import-review.summary')
+      .includesText('6 submissions')
+      .includesText('have successfully been created as answers');
+    assert.dom('.nav-btn-container').doesNotExist('buttons are hidden');
+  });
+
+  test('it shows workspace-to-be-created details when workspace name is present', async function (assert) {
+    await renderComponent(this, {
+      workspaceName: 'Imported Workspace',
+      workspaceOwner: { id: 'user-2', username: 'owner_two' },
+      folderSet: { folders: [{ id: 1 }, { id: 2 }] },
+      submissionCount: 9,
+    });
+
+    assert.dom('.import-review.workspace').exists();
+    assert
+      .dom('.import-review.workspace')
+      .includesText('Workspace to be created');
+    assert.dom('.item-card.name').includesText('Imported Workspace');
+    assert.dom('.item-card.description').includesText('owner_two');
+    assert.dom('.workspace-stats li:first-child .stat-number').hasText('9');
+    assert.dom('.workspace-stats li:last-child .stat-number').hasText('2');
+  });
+
+  test('it builds workspace link with submission route when a submission exists', async function (assert) {
+    await renderComponent(this, {
+      workspaceName: 'Imported Workspace',
+      createdWorkspace: {
+        _id: 'workspace-1',
+        submissions: ['submission-1'],
+      },
+    });
+
+    assert.dom('.import-review.workspace').includesText('Created Workspace');
+    assert
+      .dom('.import-review.workspace a')
+      .hasAttribute(
+        'href',
+        '/#/workspaces/workspace-1/submissions/submission-1'
+      );
+  });
+
+  test('it builds workspace link with /work fallback when submissions are absent', async function (assert) {
+    await renderComponent(this, {
+      workspaceName: 'Imported Workspace',
+      createdWorkspace: {
+        _id: 'workspace-2',
+        submissions: [],
+      },
+    });
+
+    assert
+      .dom('.import-review.workspace a')
+      .hasAttribute('href', '/#/workspaces/workspace-2/work');
+  });
+
+  test('it invokes workspace error reset callback from Ui::ErrorBox', async function (assert) {
+    await renderComponent(this, {
+      workspaceName: 'Imported Workspace',
+      createWorkspaceError: 'Workspace creation failed',
+    });
+
+    assert.dom('.error-box-stub').exists();
+    assert.dom('.error-text').hasText('Workspace creation failed');
+
+    await click('.dismiss-error');
+
+    assert.strictEqual(
+      this.resetWorkspaceErrorCount,
+      1,
+      'reset callback is called once'
+    );
+  });
+
+  test('it renders assignment-to-be-created summary details', async function (assert) {
+    await renderComponent(this, {
+      assignmentName: 'Assignment A',
+      selectedProblem: { id: 'problem-2', title: 'Quadratic Functions' },
+      selectedSection: { id: 'section-2', name: 'Algebra 2' },
+    });
+
+    assert
+      .dom('.import-review.assignment')
+      .includesText('Assignment to be created')
+      .includesText('Assignment A')
+      .includesText('Quadratic Functions')
+      .includesText('Algebra 2');
+  });
+});


### PR DESCRIPTION
### Description
This PR upgrades **Import Work Step 6** to modern Ember and adds targeted integration tests for the Step 6 review/create flow.

### Changes
- Migrated `import-work-step6` JS from classic component style to Glimmer class:
  - `Component.extend` -> class component
  - macro/computed state (`or`, `computed`) -> explicit getters
  - `actions` hash -> `@action` methods (`next`, `back`)
  - callback calls now use guarded `this.args` invocation
- Modernized Step 6 template:
  - replaced legacy `{{action ...}}` handlers with `{{on "click" ...}}`
  - updated workspace error reset binding to use passed callback arg
  - removed unsafe triple-curly helper output path for privacy icon rendering
  - cleaned template whitespace/layout lint issues without changing user-visible behavior
- Cleaned parent Step 6 invocation:
  - removed unused `@store={{this.store}}` from `import-work-container`
- Added new integration tests for Step 6:
  - created `tests/integration/components/import-work-step6-test.js`
  - added reusable `renderComponent()` helper + `Ui::ErrorBox` stub
  - covered summary/default state, callback behavior, loading branches, workspace preview, workspace link generation, error reset callback, and assignment summary rendering

### Testing (UI + Integration)

#### UI
- Verified Step 6 review state shows expected summary copy before create.
- Verified Back/Create button behavior and visibility changes across loading/success states.
- Verified workspace/assignment review sections render with expected values.
- Verified post-merge flow behavior in enc-test for Step 6 interactions.

#### Integration
- Added **11 integration tests** in:
  - `tests/integration/components/import-work-step6-test.js`
 - All Tests Pass