### PR TITLE
Upgrade/vmt replayer classic to octane

### DIFF
--- a/app/components/vmt-replayer.hbs
+++ b/app/components/vmt-replayer.hbs
@@ -1,0 +1,5 @@
+<div
+  id='root'
+  {{did-insert this.setupReplayer}}
+  {{will-destroy this.teardownReplayer}}
+></div>

--- a/app/components/vmt-replayer.js
+++ b/app/components/vmt-replayer.js
@@ -1,57 +1,56 @@
-import Component from '@ember/component';
-import $ from 'jquery';
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
 
-export default Component.extend({
+export default class VmtReplayerComponent extends Component {
   getVmtHost() {
-    let hostname = window.location.hostname;
-    let vmtUrl;
+    const hostname = window.location.hostname;
 
     if (hostname === 'localhost') {
-      vmtUrl = 'http://localhost:3001';
+      return 'http://localhost:3001';
     } else if (hostname === 'enc-test.mathematicalthinking.org') {
-      vmtUrl = 'https://vmt-test.mathematicalthinking.org';
+      return 'https://vmt-test.mathematicalthinking.org';
     } else if (hostname === 'encompass.mathematicalthinking.org') {
-      vmtUrl = 'https://vmt.mathematicalthinking.org';
-    } else {
-      return;
+      return 'https://vmt.mathematicalthinking.org';
     }
-    return vmtUrl;
-  },
-  didInsertElement() {
+    return undefined;
+  }
+
+  @action
+  setupReplayer() {
     this.fetchReplayer();
     this.fetchCss();
-    this._super(...arguments);
-  },
+  }
 
-  willDestroyElement() {
-    $('#vmt-enc-replayer').remove();
-    $('#vmt-enc-replayer-css').remove();
-    this._super(...arguments);
-  },
+  @action
+  teardownReplayer() {
+    document.getElementById('vmt-enc-replayer')?.remove();
+    document.getElementById('vmt-enc-replayer-css')?.remove();
+  }
 
   fetchReplayer() {
-    let vmtUrl = this.getVmtHost();
+    const vmtUrl = this.getVmtHost();
 
     if (!vmtUrl) {
       return;
     }
 
-    let replayerUrl = `${vmtUrl}/enc/replayer/js`;
-    $('body').append(
-      `<script id="vmt-enc-replayer" src=${replayerUrl}></script>`
-    );
-  },
+    const script = document.createElement('script');
+    script.id = 'vmt-enc-replayer';
+    script.src = `${vmtUrl}/enc/replayer/js`;
+    document.body.appendChild(script);
+  }
 
   fetchCss() {
-    let vmtUrl = this.getVmtHost();
+    const vmtUrl = this.getVmtHost();
 
     if (!vmtUrl) {
       return;
     }
 
-    let cssUrl = `${vmtUrl}/enc/replayer/css`;
-    $('head').append(
-      `<link id="vmt-enc-replayer-css" href=${cssUrl} rel="stylesheet">`
-    );
-  },
-});
+    const link = document.createElement('link');
+    link.id = 'vmt-enc-replayer-css';
+    link.href = `${vmtUrl}/enc/replayer/css`;
+    link.rel = 'stylesheet';
+    document.head.appendChild(link);
+  }
+}

--- a/app/templates/components/vmt-replayer.hbs
+++ b/app/templates/components/vmt-replayer.hbs
@@ -1,1 +1,0 @@
-<div id="root"/>

--- a/tests/integration/components/vmt-replayer-test.js
+++ b/tests/integration/components/vmt-replayer-test.js
@@ -1,0 +1,55 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, clearRender } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | vmt-replayer', function (hooks) {
+  setupRenderingTest(hooks);
+
+  // Safety net: make sure a failed test can't leak injected tags into later ones.
+  hooks.afterEach(function () {
+    document.getElementById('vmt-enc-replayer')?.remove();
+    document.getElementById('vmt-enc-replayer-css')?.remove();
+  });
+
+  test('renders the mount point and injects the replayer script + stylesheet on insert', async function (assert) {
+    await render(hbs`<VmtReplayer />`);
+
+    assert.dom('#root').exists('renders the replayer mount point');
+
+    const script = document.getElementById('vmt-enc-replayer');
+    assert.ok(script, 'appends the replayer script');
+    assert.strictEqual(script.tagName, 'SCRIPT', 'it is a script element');
+    assert.ok(
+      script.src.includes('/enc/replayer/js'),
+      'script points at the replayer js endpoint'
+    );
+
+    const link = document.getElementById('vmt-enc-replayer-css');
+    assert.ok(link, 'appends the replayer stylesheet');
+    assert.strictEqual(link.rel, 'stylesheet', 'it is a stylesheet link');
+    assert.ok(
+      link.href.includes('/enc/replayer/css'),
+      'link points at the replayer css endpoint'
+    );
+  });
+
+  test('removes the injected script and stylesheet on teardown', async function (assert) {
+    await render(hbs`<VmtReplayer />`);
+    assert.ok(
+      document.getElementById('vmt-enc-replayer'),
+      'script present while rendered'
+    );
+
+    await clearRender();
+
+    assert.notOk(
+      document.getElementById('vmt-enc-replayer'),
+      'script removed on teardown'
+    );
+    assert.notOk(
+      document.getElementById('vmt-enc-replayer-css'),
+      'stylesheet removed on teardown'
+    );
+  });
+});


### PR DESCRIPTION
## Description

`vmt-replayer` was a small classic `Component.extend` that used jQuery to append the external VMT replayer `<script>`/`<link>` to the page (and remove them on teardown). This converts it to a Glimmer component with native DOM and render modifiers. **No behavior change**: same host resolution, same injected URLs, same cleanup.

## Changes
- `Component.extend` → `@glimmer/component`.
- **jQuery removed:** `$('body').append('<script …>')` / `$('head').append('<link …>')`
  → native `document.createElement` + `appendChild`; `$('#…').remove()` → `document.getElementById('…')?.remove()`.
- Lifecycle: `didInsertElement`/`willDestroyElement` → `{{did-insert this.setupReplayer}}` / `{{will-destroy this.teardownReplayer}}` on the template.
- **Template co-located** (`app/templates/components/` → `app/components/`), preserving the `<div id="root">` mount point the external replayer targets.
- `getVmtHost()` host-matching logic is unchanged.

## Tests

- New suite `vmt-replayer-test.js` (2 tests) — the component had **none**:
  - renders the mount point and injects the script + stylesheet with the
    correct ids/urls on insert.
  - removes both on teardown.
- All tests pass