### PR TITLE
Update mt-test deploy steps for the Traefik migration

### DIFF
--- a/Jenkinsfile-dev
+++ b/Jenkinsfile-dev
@@ -60,7 +60,9 @@ pipeline {
                         sh """
                             # setup the /mtdocker folder on remote host (for manual manipulation of stack)
                             ssh ${deploymentHost} 'mkdir -p /mtdocker'
-                            scp DevOpsTemp/mt/docker-compose*.yml DevOpsTemp/mt/swarm-monitoring/docker-compose*.yml DevOpsTemp/mt/.env* jenkins@${deploymentHost}:/mtdocker
+                            # all flat in /mtdocker: stack files, traefik.yml, and the shared monitoring
+                            # stack (relative mounts, so its prometheus*.yml must sit alongside)
+                            scp DevOpsTemp/mt/docker-compose*.yml DevOpsTemp/mt/traefik.yml DevOpsTemp/monitoring/docker-compose-monitoring.yml DevOpsTemp/monitoring/prometheus.yml DevOpsTemp/monitoring/prometheus-web-config.yml DevOpsTemp/mt/.env* jenkins@${deploymentHost}:/mtdocker
                             ssh ${deploymentHost} 'chown -R :docker /mtdocker && chmod -R 770 /mtdocker'    
 
                             # set the docker remote host context
@@ -75,8 +77,8 @@ pipeline {
                             # redeploy the app service                            
                             docker stack deploy --compose-file DevOpsTemp/mt/docker-compose-mt-apps-test.yml mt-test
 
-                            # restart nginx (clears the cache and reconnects the backend service)
-                            docker service update --force mt-test_nginx
+                            # traefik needs no restart; nudge prom, which can miss a recreated service
+                            docker service update --force monitoring_prom
 
                             # set the docker build context back to local
                             docker context use default

--- a/Jenkinsfile-staging
+++ b/Jenkinsfile-staging
@@ -60,7 +60,9 @@ pipeline {
                         sh """
                             # setup the /mtdocker folder on remote host (for manual manipulation of stack)
                             ssh ${deploymentHost} 'mkdir -p /mtdocker'
-                            scp DevOpsTemp/mt/docker-compose*.yml DevOpsTemp/mt/swarm-monitoring/docker-compose*.yml DevOpsTemp/mt/.env* jenkins@${deploymentHost}:/mtdocker
+                            # all flat in /mtdocker: stack files, traefik.yml, and the shared monitoring
+                            # stack (relative mounts, so its prometheus*.yml must sit alongside)
+                            scp DevOpsTemp/mt/docker-compose*.yml DevOpsTemp/mt/traefik.yml DevOpsTemp/monitoring/docker-compose-monitoring.yml DevOpsTemp/monitoring/prometheus.yml DevOpsTemp/monitoring/prometheus-web-config.yml DevOpsTemp/mt/.env* jenkins@${deploymentHost}:/mtdocker
                             ssh ${deploymentHost} 'chown -R :docker /mtdocker && chmod -R 770 /mtdocker'    
 
                             # set the docker remote host context
@@ -75,8 +77,8 @@ pipeline {
                             # redeploy the app service                            
                             docker stack deploy --compose-file DevOpsTemp/mt/docker-compose-mt-apps-test.yml mt-test
 
-                            # restart nginx (clears the cache and reconnects the backend service)
-                            docker service update --force mt-test_nginx
+                            # traefik needs no restart; nudge prom, which can miss a recreated service
+                            docker service update --force monitoring_prom
 
                             # set the docker build context back to local
                             docker context use default


### PR DESCRIPTION
mt-test moved from nginx to Traefik and onto the shared monitoring stack (devops PR #102), which renamed the services these pipelines tear down.

- vmt1/vmt2/vmt3 are now the single replicated service mt-test_vmt, so `docker service rm mt-test_vmt1 ...` was about to fail the build against services that no longer exist.
- mt-test_nginx is gone; traefik needs no cache-clearing restart. Force-update monitoring_prom instead, which can miss a service that was just recreated.
- scp now ships traefik.yml and the shared monitoring stack files, and no longer ships mt/swarm-monitoring.