### PR TITLE
feat(ai): route all AI drafts through generate-draft endpoint

### DIFF
--- a/app/services/ai-draft.js
+++ b/app/services/ai-draft.js
@@ -70,8 +70,8 @@ export default class AiDraftService extends Service {
    * A/B TEST MODIFICATION - NEEDS TWEAKING ONCE PREFERRED VARIANT IS FINALIZED
    * A/B TEST MODIFICATION - NEEDS TWEAKING ONCE PREFERRED VARIANT IS FINALIZED
    *
-   * The browser sends only the submission ID. The Encompass backend chooses
-   * generate-draft or generate-draft-ocr and keeps the OCR API key server-side.
+   * The browser sends only the submission ID. The Encompass backend calls the
+   * generate-draft endpoint and keeps the API key server-side.
    *
    * @param {String} submissionId - The ID of the submission to generate feedback for
    * @param {String} variant - Variant key ('A', 'B', 'E', or 'F'); legacy aliases C/D are accepted server-side

--- a/app_server/services/ai.js
+++ b/app_server/services/ai.js
@@ -479,6 +479,7 @@ const generateDraft = async (
   const requestBody = {
     variant,
     use_rag: useRag,
+    async_ticket: true,
     problem: {
       statement: cleanProblemStatement,
     },
@@ -518,6 +519,8 @@ const generateDraft = async (
 
   let aiResult;
   if (ocrContext.images.length > 0) {
+    // Image submissions still send the OCR-shaped payload (images + selected_box
+    // coordinates), but to the default generate-draft endpoint — no OCR URL.
     const ocrRequestBody = buildOcrRequestBody({
       images: ocrContext.images,
       variant,
@@ -527,7 +530,7 @@ const generateDraft = async (
       studentName,
       requestRows: ocrContext.requestRows,
     });
-    aiResult = await makeAIRequest(ocrRequestBody, getOcrEndpointConfig());
+    aiResult = await makeAIRequest(ocrRequestBody);
   } else {
     requestBody.mentor_teacher_context.selections_and_observations =
       rows.map(toTextRequestRow);
@@ -752,69 +755,6 @@ const getTextEndpointConfig = () => ({
   apiKey: process.env.AI_DRAFT_API_KEY,
   protocol: process.env.AI_DRAFT_HOST === 'localhost' ? 'http:' : 'https:',
 });
-
-const buildOcrEndpointConfig = ({
-  endpointUrl,
-  endpointPath,
-  apiKey,
-  fallbackApiKey,
-  hostname,
-  port,
-}) => {
-  if (endpointUrl) {
-    let url;
-    try {
-      url = new URL(endpointUrl);
-    } catch (error) {
-      throw new Error('AI_DRAFT_OCR_URL must be a valid absolute URL.');
-    }
-
-    if (!['http:', 'https:'].includes(url.protocol)) {
-      throw new Error('AI_DRAFT_OCR_URL must use HTTP or HTTPS.');
-    }
-
-    const path = endpointPath || `${url.pathname}${url.search}`;
-    if (!path || path === '/') {
-      throw new Error(
-        'OCR endpoint path is not configured. Set AI_DRAFT_OCR_PATH or include the path in AI_DRAFT_OCR_URL.'
-      );
-    }
-
-    return {
-      hostname: url.hostname,
-      port: url.port,
-      path: normalizeApiPath(path),
-      apiKey: apiKey || fallbackApiKey,
-      protocol: url.protocol,
-    };
-  }
-
-  const config = {
-    hostname,
-    port,
-    path: normalizeApiPath(endpointPath),
-    apiKey: apiKey || fallbackApiKey,
-    protocol: hostname === 'localhost' ? 'http:' : 'https:',
-  };
-
-  if (!config.hostname || !config.path) {
-    throw new Error(
-      'OCR endpoint is not configured. Set AI_DRAFT_OCR_URL or AI_DRAFT_OCR_HOST and AI_DRAFT_OCR_PATH.'
-    );
-  }
-
-  return config;
-};
-
-const getOcrEndpointConfig = () =>
-  buildOcrEndpointConfig({
-    endpointUrl: process.env.AI_DRAFT_OCR_URL,
-    endpointPath: process.env.AI_DRAFT_OCR_PATH,
-    apiKey: process.env.AI_DRAFT_OCR_API_KEY,
-    fallbackApiKey: process.env.AI_DRAFT_API_KEY,
-    hostname: process.env.AI_DRAFT_OCR_HOST,
-    port: process.env.AI_DRAFT_OCR_PORT,
-  });
 
 const buildOcrContext = async (
   targetSubmission,
@@ -1060,7 +1000,6 @@ const makeAIRequest = async (
 
 module.exports.generateDraft = generateDraft;
 module.exports._test = {
-  buildOcrEndpointConfig,
   buildOcrRequestBody,
   buildSelectedBox,
   buildStatusPath,

--- a/test/mocha/unit-tests/ai_ocr.js
+++ b/test/mocha/unit-tests/ai_ocr.js
@@ -2,7 +2,6 @@
 const { expect } = require('chai');
 
 const {
-  buildOcrEndpointConfig,
   buildOcrRequestBody,
   buildSelectedBox,
   buildStatusPath,
@@ -12,36 +11,6 @@ const {
 } = require('../../../app_server/services/ai')._test;
 
 describe('AI OCR request helpers', function () {
-  it('combines the OCR base URL with its configured Lambda path', function () {
-    expect(
-      buildOcrEndpointConfig({
-        endpointUrl: 'https://example.execute-api.us-east-2.amazonaws.com',
-        endpointPath: '/prod/api/generate-draft-ocr',
-        apiKey: 'ocr-key',
-      })
-    ).to.deep.equal({
-      hostname: 'example.execute-api.us-east-2.amazonaws.com',
-      port: '',
-      path: '/prod/api/generate-draft-ocr',
-      apiKey: 'ocr-key',
-      protocol: 'https:',
-    });
-  });
-
-  it('uses a complete OCR URL when a separate path is not configured', function () {
-    expect(
-      buildOcrEndpointConfig({
-        endpointUrl:
-          'https://example.execute-api.us-east-2.amazonaws.com/prod/api/generate-draft-ocr',
-        fallbackApiKey: 'shared-key',
-      })
-    ).to.include({
-      path: '/prod/api/generate-draft-ocr',
-      apiKey: 'shared-key',
-      protocol: 'https:',
-    });
-  });
-
   it('polls ticket status in the same API stage as the OCR endpoint', function () {
     expect(
       buildStatusPath('/prod/api/generate-draft-ocr', 'ticket 123')


### PR DESCRIPTION
## Description

**What changed**

- `app_server/services/ai.js`
  - Image submissions now POST the OCR-shaped payload (images + `selected_box` coordinates, `async_ticket`, `ocr_consensus_n`) to the **generate-draft** endpoint instead of a separate `generate-draft-ocr` URL.
  - Added `async_ticket: true` to the text-only payload so **all** requests use the async ticket flow `makeAIRequest` already expects and polls for.
  - Removed the dead OCR endpoint config — `getOcrEndpointConfig`, `buildOcrEndpointConfig`, and the  env vars, since we only ever hit the generate-draft URL now.
- `app/services/ai-draft.js`
  - Updated the doc comment: the browser still sends only the submission ID, and the backend now calls the single generate-draft endpoint.


**Kept (still building the image payload)**

- `buildOcrContext`, `buildOcrRequestBody`, `buildSelectedBox`, and the  image-prep helpers stay : they assemble the base64 images and `selected_box` coordinates that Bill's side still needs. Only the separate OCR **endpoint config** was removed. The two `buildOcrEndpointConfig` unit tests were dropped with it.