### PR TITLE
Upgrade ws-copy-review to a Glimmer component

### DIFF
--- a/app/components/ws-copy-review.js
+++ b/app/components/ws-copy-review.js
@@ -1,15 +1,16 @@
-import Component from '@ember/component';
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
 
-export default Component.extend({
-  elementId: 'ws-copy-review',
-  createDate: Date.now(),
+export default class WsCopyReviewComponent extends Component {
+  createDate = Date.now();
 
-  actions: {
-    next() {
-      this.onProceed();
-    },
-    back() {
-      this.onBack(-1);
-    },
-  },
-});
+  @action
+  next() {
+    this.args.onProceed();
+  }
+
+  @action
+  back() {
+    this.args.onBack(-1);
+  }
+}

--- a/app/templates/components/ws-copy-review.hbs
+++ b/app/templates/components/ws-copy-review.hbs
@@ -1,70 +1,88 @@
-<p class="input-label">Workspace Review
-  <span class="info-text-tip simptip-position-right simptip-multiline simptip-smooth" data-tooltip="This is a representation of the new workspace you are creating">
-    <i class="fas fa-info-circle info-icon"></i>
-  </span>
-</p>
-<p class="sub-input-label">Please review the details of requested workspace. If everything looks correct, go ahead and create your new workspace</p>
+<div id='ws-copy-review'>
+  <p class='input-label'>Workspace Review
+    <span
+      class='info-text-tip simptip-position-right simptip-multiline simptip-smooth'
+      data-tooltip='This is a representation of the new workspace you are creating'
+    >
+      <i class='fas fa-info-circle info-icon'></i>
+    </span>
+  </p>
+  <p class='sub-input-label'>Please review the details of requested workspace.
+    If everything looks correct, go ahead and create your new workspace</p>
 
-{{#if showLoadingMessage}}
-  <p class="loading-message">Your copy request is in progress. Thank you for your patience.</p>
-{{/if}}
+  {{#if @showLoadingMessage}}
+    <p class='loading-message'>Your copy request is in progress. Thank you for
+      your patience.</p>
+  {{/if}}
 
-<div class="workspace-copy-card">
-  <div class="item-card-container">
-    <div class="item-card row-1">
-      <div class="item-card privacy">
-        <span class="privacy-icon">
-            <span class="info-text-tip simptip-position-right simptip-smooth" data-tooltip={{mode}}>
-              {{{public-private mode}}}
+  <div class='workspace-copy-card'>
+    <div class='item-card-container'>
+      <div class='item-card row-1'>
+        <div class='item-card privacy'>
+          <span class='privacy-icon'>
+            <span
+              class='info-text-tip simptip-position-right simptip-smooth'
+              data-tooltip={{@mode}}
+            >
+              {{public-private @mode}}
             </span>
-        </span>
-        <span class="date">{{format-date createDate 'L'}}</span>
+          </span>
+          <span class='date'>{{format-date this.createDate 'L'}}</span>
+        </div>
       </div>
-    </div>
-    <div class="item-card row-2">
-      <div class="item-card name">
-        <span>{{{name}}}</span>
+      <div class='item-card row-2'>
+        <div class='item-card name'>
+          <span>{{@name}}</span>
+        </div>
       </div>
-    </div>
-    <div class="item-card row-3">
-      <div class="item-card description">
-        {{{owner.username}}}
+      <div class='item-card row-3'>
+        <div class='item-card description'>
+          {{@owner.username}}
+        </div>
       </div>
-    </div>
-    <div class="item-card row-4">
-      <div class="item-card status">
-        <ul class="workspace-stats">
-          <li>
-            <p class="stat-header">Submissions</p>
-            <p class="stat-number">{{recordCounts.submissions}}</p>
-          </li>
-          <li>
-            <p class="stat-header">Selections</p>
-            <p class="stat-number">{{recordCounts.selections}}</p>
-          </li>
-          <li>
-            <p class="stat-header">Comments</p>
-            <p class="stat-number">{{recordCounts.comments}}</p>
-          </li>
-          <li>
-            <p class="stat-header">Responses</p>
-            <p class="stat-number">{{recordCounts.responses}}</p>
-          </li>
-          <li>
-            <p class="stat-header">Folders</p>
-            <p class="stat-number">{{recordCounts.folders}}</p>
-          </li>
-          <li>
-            <p class="stat-header">Collaborators</p>
-            <p class="stat-number">{{recordCounts.collaborators}}</p>
-          </li>
-        </ul>
+      <div class='item-card row-4'>
+        <div class='item-card status'>
+          <ul class='workspace-stats'>
+            <li>
+              <p class='stat-header'>Submissions</p>
+              <p class='stat-number'>{{@recordCounts.submissions}}</p>
+            </li>
+            <li>
+              <p class='stat-header'>Selections</p>
+              <p class='stat-number'>{{@recordCounts.selections}}</p>
+            </li>
+            <li>
+              <p class='stat-header'>Comments</p>
+              <p class='stat-number'>{{@recordCounts.comments}}</p>
+            </li>
+            <li>
+              <p class='stat-header'>Responses</p>
+              <p class='stat-number'>{{@recordCounts.responses}}</p>
+            </li>
+            <li>
+              <p class='stat-header'>Folders</p>
+              <p class='stat-number'>{{@recordCounts.folders}}</p>
+            </li>
+            <li>
+              <p class='stat-header'>Collaborators</p>
+              <p class='stat-number'>{{@recordCounts.collaborators}}</p>
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
   </div>
-</div>
 
-<div class="nav-btn-container">
-  <button class="primary-button cancel-button" type="button" {{action "back"}}>Back</button>
-  <button class="primary-button" type="button" {{action "next"}}>Create</button>
+  <div class='nav-btn-container'>
+    <button
+      class='primary-button cancel-button'
+      type='button'
+      {{on 'click' this.back}}
+    >Back</button>
+    <button
+      class='primary-button'
+      type='button'
+      {{on 'click' this.next}}
+    >Create</button>
+  </div>
 </div>

--- a/tests/integration/components/ws-copy-review-test.js
+++ b/tests/integration/components/ws-copy-review-test.js
@@ -1,0 +1,86 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | ws-copy-review', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.setProperties({
+      mode: 'M',
+      workspaceOwner: { username: 'workspace_owner' },
+      name: 'Copied Workspace',
+      recordCounts: {
+        submissions: 6,
+        selections: 5,
+        comments: 4,
+        responses: 3,
+        folders: 2,
+        collaborators: 1,
+      },
+      showLoadingMessage: false,
+      proceedCount: 0,
+      backDirections: [],
+      onProceed: () => {
+        this.set('proceedCount', this.proceedCount + 1);
+      },
+      onBack: (direction) => {
+        this.set('backDirections', [...this.backDirections, direction]);
+      },
+    });
+  });
+
+  async function renderComponent() {
+    await render(hbs`
+      <WsCopyReview
+        @showLoadingMessage={{this.showLoadingMessage}}
+        @mode={{this.mode}}
+        @owner={{this.workspaceOwner}}
+        @name={{this.name}}
+        @onProceed={{this.onProceed}}
+        @onBack={{this.onBack}}
+        @recordCounts={{this.recordCounts}}
+      />
+    `);
+  }
+
+  test('it renders the workspace copy summary', async function (assert) {
+    await renderComponent();
+
+    assert.dom('#ws-copy-review').exists();
+    assert.dom('.item-card.name').hasText('Copied Workspace');
+    assert.dom('.item-card.description').hasText('workspace_owner');
+    assert.dom('.privacy-icon .fa-unlock').exists();
+    assert
+      .dom('.workspace-stats .stat-number')
+      .exists({ count: 6 }, 'all record counts are rendered');
+    assert
+      .dom('.workspace-stats')
+      .hasText(
+        'Submissions 6 Selections 5 Comments 4 Responses 3 Folders 2 Collaborators 1'
+      );
+  });
+
+  test('it displays the request progress message when requested', async function (assert) {
+    this.set('showLoadingMessage', true);
+
+    await renderComponent();
+
+    assert
+      .dom('.loading-message')
+      .hasText(
+        'Your copy request is in progress. Thank you for your patience.'
+      );
+  });
+
+  test('it sends the wizard navigation callbacks', async function (assert) {
+    await renderComponent();
+
+    await click('.cancel-button');
+    await click('.nav-btn-container .primary-button:not(.cancel-button)');
+
+    assert.deepEqual(this.backDirections, [-1], 'back moves one step');
+    assert.strictEqual(this.proceedCount, 1, 'create proceeds once');
+  });
+});


### PR DESCRIPTION
## Summary
This PR modernizes `ws-copy-review`, the final review step in the Copy Workspace component.

## Changes
- Migrated the component from Classic Ember to Glimmer.
- Replaced the actions hash with decorated class methods.
- Updated callback access to use component arguments.
- Replaced classic template actions with modern event handlers.
- Preserved the existing SCSS selector through an explicit wrapper.
- Replaced implicit template properties with named arguments.
- Removed unsafe triple-curly rendering.
- Added three focused integration tests.

## Behavior Preserved
- The review card displays the workspace details and record counts.
- Back returns the user to the previous wizard step.
- Create starts the workspace copy request.
- The progress message appears while the request is running.

## Manual UI Verification
1. Open the Copy Workspace workflow.
2. Continue to the final Review step.
3. Verify the workspace name, owner, privacy icon, and record counts.
4. Click Back and confirm the wizard returns to Permissions.
5. Return to Review and click Create.
6. Confirm the progress message and copy-request behavior.