### PR TITLE
AI drafts for image/OCR submissions (mainly to support bulk uploads)

### DIFF
--- a/app/components/ai-variant-comparison.js
+++ b/app/components/ai-variant-comparison.js
@@ -7,6 +7,7 @@ import { service } from '@ember/service';
 // TEMPORARY A/B TEST CODE
 export default class AiVariantComparisonComponent extends Component {
   @service('ai-draft') aiDraft;
+  @service('sweet-alert') alert;
   @tracked isLoading = false;
   @tracked error = null;
 
@@ -236,6 +237,24 @@ export default class AiVariantComparisonComponent extends Component {
     }
   }
 
+  // The upstream AI service returns HTTP 429 "Limit Exceeded" when our AWS tier
+  // monthly request quota is used up. Surface that to the user clearly instead
+  // of only writing "Error: ..." into the draft panels.
+  _isQuotaError(error) {
+    const message = (error?.message || '').toLowerCase();
+    return message.includes('limit exceeded') || message.includes('429');
+  }
+
+  _notifyDraftError(errors = []) {
+    const list = errors.filter(Boolean);
+    const message = list.some((error) => this._isQuotaError(error))
+      ? 'AI usage limit reached for this billing period. Draft generation is temporarily unavailable. Please try again later or contact an administrator.'
+      : list[0]?.message || 'Failed to generate AI draft. Please try again.';
+
+    this.error = message;
+    this.alert.showToast('error', message, 'bottom-end', 8000, false, null);
+  }
+
   _canLogReview(variantCode) {
     const draft = this._getDraft(variantCode);
     const rating = this._getRating(variantCode);
@@ -293,19 +312,27 @@ export default class AiVariantComparisonComponent extends Component {
   }
 
   get variantAButtonText() {
-    return this.loadingVariant === 'A' ? 'Generating...' : 'Generate A';
+    return this.isLoading || this.loadingVariant === 'A'
+      ? 'Generating...'
+      : 'Generate A';
   }
 
   get variantBButtonText() {
-    return this.loadingVariant === 'B' ? 'Generating...' : 'Generate B';
+    return this.isLoading || this.loadingVariant === 'B'
+      ? 'Generating...'
+      : 'Generate B';
   }
 
   get variantEButtonText() {
-    return this.loadingVariant === 'E' ? 'Generating...' : 'Generate E';
+    return this.isLoading || this.loadingVariant === 'E'
+      ? 'Generating...'
+      : 'Generate E';
   }
 
   get variantFButtonText() {
-    return this.loadingVariant === 'F' ? 'Generating...' : 'Generate F';
+    return this.isLoading || this.loadingVariant === 'F'
+      ? 'Generating...'
+      : 'Generate F';
   }
 
   get canBringDownA() {
@@ -415,7 +442,7 @@ export default class AiVariantComparisonComponent extends Component {
       );
     } catch (error) {
       console.error(`Error generating variant ${variantCode}:`, error);
-      this.error = `Failed to generate variant ${variantCode}: ${error.message}`;
+      this._notifyDraftError([error]);
     } finally {
       this.loadingVariant = null;
     }
@@ -427,38 +454,46 @@ export default class AiVariantComparisonComponent extends Component {
     this.error = null;
     try {
       const workspaceId = this.args.workspace?.id;
-      const results = await Promise.all(
-        this.variants.map(async (v) => {
+      // Generate all variants concurrently. Each panel fills in as soon as its
+      // own request resolves, and per-variant failures are isolated so one bad
+      // variant does not block the others.
+      const failures = [];
+      await Promise.all(
+        this.variants.map(async (variant) => {
           try {
             const result = await this.aiDraft.generateDraft(
               submission.id,
-              v.code,
+              variant.code,
               workspaceId,
               { includeMeta: true }
             );
-            return { variantCode: v.code, result };
+            this._applyGeneratedVariant(
+              variant.code,
+              result.draft,
+              result.variantLogId || null,
+              result.requestId || null
+            );
           } catch (error) {
-            console.error(`Error generating variant ${v.code}:`, error);
-            return { variantCode: v.code, error: error.message };
+            console.error(`Error generating variant ${variant.code}:`, error);
+            failures.push(error);
+            this._applyGeneratedVariant(
+              variant.code,
+              `Error: ${error.message}`,
+              null,
+              null
+            );
           }
         })
       );
 
-      results.forEach(({ variantCode, result, error }) => {
-        const draftText = error ? `Error: ${error}` : result?.draft;
-        const variantLogId = result?.variantLogId || null;
-        const requestId = result?.requestId || null;
-        this._applyGeneratedVariant(
-          variantCode,
-          draftText,
-          variantLogId,
-          requestId
-        );
-      });
+      if (failures.length) {
+        this._notifyDraftError(failures);
+      }
     } catch (e) {
       console.error('Overall error:', e);
       this.error = e.message || 'Failed to generate drafts';
     } finally {
+      this.loadingVariant = null;
       this.isLoading = false;
     }
   }

--- a/app/components/response-mentor-reply.js
+++ b/app/components/response-mentor-reply.js
@@ -386,7 +386,7 @@ export default class ResponseMentorReplyComponent extends Component {
     if (!this.args.submission)
       return 'AI draft generation requires a valid submission';
     if (!this.aiDraft.hasStudentWork(this.args.submission))
-      return 'AI draft generation requires student work (answers or explanations)';
+      return 'AI draft generation requires student text or worksheet images';
     return 'Generate AI draft based on student work';
   }
 
@@ -778,7 +778,7 @@ export default class ResponseMentorReplyComponent extends Component {
     ) {
       this.alert.showToast(
         'info',
-        'Cannot generate AI draft: No student work found. AI drafts require student answers or explanations to analyze.',
+        'Cannot generate AI draft: No student text or worksheet images were found.',
         'bottom-end',
         6000,
         false,

--- a/app/components/response-new.js
+++ b/app/components/response-new.js
@@ -310,7 +310,7 @@ export default class ResponseNewComponent extends Component {
     if (!this.hasSubmission)
       return 'AI draft generation requires a valid submission';
     if (!this.aiDraft.hasStudentWork(this.actualSubmission))
-      return 'AI draft generation requires student work (answers or explanations)';
+      return 'AI draft generation requires student text or worksheet images';
     return 'Generate AI draft based on student work';
   }
 
@@ -752,7 +752,7 @@ export default class ResponseNewComponent extends Component {
     ) {
       this.alert.showToast(
         'info',
-        'Cannot generate AI draft: No student work found. AI drafts require student answers or explanations to analyze.',
+        'Cannot generate AI draft: No student text or worksheet images were found.',
         'bottom-end',
         6000,
         false,

--- a/app/services/ai-draft.js
+++ b/app/services/ai-draft.js
@@ -1,6 +1,22 @@
 import Service from '@ember/service';
 import { service } from '@ember/service';
 
+const relationshipId = (record, relationshipName) => {
+  try {
+    return record?.belongsTo?.(relationshipName)?.id?.() || null;
+  } catch (error) {
+    return null;
+  }
+};
+
+const relationshipValue = (record, relationshipName) => {
+  try {
+    return record?.belongsTo?.(relationshipName)?.value?.() || null;
+  } catch (error) {
+    return null;
+  }
+};
+
 /**
  * AI Draft Service
  *
@@ -14,9 +30,7 @@ export default class AiDraftService extends Service {
   /**
    * Checks if a submission has student work available for AI analysis
    *
-   * Supports two data sources:
-   * 1. Direct properties: submission.shortAnswer and submission.longAnswer (regular submissions)
-   * 2. Answer relationship: answer.answer and answer.explanation (VMT submissions)
+   * Supports direct submission text/images and answer-linked text/images.
    *
    * @param {Object} submission
    * @returns {Boolean}
@@ -27,20 +41,27 @@ export default class AiDraftService extends Service {
     // Check direct submission properties first
     let shortAnswer = submission.shortAnswer?.trim();
     let longAnswer = submission.longAnswer?.trim();
+    const hasUploadedImage = Boolean(submission.uploadedFile?.savedFileName);
+    const answerId = relationshipId(submission, 'answer');
+    const answer =
+      relationshipValue(submission, 'answer') ||
+      (answerId ? this.store.peekRecord('answer', answerId) : null);
 
-    // Fall back to answer relationship for VMT submissions
-    if (!shortAnswer && !longAnswer) {
-      const answerId = submission.belongsTo('answer').id();
-      if (answerId) {
-        const answer = this.store.peekRecord('answer', answerId);
-        if (answer) {
-          shortAnswer = answer.answer?.trim();
-          longAnswer = answer.explanation?.trim();
-        }
-      }
+    if (answer) {
+      shortAnswer ||= answer.answer?.trim();
+      longAnswer ||= answer.explanation?.trim();
     }
 
-    return Boolean(shortAnswer || longAnswer);
+    const hasAnswerImage = Boolean(
+      relationshipId(answer, 'explanationImage') ||
+        relationshipId(answer, 'additionalImage') ||
+        answer?.explanationImage?.id ||
+        answer?.additionalImage?.id
+    );
+
+    return Boolean(
+      shortAnswer || longAnswer || hasUploadedImage || hasAnswerImage
+    );
   }
 
   /**
@@ -49,8 +70,8 @@ export default class AiDraftService extends Service {
    * A/B TEST MODIFICATION - NEEDS TWEAKING ONCE PREFERRED VARIANT IS FINALIZED
    * A/B TEST MODIFICATION - NEEDS TWEAKING ONCE PREFERRED VARIANT IS FINALIZED
    *
-   * Makes API call to backend AI service which analyzes student work
-   * and generates appropriate feedback.
+   * The browser sends only the submission ID. The Encompass backend chooses
+   * generate-draft or generate-draft-ocr and keeps the OCR API key server-side.
    *
    * @param {String} submissionId - The ID of the submission to generate feedback for
    * @param {String} variant - Variant key ('A', 'B', 'E', or 'F'); legacy aliases C/D are accepted server-side
@@ -83,7 +104,11 @@ export default class AiDraftService extends Service {
       let errMessage = 'Failed to generate AI draft';
       try {
         const parsed = JSON.parse(raw);
-        errMessage = parsed.message || parsed.error || errMessage;
+        errMessage =
+          parsed.message ||
+          parsed.error ||
+          parsed.errors?.[0]?.detail ||
+          errMessage;
       } catch (e) {
         // Upstream errors may return HTML/plain text (e.g., 502), preserve status.
         errMessage = `Failed to generate AI draft (${response.status})`;

--- a/app_server/services/ai.js
+++ b/app_server/services/ai.js
@@ -3,7 +3,10 @@
 // AI SERVICE MODIFIED FOR A/B TESTING - NEEDS TWEAKING ONCE PREFERRED VARIANT IS FINALIZED
 const https = require('https');
 const http = require('http');
+const crypto = require('crypto');
 const he = require('he');
+const sharp = require('sharp');
+const { Parser } = require('htmlparser2');
 const logger = require('log4js').getLogger('ai');
 const models = require('../datasource/schemas');
 
@@ -62,6 +65,8 @@ const STAGE_NAMES = new Set(['prod', 'dev', 'test', 'stage', 'staging']);
 const AI_DRAFT_HTTP_TIMEOUT_MS = 300000;
 const AI_DRAFT_POLL_MAX_MS = 300000 * 4;
 const AI_DRAFT_POLL_INTERVAL_MS = 1000;
+const DEFAULT_OCR_CONSENSUS_N = 1;
+const MAX_OCR_SOURCE_BYTES = 20 * 1024 * 1024;
 
 const getStagePrefix = (path = '') => {
   const segments = normalizeApiPath(path).split('/').filter(Boolean);
@@ -80,6 +85,269 @@ const buildStatusPath = (requestPath, ticketId) => {
 };
 
 const extractDraft = (payload = {}) => payload.draft_feedback || null;
+
+const extractImageSources = (...htmlValues) => {
+  const sources = [];
+
+  htmlValues.forEach((html) => {
+    if (typeof html !== 'string' || !html.includes('<')) {
+      return;
+    }
+
+    const parser = new Parser({
+      onopentag(name, attributes) {
+        if (name === 'img' && attributes.src) {
+          sources.push(attributes.src);
+        }
+      },
+    });
+    parser.write(html);
+    parser.end();
+  });
+
+  return sources;
+};
+
+const imageDataToBase64 = (imageData) => {
+  if (typeof imageData !== 'string' || imageData.length === 0) {
+    return null;
+  }
+
+  const marker = 'base64,';
+  const markerIndex = imageData.indexOf(marker);
+  return markerIndex >= 0
+    ? imageData.slice(markerIndex + marker.length)
+    : imageData;
+};
+
+const imageSourceKey = (source) => {
+  if (typeof source !== 'string' || source.length === 0) {
+    return null;
+  }
+
+  if (source.startsWith('data:')) {
+    return `data:${crypto.createHash('sha256').update(source).digest('hex')}`;
+  }
+
+  try {
+    const url = new URL(source, 'http://encompass.local');
+    return `${url.pathname}${url.search}`;
+  } catch (error) {
+    return source;
+  }
+};
+
+const imageIdFromSource = (source) => {
+  if (typeof source !== 'string') {
+    return null;
+  }
+
+  const match = source.match(/\/api\/images\/file\/([a-f0-9]{24})(?:[/?#]|$)/i);
+  return match ? match[1] : null;
+};
+
+const fetchBinary = (source, redirectCount = 0) =>
+  new Promise((resolve, reject) => {
+    let url;
+    try {
+      url = new URL(source);
+    } catch (error) {
+      reject(new Error(`Invalid image URL: ${source}`));
+      return;
+    }
+
+    const protocol = url.protocol === 'http:' ? http : https;
+    const request = protocol.get(url, (response) => {
+      if (
+        response.statusCode >= 300 &&
+        response.statusCode < 400 &&
+        response.headers.location &&
+        redirectCount < 3
+      ) {
+        response.resume();
+        resolve(
+          fetchBinary(
+            new URL(response.headers.location, url).toString(),
+            redirectCount + 1
+          )
+        );
+        return;
+      }
+
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        response.resume();
+        reject(
+          new Error(
+            `Image request failed (${
+              response.statusCode
+            }) for ${url.toString()}`
+          )
+        );
+        return;
+      }
+
+      const chunks = [];
+      let totalBytes = 0;
+      response.on('data', (chunk) => {
+        totalBytes += chunk.length;
+        if (totalBytes > MAX_OCR_SOURCE_BYTES) {
+          request.destroy(
+            new Error(`Image exceeds ${MAX_OCR_SOURCE_BYTES} byte OCR limit`)
+          );
+          return;
+        }
+        chunks.push(chunk);
+      });
+      response.on('end', () => resolve(Buffer.concat(chunks)));
+    });
+
+    request.on('error', reject);
+    request.setTimeout(AI_DRAFT_HTTP_TIMEOUT_MS, () => {
+      request.destroy(new Error('Image request timed out'));
+    });
+  });
+
+const imagePageFromBuffer = async (buffer, key, pageNumber = null) => {
+  if (!Buffer.isBuffer(buffer) || buffer.length === 0) {
+    return null;
+  }
+
+  const metadata = await sharp(buffer).metadata();
+  if (!(metadata.width > 0) || !(metadata.height > 0)) {
+    return null;
+  }
+
+  return {
+    key,
+    base64: buffer.toString('base64'),
+    width: metadata.width,
+    height: metadata.height,
+    pageNumber,
+  };
+};
+
+const imagePageFromDocument = async (image, key = null) => {
+  if (!image?.imageData) {
+    return null;
+  }
+
+  const base64 = imageDataToBase64(image.imageData);
+  if (!base64) {
+    return null;
+  }
+
+  const buffer = Buffer.from(base64, 'base64');
+  const page = await imagePageFromBuffer(
+    buffer,
+    key || `image:${String(image._id)}`,
+    image.pdfPageNum || null
+  );
+
+  if (page && image.width > 0 && image.height > 0) {
+    page.width = image.width;
+    page.height = image.height;
+  }
+
+  return page;
+};
+
+const resolveImagePage = async (source) => {
+  if (typeof source !== 'string' || source.length === 0) {
+    return null;
+  }
+
+  const key = imageSourceKey(source);
+  const imageId = imageIdFromSource(source);
+  if (imageId) {
+    const image = await models.Image.findById(imageId).lean().exec();
+    return imagePageFromDocument(image, key);
+  }
+
+  if (source.startsWith('data:')) {
+    const base64 = imageDataToBase64(source);
+    return imagePageFromBuffer(Buffer.from(base64, 'base64'), key);
+  }
+
+  if (/^https?:\/\//i.test(source)) {
+    return imagePageFromBuffer(await fetchBinary(source), key);
+  }
+
+  return null;
+};
+
+const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+
+const buildSelectedBox = (selection, page, pageIndex) => {
+  if (!selection || !page || !Number.isInteger(pageIndex)) {
+    return null;
+  }
+
+  const relativeCoords = selection.relativeCoords || {};
+  const relativeSize = selection.relativeSize || {};
+  const relativeValues = [
+    relativeCoords.tagLeftPct,
+    relativeCoords.tagTopPct,
+    relativeSize.widthPct,
+    relativeSize.heightPct,
+  ].map(Number);
+
+  let x;
+  let y;
+  let width;
+  let height;
+
+  if (relativeValues.every(Number.isFinite)) {
+    x = Math.round(clamp(relativeValues[0], 0, 1) * page.width);
+    y = Math.round(clamp(relativeValues[1], 0, 1) * page.height);
+    width = Math.round(clamp(relativeValues[2], 0, 1) * page.width);
+    height = Math.round(clamp(relativeValues[3], 0, 1) * page.height);
+  } else {
+    const coordinates = String(selection.coordinates || '')
+      .trim()
+      .split(/\s+/);
+    if (coordinates.length !== 5) {
+      return null;
+    }
+    [x, y, width, height] = coordinates.slice(1).map(Number);
+    if (![x, y, width, height].every(Number.isFinite)) {
+      return null;
+    }
+  }
+
+  x = clamp(x, 0, page.width - 1);
+  y = clamp(y, 0, page.height - 1);
+  width = clamp(width, 1, page.width - x);
+  height = clamp(height, 1, page.height - y);
+
+  return { x, y, width, height, page: pageIndex };
+};
+
+const buildOcrRequestBody = ({
+  images,
+  variant,
+  problemStatement,
+  studentWork,
+  studentName,
+  requestRows,
+  consensusN = DEFAULT_OCR_CONSENSUS_N,
+}) => ({
+  images,
+  variant,
+  async_ticket: true,
+  ocr_consensus_n: consensusN,
+  problem: {
+    statement: problemStatement,
+  },
+  student_work: studentWork || {
+    short_answer: '',
+    long_answer: '',
+    student_name: studentName,
+  },
+  student_name: studentName,
+  mentor_teacher_context: {
+    selections_and_observations: requestRows,
+  },
+});
 
 const summarizeResponseBody = (value, maxLength = 400) => {
   if (value === null || value === undefined) {
@@ -155,12 +423,24 @@ const generateDraft = async (
   const targetSubmission = await models.Submission.findById(targetSubmissionId)
     .populate({
       path: 'answer',
-      populate: {
-        path: 'assignment',
-        populate: { path: 'problem', select: 'text title' },
-      },
+      populate: [
+        {
+          path: 'assignment',
+          populate: { path: 'problem', select: 'text title' },
+        },
+        {
+          path: 'explanationImage',
+          select: 'imageData width height pdfPageNum',
+        },
+        {
+          path: 'additionalImage',
+          select: 'imageData width height pdfPageNum',
+        },
+      ],
     })
-    .select('shortAnswer longAnswer answer creator clazz publication pdSet')
+    .select(
+      'shortAnswer longAnswer answer creator clazz publication pdSet uploadedFile'
+    )
     .lean()
     .exec();
 
@@ -172,8 +452,12 @@ const generateDraft = async (
   const problemStatement = await resolveProblemText(targetSubmission, models);
 
   // Step 3: Extract and clean student work
-  let shortAnswer = stripHtml(targetSubmission.shortAnswer || '');
-  let longAnswer = stripHtml(targetSubmission.longAnswer || '');
+  const rawShortAnswer = targetSubmission.shortAnswer || '';
+  const rawLongAnswer = targetSubmission.longAnswer || '';
+  const rawAnswer = targetSubmission.answer?.answer || '';
+  const rawExplanation = targetSubmission.answer?.explanation || '';
+  let shortAnswer = stripHtml(rawShortAnswer);
+  let longAnswer = stripHtml(rawLongAnswer);
 
   // If no direct student work, check the answer relationship (for VMT submissions)
   if (
@@ -181,20 +465,11 @@ const generateDraft = async (
     (!longAnswer || longAnswer.trim().length === 0)
   ) {
     if (targetSubmission.answer) {
-      shortAnswer = stripHtml(targetSubmission.answer.answer || '');
-      longAnswer = stripHtml(targetSubmission.answer.explanation || '');
+      shortAnswer = stripHtml(rawAnswer);
+      longAnswer = stripHtml(rawExplanation);
     }
   }
 
-  // If still no student work found, throw error
-  if (
-    (!shortAnswer || shortAnswer.trim().length === 0) &&
-    (!longAnswer || longAnswer.trim().length === 0)
-  ) {
-    throw new Error(
-      'No student work found. Students must provide a short or long answer.'
-    );
-  }
   // Step 4: Determine student name
   const studentName = resolveStudentName(targetSubmission);
 
@@ -217,15 +492,47 @@ const generateDraft = async (
     },
   };
 
-  const { requestRows, sentAnnotations } = await buildSelectionsAndObservations(
+  const { rows, sentAnnotations } = await buildSelectionsAndObservations(
     targetSubmissionId,
     inputType,
     workspaceId,
     teacherId
   );
-  requestBody.mentor_teacher_context.selections_and_observations = requestRows;
+  const ocrContext = await buildOcrContext(targetSubmission, rows, [
+    rawShortAnswer,
+    rawLongAnswer,
+    rawAnswer,
+    rawExplanation,
+  ]);
+  const hasTextWork = Boolean(shortAnswer.trim() || longAnswer.trim());
 
-  const aiResult = await makeAIRequest(requestBody);
+  if (!hasTextWork && ocrContext.images.length === 0) {
+    throw new Error(
+      'No student work found. Students must provide text or an image.'
+    );
+  }
+  const loggedAnnotations = sentAnnotations.map((annotation, index) => ({
+    ...annotation,
+    selectedBox: ocrContext.selectedBoxes[index] || null,
+  }));
+
+  let aiResult;
+  if (ocrContext.images.length > 0) {
+    const ocrRequestBody = buildOcrRequestBody({
+      images: ocrContext.images,
+      variant,
+      problemStatement: cleanProblemStatement,
+      studentWork: requestBody.student_work,
+      consensusN: getOcrConsensusN(),
+      studentName,
+      requestRows: ocrContext.requestRows,
+    });
+    aiResult = await makeAIRequest(ocrRequestBody, getOcrEndpointConfig());
+  } else {
+    requestBody.mentor_teacher_context.selections_and_observations =
+      rows.map(toTextRequestRow);
+    aiResult = await makeAIRequest(requestBody);
+  }
   const draft =
     typeof aiResult === 'object' && aiResult?.draft ? aiResult.draft : aiResult;
   const responseTime =
@@ -235,7 +542,7 @@ const generateDraft = async (
 
   return {
     draft,
-    sentAnnotations,
+    sentAnnotations: loggedAnnotations,
     responseTime,
   };
 };
@@ -261,12 +568,18 @@ const getTeacherSelections = async (submissionId, workspaceId, teacherId) => {
     }
     const selections = await models.Selection.find(selectionQuery)
       .populate('createdBy', 'username')
-      .select('text createDate createdBy')
+      .select(
+        'text coordinates relativeCoords relativeSize imageSrc imageTagLink createDate createdBy'
+      )
       .lean()
       .exec();
     return selections.map((sel) => ({
       selection_id: String(sel._id),
       selected_text: stripHtml(sel.text),
+      coordinates: sel.coordinates || '',
+      relativeCoords: sel.relativeCoords || null,
+      relativeSize: sel.relativeSize || null,
+      imageSrc: sel.imageSrc || null,
       selector_username: sel.createdBy?.username || '',
       selector_date: sel.createDate || null,
       comments: [],
@@ -297,7 +610,10 @@ const getTeacherComments = async (submissionId, workspaceId, teacherId) => {
       commentQuery.workspace = workspaceId;
     }
     const comments = await models.Comment.find(commentQuery)
-      .populate('selection', 'text')
+      .populate(
+        'selection',
+        'text coordinates relativeCoords relativeSize imageSrc imageTagLink'
+      )
       .populate('createdBy', 'username')
       .select('text label selection createDate createdBy')
       .lean()
@@ -309,6 +625,10 @@ const getTeacherComments = async (submissionId, workspaceId, teacherId) => {
         ? String(comment.selection)
         : null,
       selected_text: stripHtml(comment.selection?.text || ''),
+      coordinates: comment.selection?.coordinates || '',
+      relativeCoords: comment.selection?.relativeCoords || null,
+      relativeSize: comment.selection?.relativeSize || null,
+      imageSrc: comment.selection?.imageSrc || null,
       type: comment.label, // notice, wonder, feedback
       text: stripHtml(comment.text),
       annotator_username: comment.createdBy?.username || '',
@@ -352,6 +672,10 @@ const buildSelectionsAndObservations = async (
     const row = {
       selection_id: selection.selection_id || null,
       selected_text: selection.selected_text || '',
+      coordinates: selection.coordinates || '',
+      relativeCoords: selection.relativeCoords || null,
+      relativeSize: selection.relativeSize || null,
+      imageSrc: selection.imageSrc || null,
       selector_username: selection.selector_username || '',
       selector_date: selection.selector_date || null,
       comments: [],
@@ -368,6 +692,10 @@ const buildSelectionsAndObservations = async (
       row = {
         selection_id: comment.selection_id || null,
         selected_text: comment.selected_text || '',
+        coordinates: comment.coordinates || '',
+        relativeCoords: comment.relativeCoords || null,
+        relativeSize: comment.relativeSize || null,
+        imageSrc: comment.imageSrc || null,
         selector_username: '',
         selector_date: null,
         comments: [],
@@ -385,15 +713,10 @@ const buildSelectionsAndObservations = async (
   });
 
   return {
-    requestRows: list.map((row) => ({
-      selected_text: row.selected_text || '',
-      comments: row.comments.map((comment) => ({
-        type: comment.type || '',
-        text: comment.text || '',
-      })),
-    })),
+    rows: list,
     sentAnnotations: list.map((row) => ({
       selectedText: row.selected_text || '',
+      selectedBox: null,
       selectorUsername: row.selector_username || '',
       selectorDate: row.selector_date || null,
       comments: row.comments.map((comment) => ({
@@ -406,17 +729,191 @@ const buildSelectionsAndObservations = async (
   };
 };
 
+const toRequestComments = (comments = []) =>
+  comments.map((comment) => ({
+    type: comment.type || '',
+    text: comment.text || '',
+  }));
+
+const toTextRequestRow = (row) => ({
+  selected_text: row.selected_text || '',
+  comments: toRequestComments(row.comments),
+});
+
+const getOcrConsensusN = () => {
+  const value = Number.parseInt(process.env.AI_DRAFT_OCR_CONSENSUS_N, 10);
+  return Number.isInteger(value) && value > 0 ? value : DEFAULT_OCR_CONSENSUS_N;
+};
+
+const getTextEndpointConfig = () => ({
+  hostname: process.env.AI_DRAFT_HOST,
+  port: process.env.AI_DRAFT_PORT,
+  path: process.env.AI_DRAFT_PATH,
+  apiKey: process.env.AI_DRAFT_API_KEY,
+  protocol: process.env.AI_DRAFT_HOST === 'localhost' ? 'http:' : 'https:',
+});
+
+const buildOcrEndpointConfig = ({
+  endpointUrl,
+  endpointPath,
+  apiKey,
+  fallbackApiKey,
+  hostname,
+  port,
+}) => {
+  if (endpointUrl) {
+    let url;
+    try {
+      url = new URL(endpointUrl);
+    } catch (error) {
+      throw new Error('AI_DRAFT_OCR_URL must be a valid absolute URL.');
+    }
+
+    if (!['http:', 'https:'].includes(url.protocol)) {
+      throw new Error('AI_DRAFT_OCR_URL must use HTTP or HTTPS.');
+    }
+
+    const path = endpointPath || `${url.pathname}${url.search}`;
+    if (!path || path === '/') {
+      throw new Error(
+        'OCR endpoint path is not configured. Set AI_DRAFT_OCR_PATH or include the path in AI_DRAFT_OCR_URL.'
+      );
+    }
+
+    return {
+      hostname: url.hostname,
+      port: url.port,
+      path: normalizeApiPath(path),
+      apiKey: apiKey || fallbackApiKey,
+      protocol: url.protocol,
+    };
+  }
+
+  const config = {
+    hostname,
+    port,
+    path: normalizeApiPath(endpointPath),
+    apiKey: apiKey || fallbackApiKey,
+    protocol: hostname === 'localhost' ? 'http:' : 'https:',
+  };
+
+  if (!config.hostname || !config.path) {
+    throw new Error(
+      'OCR endpoint is not configured. Set AI_DRAFT_OCR_URL or AI_DRAFT_OCR_HOST and AI_DRAFT_OCR_PATH.'
+    );
+  }
+
+  return config;
+};
+
+const getOcrEndpointConfig = () =>
+  buildOcrEndpointConfig({
+    endpointUrl: process.env.AI_DRAFT_OCR_URL,
+    endpointPath: process.env.AI_DRAFT_OCR_PATH,
+    apiKey: process.env.AI_DRAFT_OCR_API_KEY,
+    fallbackApiKey: process.env.AI_DRAFT_API_KEY,
+    hostname: process.env.AI_DRAFT_OCR_HOST,
+    port: process.env.AI_DRAFT_OCR_PORT,
+  });
+
+const buildOcrContext = async (
+  targetSubmission,
+  rows,
+  studentWorkHtml = []
+) => {
+  const pages = [];
+  const pagesByKey = new Map();
+
+  const addPage = (page) => {
+    if (!page?.key || pagesByKey.has(page.key)) {
+      return;
+    }
+    pagesByKey.set(page.key, page);
+    pages.push(page);
+  };
+
+  const directImages = [
+    targetSubmission.answer?.explanationImage,
+    targetSubmission.answer?.additionalImage,
+  ].filter(Boolean);
+
+  for (const image of directImages) {
+    try {
+      addPage(
+        await imagePageFromDocument(
+          image,
+          imageSourceKey(`/api/images/file/${String(image._id)}`)
+        )
+      );
+    } catch (error) {
+      logger.warn('Unable to prepare answer image for OCR:', error.message);
+    }
+  }
+
+  const sources = extractImageSources(...studentWorkHtml);
+  rows.forEach((row) => {
+    if (row.imageSrc) {
+      sources.push(row.imageSrc);
+    }
+  });
+
+  const savedFileName = targetSubmission.uploadedFile?.savedFileName;
+  if (savedFileName) {
+    sources.push(
+      `http://mathforum.org/encpows/uploaded-images/${encodeURIComponent(
+        savedFileName
+      )}`
+    );
+  }
+
+  for (const source of sources) {
+    const key = imageSourceKey(source);
+    if (!key || pagesByKey.has(key)) {
+      continue;
+    }
+
+    try {
+      addPage(await resolveImagePage(source));
+    } catch (error) {
+      logger.warn(`Unable to prepare OCR image ${key}:`, error.message);
+    }
+  }
+
+  const requestRows = rows.map((row) => {
+    const comments = toRequestComments(row.comments);
+    const pageKey = imageSourceKey(row.imageSrc);
+    const page = pageKey ? pagesByKey.get(pageKey) : null;
+    const pageIndex = page ? pages.indexOf(page) : -1;
+    const selectedBox = buildSelectedBox(row, page, pageIndex);
+
+    if (selectedBox) {
+      return { selected_box: selectedBox, comments };
+    }
+
+    return { selected_text: row.selected_text || '', comments };
+  });
+
+  return {
+    images: pages.map((page) => page.base64),
+    requestRows,
+    selectedBoxes: requestRows.map((row) => row.selected_box || null),
+  };
+};
+
 /**
  * Makes an HTTP POST request to the AI service
  * @param {Object} requestBody - The structured request body
  * @returns {Promise<string>} The draft text from AI service
  */
-const makeAIRequest = async (requestBody) => {
+const makeAIRequest = async (
+  requestBody,
+  endpointConfig = getTextEndpointConfig()
+) => {
   const postData = JSON.stringify(requestBody);
   const options = {
-    hostname: process.env.AI_DRAFT_HOST,
-    port: process.env.AI_DRAFT_PORT,
-    path: process.env.AI_DRAFT_PATH,
+    hostname: endpointConfig.hostname,
+    port: endpointConfig.port,
+    path: endpointConfig.path,
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -425,12 +922,12 @@ const makeAIRequest = async (requestBody) => {
   };
 
   // Add API key if provided
-  if (process.env.AI_DRAFT_API_KEY) {
-    options.headers['x-api-key'] = process.env.AI_DRAFT_API_KEY;
+  if (endpointConfig.apiKey) {
+    options.headers['x-api-key'] = endpointConfig.apiKey;
   }
 
   return new Promise((resolve, reject) => {
-    const protocol = options.hostname === 'localhost' ? http : https;
+    const protocol = endpointConfig.protocol === 'http:' ? http : https;
     const requestJson = (requestOptions, body = null) =>
       new Promise((resolveRequest, rejectRequest) => {
         const req = protocol.request(requestOptions, (res) => {
@@ -514,8 +1011,8 @@ const makeAIRequest = async (requestBody) => {
           },
         };
 
-        if (process.env.AI_DRAFT_API_KEY) {
-          statusOptions.headers['x-api-key'] = process.env.AI_DRAFT_API_KEY;
+        if (endpointConfig.apiKey) {
+          statusOptions.headers['x-api-key'] = endpointConfig.apiKey;
         }
 
         const poll = () => {
@@ -562,3 +1059,12 @@ const makeAIRequest = async (requestBody) => {
 };
 
 module.exports.generateDraft = generateDraft;
+module.exports._test = {
+  buildOcrEndpointConfig,
+  buildOcrRequestBody,
+  buildSelectedBox,
+  buildStatusPath,
+  extractImageSources,
+  imageDataToBase64,
+  imageSourceKey,
+};

--- a/test/mocha/unit-tests/ai_ocr.js
+++ b/test/mocha/unit-tests/ai_ocr.js
@@ -1,0 +1,160 @@
+/* eslint-env mocha */
+const { expect } = require('chai');
+
+const {
+  buildOcrEndpointConfig,
+  buildOcrRequestBody,
+  buildSelectedBox,
+  buildStatusPath,
+  extractImageSources,
+  imageDataToBase64,
+  imageSourceKey,
+} = require('../../../app_server/services/ai')._test;
+
+describe('AI OCR request helpers', function () {
+  it('combines the OCR base URL with its configured Lambda path', function () {
+    expect(
+      buildOcrEndpointConfig({
+        endpointUrl: 'https://example.execute-api.us-east-2.amazonaws.com',
+        endpointPath: '/prod/api/generate-draft-ocr',
+        apiKey: 'ocr-key',
+      })
+    ).to.deep.equal({
+      hostname: 'example.execute-api.us-east-2.amazonaws.com',
+      port: '',
+      path: '/prod/api/generate-draft-ocr',
+      apiKey: 'ocr-key',
+      protocol: 'https:',
+    });
+  });
+
+  it('uses a complete OCR URL when a separate path is not configured', function () {
+    expect(
+      buildOcrEndpointConfig({
+        endpointUrl:
+          'https://example.execute-api.us-east-2.amazonaws.com/prod/api/generate-draft-ocr',
+        fallbackApiKey: 'shared-key',
+      })
+    ).to.include({
+      path: '/prod/api/generate-draft-ocr',
+      apiKey: 'shared-key',
+      protocol: 'https:',
+    });
+  });
+
+  it('polls ticket status in the same API stage as the OCR endpoint', function () {
+    expect(
+      buildStatusPath('/prod/api/generate-draft-ocr', 'ticket 123')
+    ).to.equal('/prod/api/status/ticket%20123');
+  });
+
+  it('builds the OCR endpoint contract', function () {
+    const selectedBox = {
+      x: 42,
+      y: 118,
+      width: 310,
+      height: 65,
+      page: 0,
+    };
+
+    expect(
+      buildOcrRequestBody({
+        images: ['page-one-base64'],
+        variant: 'B',
+        problemStatement: 'Solve 2x + 6 = 14.',
+        studentWork: {
+          short_answer: 'I solved for x.',
+          long_answer: '2x + 6 = 14, so x = 4.',
+          student_name: 'Alex',
+        },
+        studentName: 'Alex',
+        consensusN: 1,
+        requestRows: [
+          {
+            selected_box: selectedBox,
+            comments: [{ text: 'Self-corrected', type: 'highlight' }],
+          },
+        ],
+      })
+    ).to.deep.equal({
+      images: ['page-one-base64'],
+      variant: 'B',
+      async_ticket: true,
+      ocr_consensus_n: 1,
+      problem: {
+        statement: 'Solve 2x + 6 = 14.',
+      },
+      student_work: {
+        short_answer: 'I solved for x.',
+        long_answer: '2x + 6 = 14, so x = 4.',
+        student_name: 'Alex',
+      },
+      student_name: 'Alex',
+      mentor_teacher_context: {
+        selections_and_observations: [
+          {
+            selected_box: selectedBox,
+            comments: [{ text: 'Self-corrected', type: 'highlight' }],
+          },
+        ],
+      },
+    });
+  });
+
+  it('converts normalized image-selection geometry to page pixels', function () {
+    const selection = {
+      relativeCoords: {
+        tagLeftPct: 0.042,
+        tagTopPct: 0.236,
+      },
+      relativeSize: {
+        widthPct: 0.31,
+        heightPct: 0.13,
+      },
+    };
+
+    expect(
+      buildSelectedBox(selection, { width: 1000, height: 500 }, 0)
+    ).to.deep.equal({
+      x: 42,
+      y: 118,
+      width: 310,
+      height: 65,
+      page: 0,
+    });
+  });
+
+  it('uses the supplied zero-based page index', function () {
+    const selection = {
+      relativeCoords: { tagLeftPct: 0.1, tagTopPct: 0.2 },
+      relativeSize: { widthPct: 0.3, heightPct: 0.4 },
+    };
+
+    expect(
+      buildSelectedBox(selection, { width: 200, height: 100 }, 2)
+    ).to.include({ page: 2 });
+  });
+
+  it('normalizes equivalent relative and absolute image URLs', function () {
+    expect(
+      imageSourceKey(
+        'https://enc-test.mathematicalthinking.org/api/images/file/abc?size=full'
+      )
+    ).to.equal('/api/images/file/abc?size=full');
+    expect(imageSourceKey('/api/images/file/abc?size=full')).to.equal(
+      '/api/images/file/abc?size=full'
+    );
+  });
+
+  it('extracts embedded image sources and strips data URI metadata', function () {
+    expect(
+      extractImageSources(
+        '<p>First</p><img src="/api/images/file/one">',
+        '<img alt="" src="data:image/png;base64,cGFnZQ==">'
+      )
+    ).to.deep.equal(['/api/images/file/one', 'data:image/png;base64,cGFnZQ==']);
+    expect(imageDataToBase64('data:image/png;base64,cGFnZQ==')).to.equal(
+      'cGFnZQ=='
+    );
+  });
+});

--- a/tests/integration/components/response-mentor-reply-test.js
+++ b/tests/integration/components/response-mentor-reply-test.js
@@ -128,6 +128,25 @@ module('Integration | Component | response-mentor-reply', function (hooks) {
     assert.dom('.info').includesText('No Mentor Feedback');
   });
 
+  test('enables Draft From AI for an uploaded worksheet', async function (assert) {
+    const store = this.owner.lookup('service:store');
+    this.submission = store.createRecord('submission', {
+      id: 'image-submission',
+      creator: { username: 'Test Student', safeName: 'Test Student' },
+      uploadedFile: { savedFileName: 'worksheet.png' },
+    });
+
+    await renderMentorReply(this, {
+      displayResponse: null,
+      submissionResponses: [],
+      canSend: true,
+    });
+
+    assert
+      .dom('.ai-draft')
+      .isNotDisabled('Button is enabled for image-only student work');
+  });
+
   test('variant response composition falls back to imageSrc', function (assert) {
     const ComponentClass = this.owner.factoryFor(
       'component:response-mentor-reply'

--- a/tests/integration/components/response-new-test.js
+++ b/tests/integration/components/response-new-test.js
@@ -707,7 +707,7 @@ module('Integration | Component | response-new', function (hooks) {
       id: 'submission1',
       shortAnswer: 'Student answer here',
       longAnswer: 'Detailed explanation',
-      belongsTo(relationshipName) {
+      belongsTo() {
         return {
           id() {
             return null;
@@ -747,7 +747,7 @@ module('Integration | Component | response-new', function (hooks) {
     const mockSubmission = {
       id: 'submission1',
       // No shortAnswer or longAnswer
-      belongsTo(relationshipName) {
+      belongsTo() {
         return {
           id() {
             return null;
@@ -772,5 +772,38 @@ module('Integration | Component | response-new', function (hooks) {
     assert
       .dom('.ai-draft')
       .isDisabled('Button is disabled when no student work');
+  });
+
+  test('enables Draft From AI button for an uploaded worksheet', async function (assert) {
+    const mockSubmission = {
+      id: 'submission1',
+      uploadedFile: { savedFileName: 'worksheet.png' },
+      belongsTo() {
+        return {
+          id() {
+            return null;
+          },
+          value() {
+            return null;
+          },
+        };
+      },
+    };
+
+    await renderResponseNew(
+      this,
+      {
+        student: 'Test Student',
+        selections: [],
+        comments: [],
+      },
+      {
+        submission: mockSubmission,
+      }
+    );
+
+    assert
+      .dom('.ai-draft')
+      .isNotDisabled('Button is enabled for image-only student work');
   });
 });

--- a/tests/unit/services/ai-draft-test.js
+++ b/tests/unit/services/ai-draft-test.js
@@ -1,0 +1,62 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+const relationship = (id = null, value = null) => ({
+  id: () => id,
+  value: () => value,
+});
+
+module('Unit | Service | ai-draft', function (hooks) {
+  setupTest(hooks);
+
+  test('recognizes an uploaded worksheet as student work', function (assert) {
+    const service = this.owner.lookup('service:ai-draft');
+    const submission = {
+      uploadedFile: { savedFileName: 'worksheet.png' },
+      belongsTo: () => relationship(),
+    };
+
+    assert.true(service.hasStudentWork(submission));
+  });
+
+  test('recognizes an explanation image on the loaded answer', function (assert) {
+    const service = this.owner.lookup('service:ai-draft');
+    const answer = {
+      belongsTo(name) {
+        return relationship(name === 'explanationImage' ? 'image-1' : null);
+      },
+    };
+    const submission = {
+      belongsTo: () => relationship('answer-1', answer),
+    };
+
+    assert.true(service.hasStudentWork(submission));
+  });
+
+  test('recognizes an additional image from the store', function (assert) {
+    const service = this.owner.lookup('service:ai-draft');
+    const answer = {
+      belongsTo(name) {
+        return relationship(name === 'additionalImage' ? 'image-2' : null);
+      },
+    };
+    service.store.peekRecord = (type, id) =>
+      type === 'answer' && id === 'answer-2' ? answer : null;
+    const submission = {
+      belongsTo: () => relationship('answer-2'),
+    };
+
+    assert.true(service.hasStudentWork(submission));
+  });
+
+  test('rejects a submission without text or images', function (assert) {
+    const service = this.owner.lookup('service:ai-draft');
+    const submission = {
+      shortAnswer: '',
+      longAnswer: '',
+      belongsTo: () => relationship(),
+    };
+
+    assert.false(service.hasStudentWork(submission));
+  });
+});


### PR DESCRIPTION
### Summary
Adds support for new `generate-draft-ocr` endpoint so AI drafts can be generated from uploaded worksheet images, while text-only submissions keep using the existing `generate-draft` endpoint. Endpoint selection happens server-side, the browser still only sends the submission id to `/api/aiDraft`.

`generate-draft-ocr` calls `generate-draft` internally after OCR, so Encompass never calls both endpoints for the same image request.

### Endpoint routing
- **Text-only** submissions → `generate-draft` (unchanged).
- **Image content or image selection** (uploaded worksheet, answer image,
  embedded `<img>`, or a teacher image-region selection) → `generate-draft-ocr`.
- A/B/E/F variant behavior and RAG on/off are preserved on the text path.

**Server (`app_server/services/ai.js`)**
- New OCR payload: `images` (base64, one per page), `variant`, `async_ticket: true`, `ocr_consensus_n`, `student_name`, problem statement, and `mentor_teacher_context.selections_and_observations` with `selected_text`
  for text rows and `selected_box {x, y, width, height, page}` for image rows.
- Image resolution from answer explanation/additional images, embedded `<img>` in student work, image selections, and the uploaded worksheet; deduped by source key (sha256 for data URLs, path+query for URLs); `/api/images/file/:id`
  resolved via Mongo image documents.
- Multi-page worksheets supported: each page is sent as a separate base64 image, `pdfPageNum` is preserved, and `selected_box.page` is the zero-based index of the page a selection belongs to.
- Remote image fetch hardening (`fetchBinary`): follows up to 3 redirects, enforces a 20 MB(`MAX_OCR_SOURCE_BYTES`) cap, and times out; supports `http`/`https` and base64 data URLs.
- Selection-box conversion from `relativeCoords`/`relativeSize` (and legacy coordinate strings) to clamped pixel boxes, with safe `selected_text` fallback when a box is missing/invalid.
- Teacher selection and comment queries now also load geometry fields (`coordinates`, `relativeCoords`, `relativeSize`, `imageSrc`) so image-region selections can be turned into boxes.
- Variant log: `sentAnnotations` now records each row's `selectedBox` alongside its text, so the saved AIVariant export reflects image selections.
- Separate text/OCR endpoint config ; ticket-status polling in the same API stage.
- Image-only submissions allowed (only errors when there is neither text nor a resolvable image); removed the temporary "AI request payload" debug log; added `_test` exports for unit coverage.

**Client**
- `ai-draft` service: image-aware `hasStudentWork` (uploaded worksheet + answer explanation/additional images count as work); reads `errors[0].detail` so upstream errors (e.g. 429 "Limit Exceeded") reach the UI instead of a generic
  string.
- `ai-variant-comparison`: concurrent A/B/E/F generation with per-variant loading state and isolated per-variant failures; failure toast (sweet-alert) with a clear quota message for 429 "Limit Exceeded".
- `response-new` / `response-mentor-reply`: disabled-button tooltip and "no student work" toast reworded to "student text or worksheet images".

### Configuration
Requires the OCR endpoint env vars 

### Tests
- Local End-to-end Testing done. (dev pending until env variables are updated)
- **Automated:**
  - `test/mocha/unit-tests/ai_ocr.js` — OCR endpoint config, status-path stage
    prefixing, payload contract, selected-box geometry, source-key normalization.
  - `tests/unit/services/ai-draft-test.js` — image-aware `hasStudentWork`.
  - `tests/integration/components/response-new-test.js` and
    `response-mentor-reply-test.js` — image-only submissions enable the
    Draft From AI button.