### PR TITLE
Make /mtdocker configs readable by container users

### DIFF
--- a/Jenkinsfile-dev
+++ b/Jenkinsfile-dev
@@ -63,7 +63,10 @@ pipeline {
                             # all flat in /mtdocker: stack files, traefik.yml, and the shared monitoring
                             # stack (relative mounts, so its prometheus*.yml must sit alongside)
                             scp DevOpsTemp/mt/docker-compose*.yml DevOpsTemp/mt/traefik.yml DevOpsTemp/monitoring/docker-compose-monitoring.yml DevOpsTemp/monitoring/prometheus.yml DevOpsTemp/monitoring/prometheus-web-config.yml DevOpsTemp/mt/.env* jenkins@${deploymentHost}:/mtdocker
-                            ssh ${deploymentHost} 'chown -R :docker /mtdocker && chmod -R 770 /mtdocker'    
+                            # 644 files / 755 dirs: traefik.yml and prometheus*.yml are bind-mounted and
+                            # read by non-root container users. .env-* stay group-only — secrets,
+                            # and only the docker CLI reads them.
+                            ssh ${deploymentHost} 'chown -R :docker /mtdocker && chmod -R u=rwX,go=rX /mtdocker && chmod 640 /mtdocker/.env*'    
 
                             # set the docker remote host context
                             docker context use ${deploymentHost}

--- a/Jenkinsfile-staging
+++ b/Jenkinsfile-staging
@@ -63,7 +63,10 @@ pipeline {
                             # all flat in /mtdocker: stack files, traefik.yml, and the shared monitoring
                             # stack (relative mounts, so its prometheus*.yml must sit alongside)
                             scp DevOpsTemp/mt/docker-compose*.yml DevOpsTemp/mt/traefik.yml DevOpsTemp/monitoring/docker-compose-monitoring.yml DevOpsTemp/monitoring/prometheus.yml DevOpsTemp/monitoring/prometheus-web-config.yml DevOpsTemp/mt/.env* jenkins@${deploymentHost}:/mtdocker
-                            ssh ${deploymentHost} 'chown -R :docker /mtdocker && chmod -R 770 /mtdocker'    
+                            # 644 files / 755 dirs: traefik.yml and prometheus*.yml are bind-mounted and
+                            # read by non-root container users. .env-* stay group-only — secrets,
+                            # and only the docker CLI reads them.
+                            ssh ${deploymentHost} 'chown -R :docker /mtdocker && chmod -R u=rwX,go=rX /mtdocker && chmod 640 /mtdocker/.env*'    
 
                             # set the docker remote host context
                             docker context use ${deploymentHost}


### PR DESCRIPTION
770 root:docker blocked the prom and traefik container users from reading their bind-mounted configs. Files now 644, dirs 755 (capital X — a flat -R 644 would strip execute from /mtdocker itself). .env-* stay 640: secrets, read by the docker CLI rather than mounted into containers.