### PR TITLE
fix(assignment-api): honor workspace creation toggle(yes/no)

### DIFF
--- a/app_server/datasource/api/assignmentApi.js
+++ b/app_server/datasource/api/assignmentApi.js
@@ -325,17 +325,21 @@ const postAssignment = async (req, res, next) => {
     let linkedWorkspaces;
     let parentWorkspace;
     let parentWorkspaceError;
-
-    const [err, teacherWorkspaces] = await generateTeacherWorkspace(
-      assignment,
-      user
-    );
-
-    if (err) {
-      console.log(err);
-    }
+    let teacherWorkspaces = [];
 
     if (doCreateLinkedWorkspaces) {
+      const [teacherWorkspacesErr, createdTeacherWorkspaces] =
+        await generateTeacherWorkspace(assignment, user);
+
+      if (teacherWorkspacesErr) {
+        logger.error(
+          'generateTeacherWorkspaceErr: ',
+          teacherWorkspacesErr?.message || teacherWorkspacesErr
+        );
+      } else if (isNonEmptyArray(createdTeacherWorkspaces)) {
+        teacherWorkspaces = createdTeacherWorkspaces;
+      }
+
       // create a linked workspace for each student in assignment
       await assignment
         .populate('students')

--- a/test/mocha/assignmentTest.js
+++ b/test/mocha/assignmentTest.js
@@ -128,24 +128,30 @@ describe('Assignment CRUD operations by account type', function () {
 
         describe('Posting assignment without name', function () {
           let body = fixtures.withoutName.valid.body;
-          it('should post a new assignment', (done) => {
-            agent
-              .post(baseUrl)
-              .send({ assignment: body })
-              .end((err, res) => {
-                if (err) {
-                  throw err;
-                }
-                expect(res).to.have.status(200);
-                expect(res.body.assignment).to.have.any.keys(
-                  'problem',
-                  'assignment'
-                );
-                expect(res.body.assignment.name).to.eql(
-                  fixtures.withoutName.valid.expectedResultName
-                );
-                done();
-              });
+          it('should post a new assignment without creating linked workspaces', async function () {
+            const beforeWorkspacesRes = await agent.get('/api/workspaces');
+            const beforeWorkspaceCount =
+              beforeWorkspacesRes.body.workspaces.length;
+
+            const res = await agent.post(baseUrl).send({ assignment: body });
+
+            expect(res).to.have.status(200);
+            expect(res.body.assignment).to.have.any.keys(
+              'problem',
+              'assignment'
+            );
+            expect(res.body.assignment.name).to.eql(
+              fixtures.withoutName.valid.expectedResultName
+            );
+
+            const afterWorkspacesRes = await agent.get('/api/workspaces');
+            const afterWorkspaceCount =
+              afterWorkspacesRes.body.workspaces.length;
+
+            expect(afterWorkspaceCount).to.eql(
+              beforeWorkspaceCount,
+              'workspace count should not change when doCreateLinkedWorkspaces=false'
+            );
           });
         });
       }


### PR DESCRIPTION
## Description
This PR fixes assignment creation behavior so linked teacher/student workspaces are only created when `doCreateLinkedWorkspaces` is enabled.

## Changes
- Moved `generateTeacherWorkspace(...)` under `if (doCreateLinkedWorkspaces)`.
- Initialized `teacherWorkspaces` safely to an empty array.
- Improved error logging path around teacher workspace generation.
- Added regression test to verify assignment creation does not increase workspace count when linked workspace creation is disabled.

## Testing

### UI
- If you select WP creation as "No", WP wont be created.

### Integration
- Updated mocha test:
  - `test/mocha/assignmentTest.js`
- Test validates workspace count before/after assignment POST when `doCreateLinkedWorkspaces=false`.