### PR TITLE
Fix Student List Flicker and Image Selection Render and cover additional testing

### DIFF
--- a/app/components/draggable-selection.hbs
+++ b/app/components/draggable-selection.hbs
@@ -15,7 +15,7 @@
         {{#if this.isImage}}
           <img
             class='img-tag-thmb'
-            src={{@selection.imageTagLink}}
+            src={{this.imageSource}}
             alt={{@selection.text}}
           />
           <div class='overlay'>
@@ -48,7 +48,7 @@
   {{#if this.isExpanded}}
     <div class='full-image'>
       <i class='fas fa-times' {{on 'click' this.expandImage}}></i>
-      <img src={{@selection.imageTagLink}} alt={{@selection.text}} />
+      <img src={{this.imageSource}} alt={{@selection.text}} />
     </div>
   {{/if}}
 </div>

--- a/app/components/draggable-selection.js
+++ b/app/components/draggable-selection.js
@@ -89,8 +89,14 @@ export default class DraggableSelectionComponent extends Component {
   }
 
   get isImage() {
-    const imageTagLink = this.args.selection.imageTagLink;
-    return imageTagLink ? imageTagLink.length > 0 : false;
+    const source = this.imageSource;
+    return typeof source === 'string' && source.length > 0;
+  }
+
+  get imageSource() {
+    return (
+      this.args.selection.imageTagLink || this.args.selection.imageSrc || ''
+    );
   }
 
   get linkToClassName() {
@@ -202,7 +208,9 @@ export default class DraggableSelectionComponent extends Component {
   }
 
   @action
-  expandImage() {
+  expandImage(event) {
+    event?.preventDefault?.();
+    event?.stopPropagation?.();
     if (!this.isVmtClip) {
       this.isExpanded = !this.isExpanded;
     }

--- a/app/components/import-work-container.js
+++ b/app/components/import-work-container.js
@@ -205,7 +205,7 @@ export default class ImportWorkComponent extends Component {
       targetStep = 2;
     }
     if (targetStep > 3 && this.uploadedFiles.length === 0) {
-      targetStep = 3;
+      targetStep = 1;
     }
     if (targetStep > 3 && this.uploadedFiles.length > 0) {
       this.loadStudentMatching();

--- a/app/components/import-work-step2.js
+++ b/app/components/import-work-step2.js
@@ -43,6 +43,28 @@ export default class ImportWorkStep2Component extends Component {
     return [];
   }
 
+  getRecordId(record) {
+    if (!record) {
+      return null;
+    }
+    return (
+      record.id ||
+      record._id ||
+      (typeof record.get === 'function'
+        ? record.get('id') || record.get('_id')
+        : null)
+    );
+  }
+
+  isSameSection(left, right) {
+    const leftId = this.getRecordId(left);
+    const rightId = this.getRecordId(right);
+    if (leftId && rightId) {
+      return String(leftId) === String(rightId);
+    }
+    return left === right;
+  }
+
   notifySelectionChanged() {
     if (typeof this.args.onSelectionChange === 'function') {
       this.args.onSelectionChange({
@@ -77,6 +99,10 @@ export default class ImportWorkStep2Component extends Component {
 
     const section = this.store.peekRecord('section', val);
     if (this.utils.isNullOrUndefined(section)) {
+      return;
+    }
+
+    if (this.isSameSection(this.selectedSection, section)) {
       return;
     }
 

--- a/app/components/import-work-step4.js
+++ b/app/components/import-work-step4.js
@@ -10,6 +10,7 @@ export default class ImportWorkStep4Component extends Component {
   @tracked addedStudentNames = [];
   @tracked isMatchingIncompleteError = null;
   @tracked isReadyToReviewAnswers = false;
+  @tracked isRosterExpanded = false;
 
   get answers() {
     return Array.isArray(this.args.answers) ? this.args.answers : [];
@@ -32,6 +33,10 @@ export default class ImportWorkStep4Component extends Component {
       return [];
     }
     return Object.keys(this.studentMap).map((key) => this.studentMap[key]);
+  }
+
+  get studentCount() {
+    return this.displayList.length;
   }
 
   @action
@@ -230,6 +235,11 @@ export default class ImportWorkStep4Component extends Component {
   @action
   checkStatus() {
     return this.updateMatchingStatus();
+  }
+
+  @action
+  toggleRoster() {
+    this.isRosterExpanded = !this.isRosterExpanded;
   }
 
   @action

--- a/app/components/selectize-input.js
+++ b/app/components/selectize-input.js
@@ -89,6 +89,13 @@ export default class SelectizeInputComponent extends Component {
       return;
     }
 
+    if (
+      this.args.preserveCurrentItemsOnOptionsUpdate &&
+      this.selectizeInstance.isOpen
+    ) {
+      return;
+    }
+
     // Silent refresh prevents selectize sync from firing remove/add callbacks
     this.selectizeInstance.clearOptions(true);
     this.selectizeInstance.addOption(this.options || []);
@@ -157,6 +164,10 @@ export default class SelectizeInputComponent extends Component {
 
     if (this.args.isAsync) {
       hash.load = this.addItemsSelectize.bind(this);
+    }
+
+    if (this.args.preserveCurrentItemsOnOptionsUpdate) {
+      hash.onDropdownClose = () => this.updateSelectizeOptions();
     }
 
     return hash;

--- a/app/components/undraggable-selection.hbs
+++ b/app/components/undraggable-selection.hbs
@@ -15,11 +15,11 @@
         {{#if this.isImage}}
           <img
             class='img-tag-thmb'
-            src={{@selection.imageTagLink}}
+            src={{this.imageSource}}
             alt={{@selection.text}}
           />
           <div class='overlay'>
-            <button type='button' {{action 'expandImage'}}><i
+            <button type='button' {{on 'click' this.expandImage}}><i
                 class={{this.overlayIcon}}
               ></i></button>
           </div>
@@ -32,8 +32,10 @@
 
   {{#if this.isExpanded}}
     <div class='full-image'>
-      <i class='fas fa-times' {{action 'expandImage'}}></i>
-      <img src={{@selection.imageTagLink}} alt={{@selection.text}} />
+      <button type='button' {{on 'click' this.expandImage}}>
+        <i class='fas fa-times'></i>
+      </button>
+      <img src={{this.imageSource}} alt={{@selection.text}} />
     </div>
   {{/if}}
 </div>

--- a/app/components/undraggable-selection.js
+++ b/app/components/undraggable-selection.js
@@ -61,8 +61,14 @@ export default class UndraggableSelectionComponent extends Component {
   }
 
   get isImage() {
-    const imageTagLink = this.args.selection.imageTagLink;
-    return imageTagLink ? imageTagLink.length > 0 : false;
+    const source = this.imageSource;
+    return typeof source === 'string' && source.length > 0;
+  }
+
+  get imageSource() {
+    return (
+      this.args.selection.imageTagLink || this.args.selection.imageSrc || ''
+    );
   }
 
   get isText() {
@@ -162,7 +168,9 @@ export default class UndraggableSelectionComponent extends Component {
   }
 
   @action
-  expandImage() {
+  expandImage(event) {
+    event?.preventDefault?.();
+    event?.stopPropagation?.();
     if (!this.isVmtClip) {
       this.isExpanded = !this.isExpanded;
     }

--- a/app/styles/_import.scss
+++ b/app/styles/_import.scss
@@ -200,12 +200,46 @@
     @include flex-item(1, flex-start, .15 0 auto);
     .section-name {
       font-size: 1.2em;
-      margin-bottom: 10px;
+      margin: 0 0 6px;
       font-weight: $main-font-weight;
       color: $dark-font-color;
     }
+    .student-count {
+      margin: 0 0 10px;
+      font-size: 1em;
+      color: $primary-font-color;
+    }
+    .student-list-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-bottom: 10px;
+      button {
+        margin: 0;
+      }
+    }
+    .roster-toggle {
+      margin: 0;
+    }
+    .student-roster-scroll {
+      margin-top: 0;
+      max-height: 45vh;
+      overflow-y: auto;
+      padding-right: 8px;
+      border: 1px solid $input-border;
+      border-radius: 4px;
+      background: white;
+      padding: 8px 10px;
+    }
+    .student-roster-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
     .student-name {
-      margin: 25px 0;
+      margin: 0;
+      padding: 3px 0;
+      line-height: 1.2;
     }
   }
   .matching-container {

--- a/app/templates/components/import-work-step4.hbs
+++ b/app/templates/components/import-work-step4.hbs
@@ -18,16 +18,6 @@
         class='new-link'
       >Open class roster</LinkTo>, Continue the flow, come back and then click Refresh Students.
     </p>
-    <div class='nav-btn-container'>
-      <button
-        class='primary-button cancel-button'
-        type='button'
-        disabled={{@isFetchingSectionStudents}}
-        {{on 'click' this.refreshStudents}}
-      >
-        {{if @isFetchingSectionStudents 'Refreshing...' 'Refresh Students'}}
-      </button>
-    </div>
   {{else if @selectedValue}}
     <p class="sub-input-label">
       No class is selected right now. Go back to Step 2, pick a class, then return here.
@@ -38,13 +28,38 @@
     <div class="student-list">
       {{#if @selectedSection}}
         <h4 class="section-name">Class: {{@selectedSection.name}}</h4>
-        <p class="student-name">Students:</p>
-        {{#if this.displayList.length}}
-          {{#each this.displayList as |student|}}
-            <p class="student-name">{{student.username}}</p>
-          {{/each}}
-        {{else}}
-          <p class="student-name">No students in this class yet.</p>
+        <p class="student-count">{{this.studentCount}} students</p>
+        <div class='student-list-actions'>
+          <button
+            class='primary-button cancel-button'
+            type='button'
+            disabled={{@isFetchingSectionStudents}}
+            {{on 'click' this.refreshStudents}}
+          >
+            {{if @isFetchingSectionStudents 'Refreshing...' 'Refresh Students'}}
+          </button>
+          <button
+            class='primary-button cancel-button roster-toggle'
+            type='button'
+            aria-expanded={{if this.isRosterExpanded 'true' 'false'}}
+            {{on 'click' this.toggleRoster}}
+          >
+            {{if this.isRosterExpanded 'Hide Student List' 'Show Student List'}}
+          </button>
+        </div>
+
+        {{#if this.isRosterExpanded}}
+          <div class='student-roster-scroll'>
+            {{#if this.displayList.length}}
+              <ul class='student-roster-list'>
+                {{#each this.displayList as |student|}}
+                  <li class='student-name'>{{student.username}}</li>
+                {{/each}}
+              </ul>
+            {{else}}
+              <p class='student-name'>No students in this class yet.</p>
+            {{/if}}
+          </div>
         {{/if}}
       {{else}}
         <p>Not using class for matching.</p>

--- a/tests/integration/components/draggable-selection-test.js
+++ b/tests/integration/components/draggable-selection-test.js
@@ -244,4 +244,24 @@ module('Integration | Component | draggable-selection', function (hooks) {
     assert.strictEqual(alert.modalCalls[0][3], 'Yes, delete it');
     assert.strictEqual(deletedSelection, selection);
   });
+
+  test('renders image from imageSrc fallback when imageTagLink is missing', async function (assert) {
+    const fallbackSrc = 'https://example.com/fallback-image.png';
+
+    await renderSelection(this, {
+      selection: createSelection({
+        text: 'image selection',
+        imageTagLink: '',
+        imageSrc: fallbackSrc,
+        workspace: { id: 'ws-1' },
+        submission: { id: 'sub-1' },
+      }),
+      canDeleteSelections: true,
+    });
+
+    assert.dom('.img-tag-thmb').hasAttribute('src', fallbackSrc);
+
+    await click('.overlay button');
+    assert.dom('.full-image img').hasAttribute('src', fallbackSrc);
+  });
 });

--- a/tests/integration/components/import-work-container-test.js
+++ b/tests/integration/components/import-work-container-test.js
@@ -1,0 +1,118 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, settled } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import Service from '@ember/service';
+import Component from '@glimmer/component';
+
+class StoreStub extends Service {
+  peekRecord(modelName, id) {
+    if (modelName === 'problem' && id === 'problem-1') {
+      return { id: 'problem-1', title: 'Problem 1' };
+    }
+    return null;
+  }
+
+  async findRecord() {
+    throw new Error('record not found');
+  }
+}
+
+class UtilityMethodsStub extends Service {
+  isNonEmptyObject(value) {
+    return (
+      !!value && typeof value === 'object' && Object.keys(value).length > 0
+    );
+  }
+}
+
+class ErrorHandlingStub extends Service {
+  handleErrors() {}
+}
+
+class CurrentUserStub extends Service {
+  user = { id: 'user-1', username: 'teacher' };
+}
+
+class SweetAlertStub extends Service {
+  showToast() {}
+}
+
+module('Integration | Component | import-work-container', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.owner.register('service:store', StoreStub);
+    this.owner.register('service:utility-methods', UtilityMethodsStub);
+    this.owner.register('service:error-handling', ErrorHandlingStub);
+    this.owner.register('service:current-user', CurrentUserStub);
+    this.owner.register('service:currentUser', CurrentUserStub);
+    this.owner.register('service:sweet-alert', SweetAlertStub);
+
+    this.owner.register(
+      'component:details-list-item',
+      class extends Component {}
+    );
+    this.owner.register(
+      'template:components/details-list-item',
+      hbs`<li class='details-list-item-stub'></li>`
+    );
+
+    const stepTemplates = {
+      1: hbs`<div data-test-step='1'></div>`,
+      2: hbs`<div data-test-step='2'></div>`,
+      3: hbs`<div data-test-step='3'></div>`,
+      4: hbs`<div data-test-step='4'></div>`,
+      5: hbs`<div data-test-step='5'></div>`,
+      6: hbs`<div data-test-step='6'></div>`,
+    };
+
+    Object.keys(stepTemplates).forEach((step) => {
+      this.owner.register(
+        `component:import-work-step${step}`,
+        class extends Component {}
+      );
+      this.owner.register(
+        `template:components/import-work-step${step}`,
+        stepTemplates[step]
+      );
+    });
+
+    this.owner.register('component:ui/error-box', class extends Component {});
+    this.owner.register(
+      'template:components/ui/error-box',
+      hbs`<div class='error-box-stub'></div>`
+    );
+  });
+
+  test('it resets to step 1 when stale resume params point past upload with missing files', async function (assert) {
+    this.setProperties({
+      model: {
+        sections: [],
+        folderSets: [],
+        problems: [{ id: 'problem-1', title: 'Problem 1' }],
+      },
+      users: [],
+      initialStep: '4',
+      initialProblemId: 'problem-1',
+      initialUploadedFileIds: 'missing-image-id',
+    });
+
+    await render(hbs`
+      <ImportWorkContainer
+        @model={{this.model}}
+        @users={{this.users}}
+        @initialStep={{this.initialStep}}
+        @initialProblemId={{this.initialProblemId}}
+        @initialUploadedFileIds={{this.initialUploadedFileIds}}
+      />
+    `);
+    await settled();
+
+    assert
+      .dom("[data-test-step='1']")
+      .exists('stale resume without files falls back to step 1');
+    assert.dom("[data-test-step='3']").doesNotExist();
+    assert.dom("[data-test-step='4']").doesNotExist();
+  });
+});

--- a/tests/integration/components/import-work-step2-test.js
+++ b/tests/integration/components/import-work-step2-test.js
@@ -323,4 +323,21 @@ module('Integration | Component | import-work-step2', function (hooks) {
     );
     assert.dom('.error-box-stub').exists();
   });
+
+  test('it ignores duplicate add callbacks for the already selected section', async function (assert) {
+    await renderComponent(this, {
+      selectedValue: true,
+      selectedSection: this.sectionRecord,
+    });
+
+    assert.strictEqual(this.selectionPayloads.length, 0);
+
+    await click('.stub-add-section');
+
+    assert.strictEqual(
+      this.selectionPayloads.length,
+      0,
+      'duplicate add with same section id is ignored'
+    );
+  });
 });

--- a/tests/integration/components/import-work-step4-test.js
+++ b/tests/integration/components/import-work-step4-test.js
@@ -146,10 +146,12 @@ module('Integration | Component | import-work-step4', function (hooks) {
     });
 
     assert.dom('.section-name').hasText('Class: Algebra 1');
-    assert.dom('.student-list').includesText('amy_student');
-    assert
-      .dom('.primary-button.cancel-button')
-      .includesText('Refresh Students');
+    assert.dom('.student-count').hasText('1 students');
+    assert.dom('.student-list-actions').includesText('Refresh Students');
+    assert.dom('.student-list-actions').includesText('Show Student List');
+
+    await click('.roster-toggle');
+    assert.dom('.student-roster-scroll').includesText('amy_student');
   });
 
   test('it shows no-class guidance when class mode is enabled but no class is selected', async function (assert) {
@@ -168,9 +170,46 @@ module('Integration | Component | import-work-step4', function (hooks) {
       selectedSection: { id: 'section-1', name: 'Algebra 1' },
     });
 
-    await click('.primary-button.cancel-button');
+    const refreshButton = document.querySelector(
+      '.student-list-actions .primary-button.cancel-button'
+    );
+    await click(refreshButton);
 
     assert.strictEqual(this.refreshCount, 1, 'refresh callback is invoked');
+  });
+
+  test('it toggles roster visibility and aria-expanded state', async function (assert) {
+    await renderComponent(this, {
+      selectedSection: { id: 'section-1', name: 'Algebra 1' },
+      studentMap: {
+        [MONGO_ID]: { id: MONGO_ID, username: 'amy_student' },
+        another: { id: 'another', username: 'brian_student' },
+      },
+    });
+
+    assert.dom('.student-roster-scroll').doesNotExist();
+    assert.dom('.roster-toggle').hasAttribute('aria-expanded', 'false');
+
+    await click('.roster-toggle');
+
+    assert.dom('.roster-toggle').hasAttribute('aria-expanded', 'true');
+    assert.dom('.student-roster-list li').exists({ count: 2 });
+
+    await click('.roster-toggle');
+    assert.dom('.student-roster-scroll').doesNotExist();
+  });
+
+  test('it shows refreshing label/disabled state while fetching section students', async function (assert) {
+    await renderComponent(this, {
+      selectedSection: { id: 'section-1', name: 'Algebra 1' },
+      isFetchingSectionStudents: true,
+    });
+
+    const refreshButton = document.querySelector(
+      '.student-list-actions .primary-button.cancel-button'
+    );
+    assert.dom(refreshButton).hasText('Refreshing...');
+    assert.true(refreshButton.disabled, 'refresh button is disabled');
   });
 
   test('it calls onBack with -1 from Back button', async function (assert) {

--- a/tests/integration/components/selectize-input-test.js
+++ b/tests/integration/components/selectize-input-test.js
@@ -1,0 +1,108 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, settled } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import $ from 'jquery/dist/jquery.js';
+
+module('Integration | Component | selectize-input', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.originalSelectize = $.fn.selectize;
+    this.selectizeCalls = {
+      clearOptions: 0,
+      addOption: 0,
+      setValue: 0,
+      clear: 0,
+      refreshOptions: 0,
+    };
+
+    let latestInstance = null;
+    this.getLatestInstance = () => latestInstance;
+
+    const calls = this.selectizeCalls;
+    $.fn.selectize = function () {
+      latestInstance = {
+        isOpen: false,
+        items: [],
+        clearOptions() {
+          calls.clearOptions += 1;
+        },
+        addOption() {
+          calls.addOption += 1;
+        },
+        setValue(values) {
+          calls.setValue += 1;
+          this.items = Array.isArray(values) ? values.slice() : [values];
+        },
+        clear() {
+          calls.clear += 1;
+          this.items = [];
+        },
+        refreshOptions() {
+          calls.refreshOptions += 1;
+        },
+        disable() {},
+        enable() {},
+      };
+
+      return [{ selectize: latestInstance }];
+    };
+  });
+
+  hooks.afterEach(function () {
+    $.fn.selectize = this.originalSelectize;
+  });
+
+  test('it skips option refresh while dropdown is open when preserveCurrentItemsOnOptionsUpdate is enabled', async function (assert) {
+    this.setProperties({
+      options: [{ id: 'user-1', username: 'alex' }],
+      items: ['user-1'],
+    });
+
+    await render(hbs`
+      <SelectizeInput
+        @inputId='student-select'
+        @initialOptions={{this.options}}
+        @initialItems={{this.items}}
+        @valueField='id'
+        @labelField='username'
+        @searchField='username'
+        @maxItems={{10}}
+        @preserveCurrentItemsOnOptionsUpdate={{true}}
+      />
+    `);
+    await settled();
+
+    const instance = this.getLatestInstance();
+    assert.ok(instance, 'selectize instance is initialized');
+    const initialClearOptionsCalls = this.selectizeCalls.clearOptions;
+
+    instance.isOpen = true;
+    this.set('options', [
+      { id: 'user-1', username: 'alex' },
+      { id: 'user-2', username: 'sam' },
+    ]);
+    await settled();
+
+    assert.strictEqual(
+      this.selectizeCalls.clearOptions,
+      initialClearOptionsCalls,
+      'options are not reset while dropdown is open'
+    );
+
+    instance.isOpen = false;
+    this.set('options', [
+      { id: 'user-1', username: 'alex' },
+      { id: 'user-2', username: 'sam' },
+      { id: 'user-3', username: 'jamie' },
+    ]);
+    await settled();
+
+    assert.strictEqual(
+      this.selectizeCalls.clearOptions,
+      initialClearOptionsCalls + 1,
+      'options refresh resumes when dropdown is closed'
+    );
+  });
+});

--- a/tests/integration/components/undraggable-selection-test.js
+++ b/tests/integration/components/undraggable-selection-test.js
@@ -1,0 +1,55 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import Service from '@ember/service';
+
+class UtilityMethodsStub extends Service {
+  getTimeStringFromMs(ms) {
+    return String(ms ?? '');
+  }
+}
+
+class CurrentSelectionStub extends Service {
+  isCurrentSelection() {
+    return false;
+  }
+}
+
+module('Integration | Component | undraggable-selection', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.owner.register('service:utility-methods', UtilityMethodsStub);
+    this.owner.register('service:current-selection', CurrentSelectionStub);
+    this.owner.register('service:currentSelection', CurrentSelectionStub);
+  });
+
+  test('renders image from imageSrc fallback when imageTagLink is missing', async function (assert) {
+    const fallbackSrc = 'https://example.com/fallback-image.png';
+
+    this.set('selection', {
+      id: 'sel-1',
+      text: 'selection image',
+      createDate: Date.now(),
+      imageTagLink: '',
+      imageSrc: fallbackSrc,
+      createdBy: { id: 'u1', username: 'owner' },
+      workspace: {
+        id: 'ws-1',
+        workspaceType: 'individual',
+        get(key) {
+          return this[key];
+        },
+      },
+      submission: { id: 'sub-1' },
+    });
+
+    await render(hbs`<UndraggableSelection @selection={{this.selection}} />`);
+
+    assert.dom('.img-tag-thmb').hasAttribute('src', fallbackSrc);
+
+    await click('.overlay button');
+    assert.dom('.full-image img').hasAttribute('src', fallbackSrc);
+  });
+});


### PR DESCRIPTION
## Description
This PR fixes import workflow reliability issues and selection rendering issues in the Ember frontend.

It addresses:
- Step 4 roster usability for larger classes
- Step 2 duplicate section callback assertion path
- Selectize dropdown flicker while selecting from long lists
- Stale resume sessions landing in the wrong step
- Selection image rendering fallback when `imageTagLink` is missing

## Changes
- Added Step 4 collapsible roster state and student count summary in component/template.
- Added Step 4 roster container styles with internal scroll and tighter row spacing.
- Added duplicate section identity guard in Step 2 to avoid redundant tracked writes.
- Added selectize option refresh guard when dropdown is open and preserve flag is enabled.
- Changed stale resume fallback in container logic from Step 3 to Step 1 when no uploaded files exist.
- Added `imageSource` fallback (`imageTagLink || imageSrc`) for both draggable and undraggable selection components.
- Updated selection expand/close handlers to stable click handling with modern template bindings.
- Added/updated integration coverage for all above paths.

## Testing

### UI
- Verified Step 4 class summary, refresh button, show/hide roster toggle, and scroll behavior.
- Verified class switching and student matching flow still works.
- Verified stale resume/import session now returns to Step 1 when file state is missing.
- Verified selection thumbnail and expanded view both render fallback image source.

### Integration
- `tests/integration/components/import-work-step4-test.js`
- `tests/integration/components/import-work-step2-test.js`
- `tests/integration/components/selectize-input-test.js`
- `tests/integration/components/import-work-container-test.js`
- `tests/integration/components/draggable-selection-test.js`
- `tests/integration/components/undraggable-selection-test.js`
