### PR TITLE
Test/image upload

### DIFF
--- a/app/components/image-upload.js
+++ b/app/components/image-upload.js
@@ -23,6 +23,8 @@ export default class ImageUploadComponent extends Component {
     ? 'application/pdf'
     : 'image/png,image/jpeg,application/pdf';
   @tracked showLoadingMessage = false;
+  @tracked overSizedFileError = null;
+  @tracked isOverSizeLimit = false;
   loadingMessageTimer = null;
   _fileInputEl = null;
 

--- a/tests/integration/components/image-upload-test.js
+++ b/tests/integration/components/image-upload-test.js
@@ -1,0 +1,347 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click, triggerEvent } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import Service from '@ember/service';
+import Component from '@glimmer/component';
+
+const MB = 1024 * 1024;
+
+// Build a File whose `size`/`type` we control. The component only reads
+// `f.size`, `f.type`, and `f.name`, so we can fake large files without
+// allocating real megabytes of data.
+function makeFile(name, type, size) {
+  const file = new File(['x'], name, { type });
+  if (typeof size === 'number') {
+    Object.defineProperty(file, 'size', { value: size });
+  }
+  return file;
+}
+
+// Set a real FileList on the <input> and fire the change event the same way
+// a user picking files would. updateFiles reads from the input's `files`.
+async function selectFiles(files) {
+  const input = document.querySelector('input.image-upload');
+  const dataTransfer = new DataTransfer();
+  files.forEach((file) => dataTransfer.items.add(file));
+  input.files = dataTransfer.files;
+  await triggerEvent(input, 'change');
+}
+
+class ErrorBoxStub extends Component {
+  get isStub() {
+    return true;
+  }
+}
+
+module('Integration | Component | image-upload', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    // fetch is overridden per-test; default to a benign image response.
+    this.originalFetch = window.fetch;
+    this.fetchCalls = [];
+    this.setFetch = (handler) => {
+      window.fetch = (url, options) => {
+        this.fetchCalls.push({ url, options });
+        return handler(url, options);
+      };
+    };
+    this.setFetch(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ images: [{ _id: 'img-1' }] }),
+      })
+    );
+
+    const test = this;
+
+    this.toastCalls = [];
+    this.owner.register(
+      'service:sweet-alert',
+      class extends Service {
+        showToast(type, message) {
+          test.toastCalls.push({ type, message });
+        }
+      }
+    );
+
+    this.pushPayloadCalls = [];
+    this.owner.register(
+      'service:store',
+      class extends Service {
+        pushPayload(payload) {
+          test.pushPayloadCalls.push(payload);
+        }
+      }
+    );
+
+    this.handleErrorsCalls = [];
+    this.owner.register(
+      'service:error-handling',
+      class extends Service {
+        handleErrors(err, key) {
+          test.handleErrorsCalls.push({ err, key });
+        }
+      }
+    );
+
+    this.owner.register(
+      'service:current-user',
+      class extends Service {
+        user = { id: 'user-1' };
+      }
+    );
+
+    // Deterministic, inspectable error output instead of the real component.
+    this.owner.register('component:ui/error-box', ErrorBoxStub);
+    this.owner.register(
+      'template:components/ui/error-box',
+      hbs`
+        <div class='error-box-stub'>
+          <span class='error-text'>{{@error}}</span>
+          {{#if @resetError}}
+            <button
+              type='button'
+              class='dismiss-error'
+              {{on 'click' @resetError}}
+            >
+              Dismiss
+            </button>
+          {{/if}}
+        </div>
+      `
+    );
+  });
+
+  hooks.afterEach(function () {
+    window.fetch = this.originalFetch;
+  });
+
+  async function renderComponent(context, overrides = {}) {
+    context.setProperties({
+      isPdfOnly: false,
+      acceptMultiple: false,
+      hideSubmit: false,
+      doResetFilesAfterUpload: false,
+      handleUploadResults: undefined,
+      storeFiles: undefined,
+      ...overrides,
+    });
+
+    await render(hbs`
+      <ImageUpload
+        @isPdfOnly={{this.isPdfOnly}}
+        @acceptMultiple={{this.acceptMultiple}}
+        @hideSubmit={{this.hideSubmit}}
+        @doResetFilesAfterUpload={{this.doResetFilesAfterUpload}}
+        @handleUploadResults={{this.handleUploadResults}}
+        @storeFiles={{this.storeFiles}}
+      />
+    `);
+  }
+
+  test('it renders the upload form and file input', async function (assert) {
+    await renderComponent(this);
+
+    assert.dom('#image-upload').exists('wrapper id selenium/SCSS rely on');
+    assert
+      .dom('#image-upload form')
+      .hasAttribute('enctype', 'multipart/form-data');
+    assert.dom('input.image-upload[type="file"]').exists('file input renders');
+  });
+
+  test('accept attribute allows images and pdf by default', async function (assert) {
+    await renderComponent(this);
+
+    assert
+      .dom('input.image-upload')
+      .hasAttribute('accept', 'image/png,image/jpeg,application/pdf');
+  });
+
+  test('accept attribute is pdf-only when @isPdfOnly is true', async function (assert) {
+    await renderComponent(this, { isPdfOnly: true });
+
+    assert.dom('input.image-upload').hasAttribute('accept', 'application/pdf');
+  });
+
+  test('the file input is multiple only when @acceptMultiple is true', async function (assert) {
+    await renderComponent(this, { acceptMultiple: false });
+    assert.dom('input.image-upload').doesNotHaveAttribute('multiple');
+
+    await renderComponent(this, { acceptMultiple: true });
+    assert.dom('input.image-upload').hasAttribute('multiple');
+  });
+
+  test('the Upload Files button appears only after files are chosen', async function (assert) {
+    await renderComponent(this);
+
+    assert
+      .dom('input[type="button"][value="Upload Files"]')
+      .doesNotExist('no submit button before any file is selected');
+
+    await selectFiles([makeFile('a.png', 'image/png', 1024)]);
+
+    assert
+      .dom('input[type="button"][value="Upload Files"]')
+      .exists('submit button shows once a file is selected');
+  });
+
+  test('@hideSubmit hides the internal Upload Files button', async function (assert) {
+    await renderComponent(this, { hideSubmit: true });
+
+    await selectFiles([makeFile('a.png', 'image/png', 1024)]);
+
+    assert
+      .dom('input[type="button"][value="Upload Files"]')
+      .doesNotExist('parent owns the submit when @hideSubmit is set');
+  });
+
+  test('@storeFiles is invoked with the chosen files on change', async function (assert) {
+    let received = null;
+    await renderComponent(this, {
+      storeFiles: (files) => {
+        received = files;
+      },
+    });
+
+    await selectFiles([makeFile('a.png', 'image/png', 1024)]);
+
+    assert.ok(received, 'storeFiles callback fired');
+    assert.strictEqual(received.length, 1, 'received the selected FileList');
+    assert.strictEqual(received[0].name, 'a.png');
+  });
+
+  test('a successful image upload posts to /image and reports results', async function (assert) {
+    let uploadResults = null;
+    this.setFetch((url) => {
+      assert.strictEqual(url, '/image', 'posts image files to /image');
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ images: [{ _id: 'img-1' }] }),
+      });
+    });
+
+    await renderComponent(this, {
+      handleUploadResults: (results) => {
+        uploadResults = results;
+      },
+    });
+
+    await selectFiles([makeFile('a.png', 'image/png', 1024)]);
+    await click('input[type="button"][value="Upload Files"]');
+
+    assert.ok(Array.isArray(uploadResults), 'handleUploadResults received array');
+    assert.strictEqual(uploadResults.length, 1);
+    assert.strictEqual(this.pushPayloadCalls.length, 1, 'images pushed to store');
+    assert.strictEqual(this.toastCalls[0].type, 'success', 'success toast shown');
+    assert
+      .dom('.upload-results')
+      .hasText('1 file uploaded successfully!', 'singular results message');
+  });
+
+  test('a successful pdf upload posts to /pdf', async function (assert) {
+    let uploadResults = null;
+    this.setFetch((url) => {
+      assert.strictEqual(url, '/pdf', 'posts pdf files to /pdf');
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({ images: [{ _id: 'page-1' }, { _id: 'page-2' }] }),
+      });
+    });
+
+    await renderComponent(this, {
+      handleUploadResults: (results) => {
+        uploadResults = results;
+      },
+    });
+
+    await selectFiles([makeFile('doc.pdf', 'application/pdf', 2048)]);
+    await click('input[type="button"][value="Upload Files"]');
+
+    assert.strictEqual(uploadResults.length, 2, 'both pages returned');
+    assert
+      .dom('.upload-results')
+      .hasText('2 files uploaded successfully!', 'plural results message');
+  });
+
+  test('an over-sized single file is rejected before any upload', async function (assert) {
+    await renderComponent(this);
+
+    await selectFiles([makeFile('huge.png', 'image/png', 16 * MB)]);
+    await click('input[type="button"][value="Upload Files"]');
+
+    assert.strictEqual(this.fetchCalls.length, 0, 'no request is sent');
+    assert
+      .dom('.error-text')
+      .hasText(
+        'The file huge.png (16.0MB) was not accepted due to exceeding the size limit of 15.0MB'
+      );
+  });
+
+  test('exceeding the total image size limit blocks the upload', async function (assert) {
+    await renderComponent(this);
+
+    await selectFiles([
+      makeFile('a.png', 'image/png', 30 * MB),
+      makeFile('b.png', 'image/png', 30 * MB),
+    ]);
+    await click('input[type="button"][value="Upload Files"]');
+
+    assert.strictEqual(this.fetchCalls.length, 0, 'no request is sent');
+    assert
+      .dom('.error-text')
+      .hasText(
+        'Sorry, the total size of your image uploads (60.0MB) exceeds the maximum of 50.0MB'
+      );
+  });
+
+  test('a server error surfaces a message and is handed to errorHandling', async function (assert) {
+    this.setFetch(() =>
+      Promise.resolve({
+        ok: false,
+        status: 413,
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({ errors: [{ detail: 'too large' }] })
+          ),
+      })
+    );
+
+    await renderComponent(this);
+
+    await selectFiles([makeFile('a.png', 'image/png', 1024)]);
+    await click('input[type="button"][value="Upload Files"]');
+
+    assert
+      .dom('.error-message')
+      .hasText(
+        'Upload is too large for the server limit. Try fewer/smaller files, or ask an admin to increase the upload limit.'
+      );
+    assert.strictEqual(
+      this.handleErrorsCalls.length,
+      1,
+      'errorHandling.handleErrors invoked'
+    );
+    assert.strictEqual(this.handleErrorsCalls[0].key, 'uploadErrors');
+  });
+
+  test('@doResetFilesAfterUpload clears the input after a successful upload', async function (assert) {
+    await renderComponent(this, { doResetFilesAfterUpload: true });
+
+    await selectFiles([makeFile('a.png', 'image/png', 1024)]);
+    assert.dom('input[type="button"][value="Upload Files"]').exists();
+
+    await click('input[type="button"][value="Upload Files"]');
+
+    assert
+      .dom('input[type="button"][value="Upload Files"]')
+      .doesNotExist('files cleared, so the submit button disappears again');
+    assert.strictEqual(
+      document.querySelector('input.image-upload').value,
+      '',
+      'the real file input is reset'
+    );
+  });
+});


### PR DESCRIPTION
## Description

### Summary
The `ImageUpload` component (file/PDF upload used in **problem-info**, **problem-new**, and the **import-work-step3** bulk-import flow) had **zero test coverage** after its Octane/Glimmer migration. This PR adds a 13-test integration suite and, in the process, fixes a user-facing reactivity bug the tests surfaced.

### The bug
`overSizedFileError` and `isOverSizeLimit` are written in `uploadImages()` but were never declared `@tracked`. The template renders the size-limit error boxes conditionally on them:

```hbs
{{#if this.overSizedFileError}} … {{/if}}
{{#if this.isOverSizeLimit}} … {{/if}}
```

Glimmer autotracking only re-evaluates an `{{#if}}` when a **tracked** property it consumed changes. Reading an untracked field subscribes to nothing, so these blocks never re-rendere.  meaning a user who selected an over-sized file (>15MB) or exceeded the total cap (>50MB) **saw no error at all**. Every other piece of mutable display state in the component (`uploadErrors`, `missingFilesError`, `showLoadingMessage`, …) was already `@tracked`; these two were simply missed in the migration.

**Fix:** declare both as `@tracked`. They stay as settable state rather than derived getters by design ,`isOverSizeLimit` is an "attempted upload" flag (the error must appear only after the user clicks Upload, not on selection), and `overSizedFileError` captures the specific offending file's name/size at click time.

### Changes
- **`app/components/image-upload.js`** — add `@tracked overSizedFileError = null;` and `@tracked isOverSizeLimit = false;` .
- **`tests/integration/components/image-upload-test.js`** new test integration suite.

### Testing approach
- Stubs the four service dependencies plus a controllable `Ui::ErrorBox` (renders `.error-text` for exact-message assertions) and a per-test `window.fetch` recorder.
- Simulates real file selection with `DataTransfer` (since `input.files` is read-only) and fakes file `size` via `Object.defineProperty`, so the size-limit paths run without allocating real megabytes.

### Coverage (13 tests)
| Area | Tests |
|------|-------|
| Render / structure | wrapper `#image-upload`, form `enctype`, file input |
| Attributes | `accept` (images+pdf vs pdf-only), `multiple` |
| Submit gating | Upload button appears only after a file is chosen; `@hideSubmit` suppresses it |
| Callbacks | `@storeFiles` fires on change with the FileList |
| Upload success | `/image` (toast + `pushPayload` + singular message); `/pdf` (plural message) |
| Validation | over-sized single file; over-total-image-limit |
| Errors | 413 → friendly message + `errorHandling.handleErrors` |
| Reset | `@doResetFilesAfterUpload` clears the input |

### Result
- 13/13 green via `ember test --filter "image-upload"`.
- The two size-limit error boxes now render for users (previously silent).
- Component is Glimmer-correct and covered; no behavior change beyond the bug fix.