### PR TITLE
Upgrade/workspace info family

### DIFF
--- a/app/components/workspace-info-collaborators-new.hbs
+++ b/app/components/workspace-info-collaborators-new.hbs
@@ -6,8 +6,8 @@
         @maxItems={{1}}
         @initialOptions={{@initialCollabOptions}}
         @selectedItemsHash={{@selectedCollaborators}}
-        @onItemAdd={{action 'setCollab'}}
-        @onItemRemove={{action 'setCollab'}}
+        @onItemAdd={{this.setCollab}}
+        @onItemRemove={{this.setCollab}}
         @labelField='username'
         @valueField='id'
         @searchField='username'
@@ -22,7 +22,7 @@
       <Ui::RadioGroup
         @options={{@globalItems}}
         @selectedValue={{this.globalPermissionValue}}
-        @updateValue={{action 'updateGlobalPermissionValue'}}
+        @updateValue={{this.updateGlobalPermissionValue}}
       />
     </div>
 
@@ -37,12 +37,12 @@
               @cannotBeNull={{true}}
               @selectedValue={{this.submissions}}
               @content={{this.submissionPermissions}}
-              @action={{action (mut this.submissions)}}
+              @action={{this.setSubmissions}}
             />
             {{#if (is-equal this.submissions.value 'custom')}}
               <span class='submission-count'>{{@customSubmissionIds.length}}
                 submissions selected</span>
-              <span class='viewer-toggle' {{action 'toggleSubmissionView'}}>
+              <span class='viewer-toggle' {{on 'click' this.toggleSubmissionView}}>
                 {{if @isShowingCustomViewer 'Hide' 'Show'}}
                 Submission Viewer</span>
             {{/if}}
@@ -57,7 +57,7 @@
               @cannotBeNull={{true}}
               @selectedValue={{this.selections}}
               @content={{this.mainPermissions}}
-              @action={{action (mut this.selections)}}
+              @action={{this.setSelections}}
             />
           </div>
         </div>
@@ -70,7 +70,7 @@
               @cannotBeNull={{true}}
               @selectedValue={{this.comments}}
               @content={{this.mainPermissions}}
-              @action={{action (mut this.comments)}}
+              @action={{this.setComments}}
             />
           </div>
         </div>
@@ -83,7 +83,7 @@
               @cannotBeNull={{true}}
               @selectedValue={{this.folders}}
               @content={{this.mainPermissions}}
-              @action={{action (mut this.folders)}}
+              @action={{this.setFolders}}
             />
           </div>
         </div>
@@ -96,7 +96,7 @@
               @cannotBeNull={{true}}
               @selectedValue={{this.feedback}}
               @content={{this.feedbackPermissions}}
-              @action={{action (mut this.feedback)}}
+              @action={{this.setFeedback}}
             />
           </div>
         </div>
@@ -105,7 +105,7 @@
         <div class='card-row'>
           <Ui::ErrorBox
             @error='Please select a user'
-            @resetError={{action (mut this.missingUserError) false}}
+            @resetError={{this.clearMissingUserError}}
             @showDismiss={{true}}
           />
         </div>
@@ -114,7 +114,7 @@
         <div class='card-row'>
           <Ui::ErrorBox
             @error='Collaborator already exists. Edit permissions below'
-            @resetError={{action (mut this.existingUserError) false}}
+            @resetError={{this.clearExistingUserError}}
             @showDismiss={{true}}
           />
         </div>
@@ -123,12 +123,12 @@
         <button
           class='primary-button cancel-button'
           type='button'
-          {{action 'cancelCreateCollab'}}
+          {{on 'click' this.cancelCreateCollab}}
         >Cancel</button>
         <button
           class='primary-button'
           type='button'
-          {{action 'saveCollab'}}
+          {{on 'click' this.saveCollab}}
         >Save</button>
       </div>
     </div>

--- a/app/components/workspace-info-collaborators-new.js
+++ b/app/components/workspace-info-collaborators-new.js
@@ -89,13 +89,34 @@ export default class WorkspaceInfoCollaboratorsNewComponent extends Component {
   @action updateGlobalPermissionValue(val) {
     this.globalPermissionValue = val;
   }
+  @action setSubmissions(val) {
+    this.submissions = val;
+  }
+  @action setSelections(val) {
+    this.selections = val;
+  }
+  @action setComments(val) {
+    this.comments = val;
+  }
+  @action setFolders(val) {
+    this.folders = val;
+  }
+  @action setFeedback(val) {
+    this.feedback = val;
+  }
+  @action clearMissingUserError() {
+    this.missingUserError = false;
+  }
+  @action clearExistingUserError() {
+    this.existingUserError = false;
+  }
   @action setCollab(val) {
     if (!val) {
       return;
     }
-    let existingCollab = this.args.workspace.get('collaborators');
+    const existingCollab = this.args.workspace.collaborators;
     const user = this.store.peekRecord('user', val);
-    let alreadyCollab = existingCollab.includes(user.get('id'));
+    const alreadyCollab = existingCollab.includes(user.id);
 
     if (alreadyCollab) {
       this.existingUserError = true;
@@ -112,10 +133,10 @@ export default class WorkspaceInfoCollaboratorsNewComponent extends Component {
       return;
     }
     let ws = this.args.workspace;
-    let permissions = ws.get('permissions');
+    let permissions = ws.permissions;
 
     let newObj = {
-      user: this.collabUser.get('id'),
+      user: this.collabUser.id,
       global: this.globalPermissionValue,
       submissions: { all: false, userOnly: false, submissionIds: [] },
     };
@@ -188,12 +209,12 @@ export default class WorkspaceInfoCollaboratorsNewComponent extends Component {
       ? [...permissions, newObj]
       : [newObj];
 
-    ws.set('permissions', newPermissions);
+    ws.permissions = newPermissions;
 
     ws.save().then(() => {
       this.alert.showToast(
         'success',
-        `${this.collabUser.get('username')} added as collaborator`,
+        `${this.collabUser.username} added as collaborator`,
         'bottom-end',
         3000,
         null,

--- a/app/components/workspace-info-collaborators.hbs
+++ b/app/components/workspace-info-collaborators.hbs
@@ -3,7 +3,7 @@
     <div class='heading'>
       Collaborators
       {{#if @canEdit}}
-        <span class='heading-icon' {{action 'addCollaborator'}}>
+        <span class='heading-icon' {{on 'click' this.addCollaborator}}>
           <i class='fas fa-plus'></i>
         </span>
       {{/if}}
@@ -14,7 +14,7 @@
           <ParentWsCollabNew
             @workspace={{@workspace}}
             @createNewCollaborator={{this.createNewCollaborator}}
-            @cancelEditCollab={{action 'cancelEditCollab'}}
+            @cancelEditCollab={{this.cancelEditCollab}}
             @originalCollaborators={{@originalCollaborators}}
             @initialCollabOptions={{@initialCollabOptions}}
             @selectedCollaborators={{@selectedCollaborators}}
@@ -26,7 +26,7 @@
           <WorkspaceInfoCollaboratorsNew
             @workspace={{@workspace}}
             @createNewCollaborator={{this.createNewCollaborator}}
-            @cancelEditCollab={{action 'cancelEditCollab'}}
+            @cancelEditCollab={{this.cancelEditCollab}}
             @isShowingCustomViewer={{@isShowingCustomViewer}}
             @customSubmissionIds={{@customSubmissionIds}}
             @originalCollaborators={{@originalCollaborators}}
@@ -54,12 +54,12 @@
                     }}
                       <i
                         class='fas fa-minus-circle'
-                        {{action 'removeCollab' collaborator.userObj}}
+                        {{on 'click' (fn this.removeCollab collaborator.userObj)}}
                       ></i>
                     {{else}}
                       <i
                         class='fas fa-edit'
-                        {{action 'editCollab' collaborator}}
+                        {{on 'click' (fn this.editCollab collaborator)}}
                       ></i>
                     {{/if}}
                   </span>
@@ -81,7 +81,7 @@
                     <button
                       class='primary-button cancel-button'
                       type='button'
-                      {{action 'cancelEditCollab'}}
+                      {{on 'click' this.cancelEditCollab}}
                     >Cancel</button>
                   </div>
                 {{/if}}
@@ -103,12 +103,12 @@
                     }}
                       <i
                         class='fas fa-minus-circle'
-                        {{action 'removeCollab' collaborator.userObj}}
+                        {{on 'click' (fn this.removeCollab collaborator.userObj)}}
                       ></i>
                     {{else}}
                       <i
                         class='fas fa-edit'
-                        {{action 'editCollab' collaborator}}
+                        {{on 'click' (fn this.editCollab collaborator)}}
                       ></i>
                     {{/if}}
                   </span>
@@ -132,7 +132,7 @@
                       <Ui::RadioGroup
                         @options={{this.globalItems}}
                         @selectedValue={{this.globalPermissionValue}}
-                        @updateValue={{action 'updateGlobalPermissionValue'}}
+                        @updateValue={{this.updateGlobalPermissionValue}}
                       />
                     {{else}}
                       {{collab-permissions collaborator.global}}
@@ -162,7 +162,7 @@
                           @cannotBeNull={{true}}
                           @selectedValue={{this.submissions}}
                           @content={{this.submissionPermissions}}
-                          @action={{action (mut this.submissions)}}
+                          @action={{this.setSubmissions}}
                         />
                         {{#if (is-equal this.submissions.value 'custom')}}
                           <span
@@ -172,12 +172,12 @@
                           {{#if @isShowingCustomViewer}}
                             <span
                               class='viewer-toggle'
-                              {{action 'toggleSubmissionView'}}
+                              {{on 'click' this.toggleSubmissionView}}
                             >Hide Submission Viewer</span>
                           {{else}}
                             <span
                               class='viewer-toggle'
-                              {{action 'toggleSubmissionView'}}
+                              {{on 'click' this.toggleSubmissionView}}
                             >Show Submission Viewer</span>
                           {{/if}}
                         {{/if}}
@@ -192,7 +192,7 @@
                           @cannotBeNull={{true}}
                           @selectedValue={{this.selections}}
                           @content={{this.mainPermissions}}
-                          @action={{action (mut this.selections)}}
+                          @action={{this.setSelections}}
                         />
                       </div>
                     </div>
@@ -205,7 +205,7 @@
                           @cannotBeNull={{true}}
                           @selectedValue={{this.comments}}
                           @content={{this.mainPermissions}}
-                          @action={{action (mut this.comments)}}
+                          @action={{this.setComments}}
                         />
                       </div>
                     </div>
@@ -218,7 +218,7 @@
                           @cannotBeNull={{true}}
                           @selectedValue={{this.folders}}
                           @content={{this.mainPermissions}}
-                          @action={{action (mut this.folders)}}
+                          @action={{this.setFolders}}
                         />
                       </div>
                     </div>
@@ -231,7 +231,7 @@
                           @cannotBeNull={{true}}
                           @selectedValue={{this.feedback}}
                           @content={{this.feedbackPermission}}
-                          @action={{action (mut this.feedback)}}
+                          @action={{this.setFeedback}}
                         />
                       </div>
                     </div>
@@ -253,7 +253,7 @@
                             @cannotBeNull={{true}}
                             @selectedValue={{this.submissions}}
                             @content={{this.submissionPermissions}}
-                            @action={{action (mut this.submissions)}}
+                            @action={{this.setSubmissions}}
                           />
                           {{#if (is-equal this.submissions.value 'custom')}}
                             <span
@@ -262,7 +262,7 @@
                               submissions selected</span>
                             <span
                               class='viewer-toggle'
-                              {{action 'toggleSubmissionView'}}
+                              {{on 'click' this.toggleSubmissionView}}
                             >
                               {{if @isShowingCustomViewer 'Hide' 'Show'}}
                               Submission Viewer</span>
@@ -320,12 +320,12 @@
                     <button
                       class='primary-button cancel-button'
                       type='button'
-                      {{action 'cancelEditCollab'}}
+                      {{on 'click' this.cancelEditCollab}}
                     >Cancel</button>
                     <button
                       class='primary-button'
                       type='button'
-                      {{action 'savePermissions' collaborator}}
+                      {{on 'click' (fn this.savePermissions collaborator)}}
                     >Save</button>
                   </div>
                 {{/if}}

--- a/app/components/workspace-info-collaborators.js
+++ b/app/components/workspace-info-collaborators.js
@@ -148,8 +148,8 @@ export default class WorkspaceInfoCollaborators extends Component {
   }
 
   get workspacePermissions() {
-    let permissions = this.args.workspace.get('permissions');
-    let collabs = this.args.originalCollaborators;
+    const permissions = this.args.workspace.permissions;
+    const collabs = this.args.originalCollaborators;
 
     if (!this.utils.isNonEmptyArray(permissions)) {
       return [];
@@ -266,6 +266,22 @@ export default class WorkspaceInfoCollaborators extends Component {
     this.globalPermissionValue = val;
   }
 
+  @action setSubmissions(val) {
+    this.submissions = val;
+  }
+  @action setSelections(val) {
+    this.selections = val;
+  }
+  @action setComments(val) {
+    this.comments = val;
+  }
+  @action setFolders(val) {
+    this.folders = val;
+  }
+  @action setFeedback(val) {
+    this.feedback = val;
+  }
+
   @action editCollab(collaborator) {
     this.isEditing = true;
     if (!this.utils.isNonEmptyObject(collaborator)) {
@@ -295,7 +311,7 @@ export default class WorkspaceInfoCollaborators extends Component {
     if (!this.utils.isNonEmptyObject(permissionsObject)) {
       return;
     }
-    const permissions = this.args.workspace.get('permissions');
+    const permissions = this.args.workspace.permissions;
     let existingObj = Array.isArray(permissions)
       ? permissions.find((p) => p.user === permissionsObject.user)
       : null;
@@ -381,13 +397,13 @@ export default class WorkspaceInfoCollaborators extends Component {
       updatedPermissions = [newObj];
     }
 
-    ws.set('permissions', updatedPermissions);
+    ws.permissions = updatedPermissions;
 
     ws.save().then(() => {
       this.globalPermissionValue = null;
       this.alert.showToast(
         'success',
-        `Permissions set for ${permissionsObject.userObj.get('username')}`,
+        `Permissions set for ${permissionsObject.userObj.username}`,
         'bottom-end',
         3000,
         null,
@@ -405,15 +421,15 @@ export default class WorkspaceInfoCollaborators extends Component {
     if (!utils.isNonEmptyObject(user)) {
       return;
     }
-    const permissions = this.args.workspace.get('permissions');
+    const permissions = this.args.workspace.permissions;
 
     if (utils.isNonEmptyArray(permissions)) {
-      const objToRemove = permissions.find((p) => p.user === user.get('id'));
+      const objToRemove = permissions.find((p) => p.user === user.id);
       if (objToRemove) {
-        let userDisplay = user.get('username');
+        let userDisplay = user.username;
         let pronoun = 'their';
 
-        let isSelf = user.get('id') === this.currentUser.user.id;
+        let isSelf = user.id === this.currentUser.user.id;
 
         if (isSelf) {
           userDisplay = 'yourself';
@@ -433,12 +449,12 @@ export default class WorkspaceInfoCollaborators extends Component {
               const updatedPermissions = Array.isArray(permissions)
                 ? permissions.filter((p) => p !== objToRemove)
                 : [];
-              workspace.set('permissions', updatedPermissions);
+              workspace.permissions = updatedPermissions;
 
               workspace.save().then(() => {
                 this.alert.showToast(
                   'success',
-                  `${user.get('username')} removed`,
+                  `${user.username} removed`,
                   'bottom-end',
                   3000,
                   null,

--- a/app/components/workspace-info-settings.hbs
+++ b/app/components/workspace-info-settings.hbs
@@ -7,7 +7,7 @@
           <span
             class='heading-icon'
             data-test='ws-settings-edit'
-            {{action 'editWorkspaceInfo'}}
+            {{on 'click' this.editWorkspaceInfo}}
           >
             <i class='fas fa-edit'></i>
           </span>
@@ -61,8 +61,8 @@
               @inputId='owner-select'
               @maxItems={{1}}
               @initialItems={{this.initialOwnerItem}}
-              @onItemAdd={{action 'setOwner'}}
-              @onItemRemove={{action 'setOwner'}}
+              @onItemAdd={{this.setOwner}}
+              @onItemRemove={{this.setOwner}}
               @labelField='username'
               @valueField='id'
               @searchField='username'
@@ -90,7 +90,7 @@
               @cannotBeNull={{true}}
               @selectedValue={{this.selectedMode}}
               @content={{this.modes}}
-              @action={{action (mut this.selectedMode)}}
+              @action={{this.setSelectedMode}}
             />
           {{else}}
             {{@workspace.mode}}
@@ -108,8 +108,8 @@
                 @inputId='linked-assignment-select'
                 @maxItems={{1}}
                 @initialItems={{this.initialLinkedAssignmentItem}}
-                @onItemAdd={{action 'setLinkedAssignment'}}
-                @onItemRemove={{action 'setLinkedAssignment'}}
+                @onItemAdd={{this.setLinkedAssignment}}
+                @onItemRemove={{this.setLinkedAssignment}}
                 @labelField='name'
                 @valueField='id'
                 @searchField='name'
@@ -143,7 +143,7 @@
                 @cannotBeNull={{true}}
                 @selectedValue={{this.selectedAutoUpdateSetting}}
                 @content={{this.yesNoMySelect}}
-                @action={{action (mut this.selectedAutoUpdateSetting)}}
+                @action={{this.setSelectedAutoUpdateSetting}}
               />
             {{else}}
               {{yes-no @workspace.doAllowSubmissionUpdates}}
@@ -155,22 +155,22 @@
             <button
               class='primary-button'
               type='button'
-              {{action 'updateWithExistingWork'}}
+              {{on 'click' this.updateWithExistingWork}}
             >Update Workspace</button>
             <div class='update-results'>
               {{#if this.missingLinkedAssignment}}
                 <Ui::ErrorBox
                   @error='Please link an assignment first.'
                   @showDismiss={{true}}
-                  @resetError={{action (mut this.missingLinkedAssignment) null}}
+                  @resetError={{this.clearMissingLinkedAssignment}}
                 />
               {{/if}}
               {{#each this.updateErrors as |error|}}
                 <Ui::ErrorBox
                   @error={{error}}
                   @showDismiss={{true}}
-                  @resetError={{action
-                    'removeErrorFromArray'
+                  @resetError={{fn
+                    this.removeErrorFromArray
                     'updateErrors'
                     error
                   }}
@@ -180,8 +180,8 @@
                 <Ui::ErrorBox
                   @error={{error}}
                   @showDismiss={{true}}
-                  @resetError={{action
-                    'removeErrorFromArray'
+                  @resetError={{fn
+                    this.removeErrorFromArray
                     'serverErrors'
                     error
                   }}
@@ -223,10 +223,10 @@
                 @cannotBeNull={{true}}
                 @selectedValue={{this.selectedAutoUpdateSetting}}
                 @content={{this.yesNoMySelect}}
-                @action={{action (mut this.selectedAutoUpdateSetting)}}
+                @action={{this.setSelectedAutoUpdateSetting}}
               />
             {{else}}
-              {{yes-no this.workspace.doAutoUpdateFromChildren}}
+              {{yes-no @workspace.doAutoUpdateFromChildren}}
             {{/if}}
           </div>
         </div>
@@ -236,22 +236,22 @@
               class='primary-button'
               data-test='parent-ws-update'
               type='button'
-              {{action 'updateWithExistingWork'}}
+              {{on 'click' this.updateWithExistingWork}}
             >Update Parent Workspace</button>
             <div class='update-results'>
               {{#if this.missingChildWorkspaces}}
                 <Ui::ErrorBox
                   @error='No child workspaces to update from'
                   @showDismiss={{true}}
-                  @resetError={{action (mut this.missingChildWorkspaces) null}}
+                  @resetError={{this.clearMissingChildWorkspaces}}
                 />
               {{/if}}
               {{#each this.updateErrors as |error|}}
                 <Ui::ErrorBox
                   @error={{error}}
                   @showDismiss={{true}}
-                  @resetError={{action
-                    'removeErrorFromArray'
+                  @resetError={{fn
+                    this.removeErrorFromArray
                     'updateErrors'
                     error
                   }}
@@ -261,8 +261,8 @@
                 <Ui::ErrorBox
                   @error={{error}}
                   @showDismiss={{true}}
-                  @resetError={{action
-                    'removeErrorFromArray'
+                  @resetError={{fn
+                    this.removeErrorFromArray
                     'serverErrors'
                     error
                   }}
@@ -294,12 +294,12 @@
           <button
             class='primary-button cancel-button'
             type='button'
-            {{action 'stopEditing'}}
+            {{on 'click' this.stopEditing}}
           >Cancel</button>
           <button
             class='primary-button'
             type='button'
-            {{action 'checkWorkspace'}}
+            {{on 'click' this.checkWorkspace}}
           >Save</button>
         </div>
       {{/if}}

--- a/app/components/workspace-info-settings.js
+++ b/app/components/workspace-info-settings.js
@@ -46,15 +46,17 @@ export default class WorkspaceInfoSettingsComponent extends ErrorHandlingCompone
   }
 
   get initialOwnerItem() {
-    const owner = this.args.workspace.get('owner');
-    if (this.utils.isNonEmptyObject(owner)) {
-      return [owner.get('id')];
+    const ownerId = this.args.workspace.belongsTo('owner').id();
+    if (ownerId) {
+      return [ownerId];
     }
     return [];
   }
 
   get initialLinkedAssignmentItem() {
-    let linkedAssignmentId = this.args.linkedAssignment.get('id');
+    const linkedAssignmentId = this.args.workspace
+      .belongsTo('linkedAssignment')
+      .id();
 
     if (linkedAssignmentId) {
       return [linkedAssignmentId];
@@ -85,6 +87,19 @@ export default class WorkspaceInfoSettingsComponent extends ErrorHandlingCompone
     return boolean ? 'Yes' : 'No';
   }
 
+  @action setSelectedMode(val) {
+    this.selectedMode = val;
+  }
+  @action setSelectedAutoUpdateSetting(val) {
+    this.selectedAutoUpdateSetting = val;
+  }
+  @action clearMissingLinkedAssignment() {
+    this.missingLinkedAssignment = null;
+  }
+  @action clearMissingChildWorkspaces() {
+    this.missingChildWorkspaces = null;
+  }
+
   @action editWorkspaceInfo() {
     this.isEditing = true;
     let workspace = this.args.workspace;
@@ -107,13 +122,13 @@ export default class WorkspaceInfoSettingsComponent extends ErrorHandlingCompone
 
     const user = this.store.peekRecord('user', val);
     if (this.utils.isNonEmptyObject(user)) {
-      workspace.set('owner', user);
-      let ownerOrg = user.get('organization');
-      let ownerOrgName = ownerOrg.get('name');
-      let ownerOrgId = ownerOrg.get('id');
-      let workspaceOrg = workspace.get('organization');
-      let workspaceOrgName = workspaceOrg.get('name');
-      let workspaceOrgId = workspaceOrg.get('id');
+      workspace.owner = user;
+      const ownerOrg = user.belongsTo('organization').value();
+      const ownerOrgName = ownerOrg?.name;
+      const ownerOrgId = ownerOrg?.id;
+      const workspaceOrg = workspace.belongsTo('organization').value();
+      const workspaceOrgName = workspaceOrg?.name;
+      const workspaceOrgId = workspaceOrg?.id;
 
       if (workspaceOrgId) {
         if (workspaceOrgId !== ownerOrgId) {
@@ -127,19 +142,19 @@ export default class WorkspaceInfoSettingsComponent extends ErrorHandlingCompone
             )
             .then((results) => {
               if (results.value) {
-                workspace.set('organization', ownerOrg);
+                workspace.organization = ownerOrg;
                 this.saveOwner = user;
               } else {
-                workspace.set('organization', workspaceOrg);
+                workspace.organization = workspaceOrg;
                 this.saveOwner = user;
               }
             });
         } else {
-          workspace.set('organization', ownerOrg);
+          workspace.organization = ownerOrg;
           this.saveOwner = user;
         }
       } else {
-        workspace.set('organization', ownerOrg);
+        workspace.organization = ownerOrg;
         this.saveOwner = user;
       }
     }
@@ -163,7 +178,7 @@ export default class WorkspaceInfoSettingsComponent extends ErrorHandlingCompone
     let assignment = this.store.peekRecord('assignment', val);
 
     if (assignment) {
-      if (assignment.get('id') !== linkedAssignmentId) {
+      if (assignment.id !== linkedAssignmentId) {
         this.selectedLinkedAssignment = assignment;
         this.didLinkedAssignmentChange = true;
       }
@@ -171,13 +186,13 @@ export default class WorkspaceInfoSettingsComponent extends ErrorHandlingCompone
   }
 
   @action checkWorkspace() {
-    let workspace = this.args.workspace;
-    let workspaceOrg = workspace.get('organization.content');
-    let workspaceOwner = workspace.get('owner');
-    let ownerOrg = workspaceOwner.get('organization');
-    let ownerOrgName = ownerOrg.get('name');
-    let mode = this.selectedMode;
-    workspace.set('mode', mode);
+    const workspace = this.args.workspace;
+    const workspaceOrg = workspace.belongsTo('organization').value();
+    const workspaceOwner = workspace.belongsTo('owner').value();
+    const ownerOrg = workspaceOwner?.belongsTo('organization').value();
+    const ownerOrgName = ownerOrg?.name;
+    const mode = this.selectedMode;
+    workspace.mode = mode;
     if (mode === 'org' && workspaceOrg === null) {
       this.alert
         .showModal(
@@ -189,7 +204,7 @@ export default class WorkspaceInfoSettingsComponent extends ErrorHandlingCompone
         )
         .then((results) => {
           if (results.value) {
-            workspace.set('organization', ownerOrg);
+            workspace.organization = ownerOrg;
             this.saveWorkspace();
           }
         });
@@ -217,17 +232,17 @@ export default class WorkspaceInfoSettingsComponent extends ErrorHandlingCompone
         ? 'doAutoUpdateFromChildren'
         : 'doAllowSubmissionUpdates';
 
-      if (updateSettingBool !== workspace.get(updateProp)) {
-        workspace.set(updateProp, updateSettingBool);
+      if (updateSettingBool !== workspace[updateProp]) {
+        workspace[updateProp] = updateSettingBool;
       }
     }
 
     if (this.didLinkedAssignmentChange) {
-      workspace.set('linkedAssignment', this.selectedLinkedAssignment);
+      workspace.linkedAssignment = this.selectedLinkedAssignment;
     }
 
     if (
-      workspace.get('hasDirtyAttributes') ||
+      workspace.hasDirtyAttributes ||
       this.saveOwner ||
       this.didLinkedAssignmentChange
     ) {
@@ -328,7 +343,7 @@ export default class WorkspaceInfoSettingsComponent extends ErrorHandlingCompone
         this.isUpdateRequestInProgress = false;
 
         if (isParentUpdate) {
-          if (results.get('wasNoDataToUpdate') === true) {
+          if (results.wasNoDataToUpdate === true) {
             console.log('[UPDATE WORKSPACE] Parent workspace up to date');
             this.alert.showToast(
               'info',
@@ -359,7 +374,7 @@ export default class WorkspaceInfoSettingsComponent extends ErrorHandlingCompone
           }
         }
 
-        if (results.get('wereNoAnswersToUpdate') === true) {
+        if (results.wereNoAnswersToUpdate === true) {
           this.alert.showToast(
             'info',
             'Workspace Up to Date',
@@ -370,7 +385,7 @@ export default class WorkspaceInfoSettingsComponent extends ErrorHandlingCompone
           );
           return;
         }
-        if (this.utils.isNonEmptyArray(results.get('updateErrors'))) {
+        if (this.utils.isNonEmptyArray(results.updateErrors)) {
           this.updateErrors = results.updateErrors;
           return;
         }

--- a/app/components/workspace-info.hbs
+++ b/app/components/workspace-info.hbs
@@ -19,7 +19,7 @@
       @workspace={{@workspace}}
       @originalCollaborators={{@originalCollaborators}}
       @isShowingCustomViewer={{this.isShowingCustomViewer}}
-      @toggleIsShowingCustomViewer={{action 'toggleIsShowingCustomViewer'}}
+      @toggleIsShowingCustomViewer={{this.toggleIsShowingCustomViewer}}
       @customSubmissionIds={{this.customSubmissionIds}}
       @initialCollabOptions={{this.initialCollabOptions}}
       @selectedCollaborators={{this.selectedCollaborators}}
@@ -37,9 +37,9 @@
       <CustomSubmissionViewerList
         @submissions={{@workspace.submissions.content}}
         @selectedSubmissionIds={{this.customSubmissionIds}}
-        @onSelect={{action 'updateCustomSubs'}}
-        @onSelectAll={{action 'selectAllSubmissions'}}
-        @onUnselectAll={{action 'deselectAllSubmissions'}}
+        @onSelect={{this.updateCustomSubs}}
+        @onSelectAll={{this.selectAllSubmissions}}
+        @onUnselectAll={{this.deselectAllSubmissions}}
         @onDone={{this.toggleIsShowingCustomViewer}}
       />
     {{/if}}

--- a/app/components/workspace-info.js
+++ b/app/components/workspace-info.js
@@ -1,6 +1,5 @@
 import ErrorHandlingComponent from './error-handling';
 import { tracked } from '@glimmer/tracking';
-// import { inject as controller } from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import isObject from 'lodash-es/isObject';
@@ -8,7 +7,6 @@ import isString from 'lodash-es/isString';
 
 export default class WorkspaceInfoComponent extends ErrorHandlingComponent {
   @service('current-user') currentUser;
-  // comments: controller(),
   @service('sweet-alert') alert;
   @service store;
   @service('utility-methods') utils;
@@ -17,14 +15,11 @@ export default class WorkspaceInfoComponent extends ErrorHandlingComponent {
   @tracked customSubmissionIds = [];
 
   get canEdit() {
-    let workspace = this.args.workspace;
-    // let ownerId = workspace.get('owner.id');
-    let creatorId = workspace.get('createdBy.id');
-    let currentUser = this.currentUser.user;
-    let accountType = currentUser.accountType;
-    let isAdmin = accountType === 'A';
-    // let isOwner = ownerId === currentUser.id;
-    let isCreator = creatorId === currentUser.id;
+    const workspace = this.args.workspace;
+    const creatorId = workspace.belongsTo('createdBy').id();
+    const currentUser = this.currentUser.user;
+    const isAdmin = currentUser.accountType === 'A';
+    const isCreator = creatorId === currentUser.id;
 
     return isAdmin || isCreator;
   }
@@ -33,38 +28,32 @@ export default class WorkspaceInfoComponent extends ErrorHandlingComponent {
     if (this.canEdit) {
       return true;
     }
-    return this.args.workspace
-      .get('feedbackAuthorizers')
-      .includes(this.currentUser.user.id);
+    return this.args.workspace.feedbackAuthorizers.includes(
+      this.currentUser.user.id
+    );
   }
 
   get initialCollabOptions() {
-    let peeked = this.store.peekAll('user');
-    let collabs = this.selectedCollaborators;
+    const peeked = this.store.peekAll('user');
+    const collabs = this.selectedCollaborators;
 
     if (!isObject(peeked)) {
       return [];
     }
-    let filtered = peeked.reject((record) => {
-      return collabs[record.get('id')];
-    });
-    return filtered.map((obj) => {
-      return {
-        id: obj.get('id'),
-        username: obj.get('username'),
-      };
-    });
+    return [...peeked]
+      .filter((record) => !collabs[record.id])
+      .map((obj) => ({ id: obj.id, username: obj.username }));
   }
 
   get selectedCollaborators() {
-    let hash = {};
-    let wsOwnerId = this.args.workspace.get('owner.id');
+    const hash = {};
+    const wsOwnerId = this.args.workspace.belongsTo('owner').id();
 
     // no reason to set owner as a collaborator
     if (wsOwnerId) {
       hash[wsOwnerId] = true;
     }
-    const originalCollaborators = this.originalCollaborators;
+    const originalCollaborators = this.args.originalCollaborators;
 
     if (!this.utils.isNonEmptyArray(originalCollaborators)) {
       return hash;
@@ -73,40 +62,42 @@ export default class WorkspaceInfoComponent extends ErrorHandlingComponent {
       if (isString(user)) {
         hash[user] = true;
       } else if (isObject(user)) {
-        hash[user.get('id')] = true;
+        hash[user.id] = true;
       }
     });
     return hash;
   }
 
-  @action removeErrorString(arrayPropName, errorString) {
-    let errors = this[arrayPropName];
+  @action
+  removeErrorString(arrayPropName, errorString) {
+    const errors = this[arrayPropName];
     if (Array.isArray(errors)) {
-      errors.removeObject(errorString);
+      this[arrayPropName] = errors.filter((e) => e !== errorString);
     }
   }
-  @action updateCustomSubs(id) {
-    if (!this.utils.isNonEmptyArray(this.customSubmissionIds)) {
-      this.customSubmissionIds = [];
-    }
-    const customSubmissionIds = this.customSubmissionIds;
 
-    const isIn = customSubmissionIds.includes(id);
-    if (isIn) {
-      customSubmissionIds.removeObject(id);
-    } else {
-      customSubmissionIds.addObject(id);
-    }
+  @action
+  updateCustomSubs(id) {
+    const current = Array.isArray(this.customSubmissionIds)
+      ? this.customSubmissionIds
+      : [];
+    this.customSubmissionIds = current.includes(id)
+      ? current.filter((x) => x !== id)
+      : [...current, id];
   }
-  @action selectAllSubmissions() {
-    this.customSubmissionIds = this.args.workspace
-      .get('submissions')
-      .mapBy('id');
+
+  @action
+  selectAllSubmissions() {
+    this.customSubmissionIds = this.args.workspace.hasMany('submissions').ids();
   }
-  @action deselectAllSubmissions() {
+
+  @action
+  deselectAllSubmissions() {
     this.customSubmissionIds = [];
   }
-  @action toggleIsShowingCustomViewer() {
+
+  @action
+  toggleIsShowingCustomViewer() {
     this.isShowingCustomViewer = !this.isShowingCustomViewer;
   }
 }

--- a/tests/integration/components/workspace-info-collaborators-new-test.js
+++ b/tests/integration/components/workspace-info-collaborators-new-test.js
@@ -1,0 +1,188 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click, settled } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { A } from '@ember/array';
+import templateOnly from '@ember/component/template-only';
+import Service from '@ember/service';
+
+module(
+  'Integration | Component | workspace-info-collaborators-new',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    function findButtonByText(text) {
+      const buttons = Array.from(document.querySelectorAll('button'));
+      return buttons.find((btn) => btn.textContent.trim() === text);
+    }
+
+    hooks.beforeEach(function () {
+      const store = this.owner.lookup('service:store');
+
+      class UtilityMethodsService extends Service {
+        isNonEmptyObject(obj) {
+          return obj && typeof obj === 'object' && Object.keys(obj).length > 0;
+        }
+        isNonEmptyArray(arr) {
+          return Array.isArray(arr) && arr.length > 0;
+        }
+      }
+
+      class SweetAlertService extends Service {
+        showToast() {
+          return Promise.resolve();
+        }
+      }
+
+      this.owner.register('service:utility-methods', UtilityMethodsService);
+      this.owner.register('service:sweet-alert', SweetAlertService);
+
+      // Stub the UI children so the form renders in isolation.
+      const register = (name, tmpl) => {
+        this.owner.register(`template:components/${name}`, tmpl);
+        this.owner.register(`component:${name}`, templateOnly());
+      };
+      register(
+        'selectize-input',
+        hbs`<div class='stub-selectize'>
+          <button
+            type='button'
+            class='add-existing'
+            {{on 'click' (fn @onItemAdd 'user-1')}}
+          >add existing</button>
+          <button
+            type='button'
+            class='add-new'
+            {{on 'click' (fn @onItemAdd 'user-2')}}
+          >add new</button>
+        </div>`
+      );
+      register(
+        'ui/radio-group',
+        hbs`<div class='stub-radio'>
+          <button
+            type='button'
+            class='pick-custom'
+            {{on 'click' (fn @updateValue 'custom')}}
+          >custom</button>
+        </div>`
+      );
+      register('ui/my-select', hbs`<div class='stub-select'></div>`);
+      register(
+        'ui/error-box',
+        hbs`<div class='stub-error'>{{@error}}
+          <button type='button' class='dismiss' {{on 'click' @resetError}}>x</button>
+        </div>`
+      );
+
+      // Seed one existing collaborator (user-1) via the permissions attr; the
+      // component's collaborators getter derives ids from it.
+      const workspace = store.createRecord('workspace', {
+        id: 'ws-1',
+        name: 'Test Workspace',
+        workspaceType: 'individual',
+        permissions: [
+          {
+            user: 'user-1',
+            global: 'viewOnly',
+            submissions: { all: true, userOnly: false, submissionIds: [] },
+          },
+        ],
+      });
+      workspace.save = () => Promise.resolve();
+
+      store.createRecord('user', { id: 'user-1', username: 'existing' });
+      store.createRecord('user', { id: 'user-2', username: 'newuser' });
+
+      this.cancelCount = 0;
+      this.set('onCancel', () => {
+        this.cancelCount += 1;
+      });
+      this.set('workspace', workspace);
+      this.set('originalCollaborators', A([]));
+      this.set('customSubmissionIds', []);
+      this.set('globalItems', {
+        groupName: 'globalPermissionValue',
+        groupLabel: 'Workspace Permissions',
+        inputs: [],
+      });
+    });
+
+    async function renderComponent(context) {
+      return render(hbs`
+        <WorkspaceInfoCollaboratorsNew
+          @workspace={{this.workspace}}
+          @createNewCollaborator={{true}}
+          @cancelEditCollab={{this.onCancel}}
+          @isShowingCustomViewer={{false}}
+          @customSubmissionIds={{this.customSubmissionIds}}
+          @originalCollaborators={{this.originalCollaborators}}
+          @globalItems={{this.globalItems}}
+          @initialCollabOptions={{this.initialCollabOptions}}
+          @selectedCollaborators={{this.selectedCollaborators}}
+        />
+      `);
+    }
+
+    test('renders the add-collaborator form with the user search, permission group, and Save/Cancel', async function (assert) {
+      await renderComponent(this);
+
+      assert.dom('#workspace-info-collaborators-new').exists();
+      assert.dom('.stub-selectize').exists('renders the user search');
+      assert.dom('.stub-radio').exists('renders the global permission group');
+      assert.ok(findButtonByText('Save'), 'has a Save button');
+      assert.ok(findButtonByText('Cancel'), 'has a Cancel button');
+    });
+
+    test('selecting a user who is already a collaborator shows the already-exists error', async function (assert) {
+      await renderComponent(this);
+
+      assert.dom('.stub-error').doesNotExist('no error initially');
+
+      await click('.add-existing');
+
+      assert
+        .dom('.stub-error')
+        .includesText('already exists', 'surfaces the existing-user error');
+    });
+
+    test('dismissing the existing-user error clears it', async function (assert) {
+      await renderComponent(this);
+      await click('.add-existing');
+      assert.dom('.stub-error').exists('error is showing');
+
+      await click('.stub-error .dismiss');
+
+      assert.dom('.stub-error').doesNotExist('error is cleared');
+    });
+
+    test('choosing the custom global permission reveals the per-aspect selects', async function (assert) {
+      await renderComponent(this);
+
+      assert.dom('.stub-select').doesNotExist('no permission selects initially');
+
+      await click('.pick-custom');
+
+      assert
+        .dom('.stub-select')
+        .exists({ count: 5 }, 'shows submissions/selections/comments/folders/feedback');
+      assert.dom('.card-row').includesText('Submissions');
+    });
+
+    test('saving a valid new user adds a permission entry and closes the form', async function (assert) {
+      await renderComponent(this);
+
+      await click('.add-new');
+      await click(findButtonByText('Save'));
+      await settled();
+
+      const permissions = this.workspace.permissions;
+      assert.strictEqual(permissions.length, 2, 'appends a permission entry');
+      assert.ok(
+        permissions.some((p) => p.user === 'user-2'),
+        'the new entry is for the selected user'
+      );
+      assert.strictEqual(this.cancelCount, 1, 'closes the form after saving');
+    });
+  }
+);

--- a/tests/integration/components/workspace-info-settings-test.js
+++ b/tests/integration/components/workspace-info-settings-test.js
@@ -288,6 +288,7 @@ module('Integration | Component | workspace-info-settings', function (hooks) {
         return {
           save() {
             return Promise.resolve({
+              wereNoAnswersToUpdate: true,
               get(key) {
                 if (key === 'wereNoAnswersToUpdate') return true;
                 return null;

--- a/tests/integration/components/workspace-info-test.js
+++ b/tests/integration/components/workspace-info-test.js
@@ -1,0 +1,163 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click, settled } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { A } from '@ember/array';
+import templateOnly from '@ember/component/template-only';
+import Service from '@ember/service';
+
+module('Integration | Component | workspace-info', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    const store = this.owner.lookup('service:store');
+
+    class UtilityMethodsService extends Service {
+      isNonEmptyObject(obj) {
+        return obj && typeof obj === 'object' && Object.keys(obj).length > 0;
+      }
+      isNonEmptyArray(arr) {
+        return Array.isArray(arr) && arr.length > 0;
+      }
+    }
+
+    class CurrentUserService extends Service {
+      user = {
+        id: 'current-user',
+        username: 'currentuser',
+        accountType: 'A',
+        isAdmin: true,
+        isStudent: false,
+      };
+    }
+
+    class SweetAlertService extends Service {}
+
+    this.owner.register('service:utility-methods', UtilityMethodsService);
+    this.owner.register('service:current-user', CurrentUserService);
+    this.owner.register('service:sweet-alert', SweetAlertService);
+
+    // Stub the child components so the container renders in isolation, wiring
+    // each stub to fire the closures the container passes down.
+    const register = (name, tmpl) => {
+      this.owner.register(`template:components/${name}`, tmpl);
+      this.owner.register(`component:${name}`, templateOnly());
+    };
+    register(
+      'workspace-info-settings',
+      hbs`<div class='stub-settings'>{{if @canEdit 'can-edit' 'read-only'}}</div>`
+    );
+    register('workspace-info-stats', hbs`<div class='stub-stats'></div>`);
+    register(
+      'workspace-info-collaborators',
+      hbs`<div class='stub-collaborators'>
+        <button
+          type='button'
+          class='open-viewer'
+          {{on 'click' @toggleIsShowingCustomViewer}}
+        >toggle</button>
+      </div>`
+    );
+    register(
+      'custom-submission-viewer-list',
+      hbs`<div class='stub-viewer'>
+        <span class='sel-count'>{{@selectedSubmissionIds.length}}</span>
+        <button type='button' class='sel-all' {{on 'click' @onSelectAll}}>all</button>
+        <button type='button' class='unsel-all' {{on 'click' @onUnselectAll}}>none</button>
+        <button
+          type='button'
+          class='sel-one'
+          {{on 'click' (fn @onSelect 'sub-9')}}
+        >one</button>
+        <button type='button' class='done' {{on 'click' @onDone}}>done</button>
+      </div>`
+    );
+
+    const workspace = store.createRecord('workspace', {
+      id: 'ws-1',
+      name: 'Test Workspace',
+      workspaceType: 'individual',
+      owner: store.createRecord('user', { id: 'owner-1', username: 'owner' }),
+      permissions: [],
+      submissions: [
+        store.createRecord('submission', { id: 'sub-1' }),
+        store.createRecord('submission', { id: 'sub-2' }),
+      ],
+    });
+
+    this.set('workspace', workspace);
+    this.set('originalCollaborators', A([]));
+  });
+
+  async function renderComponent(context) {
+    return render(hbs`
+      <WorkspaceInfo
+        @workspace={{this.workspace}}
+        @originalCollaborators={{this.originalCollaborators}}
+      />
+    `);
+  }
+
+  test('renders the workspace name and the settings, collaborators, and stats panels', async function (assert) {
+    await renderComponent(this);
+
+    assert.dom('#workspace-info h2').hasText('Test Workspace');
+    assert.dom('.stub-settings').exists('renders the settings panel');
+    assert.dom('.stub-collaborators').exists('renders the collaborators panel');
+    assert.dom('.stub-stats').exists('renders the stats panel');
+    assert.dom('.stub-viewer').doesNotExist('custom viewer is hidden initially');
+  });
+
+  test('toggling the custom viewer shows it and hides the settings and stats panels', async function (assert) {
+    await renderComponent(this);
+
+    await click('.open-viewer');
+
+    assert.dom('.stub-viewer').exists('custom viewer is shown');
+    assert.dom('.stub-settings').doesNotExist('settings panel is hidden');
+    assert.dom('.stub-stats').doesNotExist('stats panel is hidden');
+    assert
+      .dom('.stub-collaborators')
+      .exists('collaborators panel stays rendered');
+  });
+
+  test('select-all fills the selected ids from the workspace submissions and unselect-all clears them', async function (assert) {
+    await renderComponent(this);
+    await click('.open-viewer');
+
+    assert.dom('.sel-count').hasText('0', 'starts with nothing selected');
+
+    await click('.sel-all');
+    assert
+      .dom('.sel-count')
+      .hasText('2', 'select-all pulls both submission ids');
+
+    await click('.unsel-all');
+    assert.dom('.sel-count').hasText('0', 'unselect-all clears the list');
+  });
+
+  test('selecting a single submission toggles its id in the list', async function (assert) {
+    await renderComponent(this);
+    await click('.open-viewer');
+
+    await click('.sel-one');
+    assert.dom('.sel-count').hasText('1', 'adds the id on first click');
+
+    await click('.sel-one');
+    assert.dom('.sel-count').hasText('0', 'removes the same id on second click');
+  });
+
+  test('passes canEdit to the settings panel for the workspace creator', async function (assert) {
+    // Non-admin, but the creator — exercises belongsTo('createdBy').id().
+    const store = this.owner.lookup('service:store');
+    const currentUser = this.owner.lookup('service:current-user');
+    currentUser.user.accountType = 'T';
+    currentUser.user.id = 'creator-1';
+    this.workspace.createdBy = store.createRecord('user', { id: 'creator-1' });
+
+    await renderComponent(this);
+    await settled();
+
+    assert.dom('.stub-settings').hasText('can-edit');
+  });
+});


### PR DESCRIPTION
## Description

Finishes the Octane cleanup for the workspace **Info** page. The four components (`workspace-info`, `workspace-info-collaborators`, `workspace-info-collaborators-new`, `workspace-info-settings`) were already `@glimmer/component` classes, but their templates still used the classic `{{action}}` modifier and `(mut …)` two-way bindings, and their JS still read
and wrote records through `.get()` / `.set()`. This PR removes those patterns and, in doing so, fixes several latent bugs.

The one subtlety worth calling out: `owner`, `organization`, and `linkedAssignment` are all `async: true` belongsTo relationships, so they resolve to an `ObjectProxy`. Native property access (`proxy.name`) does **not**  forward through `unknownProperty` the way `proxy.get('name')` does, so those reads were converted to the Ember Data reference APIs (`belongsTo('x').id()` / `.value()`) rather than naive native access, which would have compiled cleanly but broken at runtime.

## Changes

- **Templates:** every `{{action …}}` → `{{on 'click' …}}` (or `{{fn …}}` / direct method reference where an argument or closure is passed); every `(mut this.x)` two-way binding → a dedicated `@tracked` setter action.
- **JS:** `.get()` / `.set()` → native access for concrete records and sync attributes; async belongsTo reads → `belongsTo().id()` / `.value()` reference APIs.
- **Bug fixes surfaced during the pass:**
  - `workspace-info` read `this.originalCollaborators` (undefined on a Glimmer component) instead of `this.args.originalCollaborators`.
  - `workspace-info` mutated `@tracked customSubmissionIds` in place (`addObject`/`removeObject`), so toggles were not reactive, now reassigned.
  - `workspace-info-settings` referenced `this.workspace` in one template spot instead of `@workspace`.

## Tests

- Existing suites, updated: `workspace-info-collaborators` (10 tests) and `workspace-info-settings` (6 tests) — **all 16 green** after the change. The one `workspace-info-settings` mock ("workspace up to date") that was coupled to the old `.get()` read now exposes the field natively, matching a real Ember Data record and the rest of `updateWithExistingWork` (which already read `addedSubmissions` / `updateErrors` natively). No production behavior change.
- New suites for the two previously-uncovered components — **10 tests added**:
  - `workspace-info-test.js` (5) — renders the three child panels; viewer toggle hides settings + stats; select-all / unselect all; single-submission toggle; creator gets `canEdit`.
  - `workspace-info-collaborators-new-test.js` (5) — renders the form; existing-user error; error dismiss; custom permission reveals the selects; saving a new user appends a permission entry and closes the form.
  - Both follow the house pattern (service stubs + real `store.createRecord` records, child components stubbed as template-only).
- Coverage for the Info page goes from **16 → 26 tests** across the four components.

## Notes / follow-ups (out of scope)
- The shared `ErrorHandlingComponent.removeErrorFromArray` still mutates its `@tracked` arrays in place via `removeObject`, so dismissing an individual `updateErrors`/`serverErrors` box does not re-render. It is a base-class
  method used across many components : left for a separate, scoped change.