### PR TITLE
refactor(submission-viewer): native record access in the viewer pair

### DIFF
--- a/app/components/submission-viewer-list-item.js
+++ b/app/components/submission-viewer-list-item.js
@@ -142,7 +142,7 @@ export default class SubmissionViewerListItemComponent extends Component {
     );
 
     if (result.value) {
-      answer.set('isTrashed', true);
+      answer.isTrashed = true;
       await answer.save();
 
       const toastResult = await this.alert.showToast(
@@ -155,7 +155,7 @@ export default class SubmissionViewerListItemComponent extends Component {
       );
 
       if (toastResult.value) {
-        answer.set('isTrashed', false);
+        answer.isTrashed = false;
         await answer.save();
 
         this.alert.showToast(
@@ -182,7 +182,7 @@ export default class SubmissionViewerListItemComponent extends Component {
     );
 
     if (result.value) {
-      answer.set('isTrashed', false);
+      answer.isTrashed = false;
       await answer.save();
 
       const toastResult = await this.alert.showToast(
@@ -195,7 +195,7 @@ export default class SubmissionViewerListItemComponent extends Component {
       );
 
       if (toastResult.value) {
-        answer.set('isTrashed', true);
+        answer.isTrashed = true;
         await answer.save();
 
         this.alert.showToast(

--- a/app/components/submission-viewer-list.js
+++ b/app/components/submission-viewer-list.js
@@ -37,7 +37,7 @@ export default class SubmissionViewerListComponent extends Component {
 
     answers.forEach((answer) => {
       let isSelected = selectedAnswers.includes(answer);
-      hash[answer.get('id')] = isSelected;
+      hash[answer.id] = isSelected;
     });
     return hash;
   }


### PR DESCRIPTION
## Description

Finishes the Octane cleanup for the submission-viewer pair. Both components were already `@glimmer/component`s with co-located templates, tracked state, getters, and element modifiers. Updated Ember-object `.get()`/`.set()` accessors on the `answer` record. **No behavior change.**

## Changes

- `submission-viewer-list.js` — `answer.get('id')` → `answer.id` in the `answersSelectedHash` getter.
- `submission-viewer-list-item.js` — the four `answer.set('isTrashed', …)` calls in `deleteAnswer` / `restoreAnswer` and their undo branches → native assignment. In production `answer` is a real Ember Data record, so native attribute assignment is the standard, reactive equivalent of `.set()`.

## Tests
- **No new suite needed**: both components already have integration tests