### PR TITLE
fix(selection): prevent server crash when group workspace lacks a matching submission

### DIFF
--- a/app_server/datasource/api/selectionApi.js
+++ b/app_server/datasource/api/selectionApi.js
@@ -531,13 +531,19 @@ const resolveGroupWorkspaces = async (selection, type) => {
           childCopy.submission.answer
         );
       });
+      // No matching submission in this group workspace. Skip it rather than
+      // dereferencing undefined — an unhandled throw here crashes the whole
+      // Node process (it runs in a fire-and-forget post-save hook).
+      if (!parentSub) {
+        return null;
+      }
       childCopy.submission = parentSub._id;
       childCopy.workspace = workspace._id;
       const newSelection = await models.Selection.create(childCopy);
       return newSelection;
     })
   );
-  return createdSelections;
+  return createdSelections.filter(Boolean);
 };
 
 const deleteGroupLevelSelections = async (selection) => {

--- a/app_server/datasource/schemas/selection.js
+++ b/app_server/datasource/schemas/selection.js
@@ -195,7 +195,9 @@ SelectionSchema.post('save', function (selection) {
     ).catch((err) => {
       console.log('Error creating parent selection: ', err);
     });
-    resolveGroupWorkspaces(selection, 'create');
+    resolveGroupWorkspaces(selection, 'create').catch((err) => {
+      console.log('Error creating group selection: ', err);
+    });
   } else if (wereUpdatedFields) {
     let allowedParentUpdateFields = [
       'isTrashed',
@@ -220,7 +222,9 @@ SelectionSchema.post('save', function (selection) {
       console.log('Error updating parent selection: ', err);
     });
     if (parentFieldsToUpdate.includes('isTrashed')) {
-      resolveGroupWorkspaces(selection, 'delete');
+      resolveGroupWorkspaces(selection, 'delete').catch((err) => {
+        console.log('Error trashing group selection: ', err);
+      });
     }
   }
 });


### PR DESCRIPTION
## Summary

Cropping a selection in a **group/linked workspace** crashed the Node server, causing intermittent `502`s on image loads (broken thumbnails that "fixed themselves" on refresh).

Cause: `resolveGroupWorkspaces` (fire-and-forget in the Selection `post('save')` hook) dereferenced `parentSub._id` without checking the lookup succeeded. When a group workspace's submissions had diverged from the member's individual workspace, `_.find` returned `undefined` → `TypeError`. With no `.catch()`, it became an unhandled rejection and crashed the process (Node 18+).

Confirmed from enc-test logs: `POST /api/selections` 200 → ~30ms later `TypeError ... at selectionApi.js:534` → process exits → `GET /api/images/file/<id>` hits a dead upstream → nginx `connect() failed (Connection refused)` → 502 → recovers on restart/refresh.

## Changes

- **`selectionApi.js`** — `resolveGroupWorkspaces`: skip workspaces with no matching submission (`if (!parentSub) return null;` + `.filter(Boolean)`) instead of throwing.
- **`selection.js`** — add the missing `.catch()` to both `resolveGroupWorkspaces` calls (`'create'` + `'delete'`), matching `resolveParentUpdates`, so a cascade error can't crash the server.

## Testing

Reproduced the crash on enc-test (crash log + nginx `Connection refused`). After the fix, cropping in the affected workspace keeps `POST /api/selections` and the following `GET /api/images/file/<id>` at `200`; thumbnails load without a refresh.