### PR TITLE
Upgrade/parent ws collab new

### DIFF
--- a/app/components/parent-ws-collab-new.hbs
+++ b/app/components/parent-ws-collab-new.hbs
@@ -3,9 +3,9 @@
     <Ui::RadioGroup
       @options={{this.addTypeItems}}
       @selectedValue={{this.addType}}
-      @updateValue={{action 'updateAddType'}}
+      @updateValue={{this.updateAddType}}
     />
-    {{#if isBulkAdd}}
+    {{#if this.isBulkAdd}}
       <Ui::CheckboxList
         @items={{this.usersToAdd}}
         @selectedItems={{this.collabsToAdd}}
@@ -21,8 +21,8 @@
           @maxItems={{1}}
           @initialOptions={{@initialCollabOptions}}
           @selectedItemsHash={{@selectedCollaborators}}
-          @onItemAdd={{action 'setCollab'}}
-          @onItemRemove={{action 'setCollab'}}
+          @onItemAdd={{this.setCollab}}
+          @onItemRemove={{this.setCollab}}
           @labelField='username'
           @valueField='id'
           @searchField='username'
@@ -39,7 +39,7 @@
         <Ui::RadioGroup
           @options={{this.globalItems}}
           @selectedValue={{this.globalPermissionValue}}
-          @updateValue={{action 'updateGlobalPermissionValue'}}
+          @updateValue={{this.updateGlobalPermissionValue}}
         />
       </div>
     {{/unless}}
@@ -48,7 +48,7 @@
         <div class='card-row'>
           <Ui::ErrorBox
             @error='Please select a user'
-            @resetError={{action (mut this.missingUserError) false}}
+            @resetError={{this.clearMissingUserError}}
             @showDismiss={{true}}
           />
         </div>
@@ -57,7 +57,7 @@
         <div class='card-row'>
           <Ui::ErrorBox
             @error='Collaborator already exists. Edit permissions below'
-            @resetError={{action (mut this.existingUserError) false}}
+            @resetError={{this.clearExistingUserError}}
             @showDismiss={{true}}
           />
         </div>
@@ -66,11 +66,11 @@
         <button
           class='primary-button cancel-button'
           type='button'
-          {{action 'cancelCreateCollab'}}
+          {{on 'click' this.cancelCreateCollab}}
         >
           Cancel
         </button>
-        <button class='primary-button' type='button' {{action 'saveCollab'}}>
+        <button class='primary-button' type='button' {{on 'click' this.saveCollab}}>
           Save
         </button>
       </div>

--- a/app/components/parent-ws-collab-new.js
+++ b/app/components/parent-ws-collab-new.js
@@ -88,27 +88,38 @@ export default class ParentWsCollabNewComponent extends Component {
   collabsToAdd = [];
 
   get childWorkspaceOwners() {
-    let workspaces = this.args.childWorkspaces || [];
-    return workspaces.map((ws) => {
-      return ws.get('owner.content');
-    });
+    const workspaces = this.args.childWorkspaces || [];
+    return workspaces.map((ws) => ws.belongsTo('owner').value());
   }
 
   get usersToAdd() {
-    let existingCollabs = this.args.workspace.get('collaborators') || [];
-    let users = this.combinedUsers || [];
-    let ownerId = this.args.workspace.get('owner.id');
-    let creatorId = this.args.workspace.get('creator.id');
+    const existingCollabs = this.args.workspace.collaborators || [];
+    const users = this.combinedUsers || [];
+    const ownerId = this.args.workspace.belongsTo('owner').id();
+    // NOTE: the workspace model has no `creator` relationship, so this stays
+    // undefined — preserving the original `.get('creator.id')` behavior (the
+    // creator check was always a no-op). belongsTo('creator') would throw.
+    const creatorId = this.args.workspace.creator?.id;
     return users.filter((user) => {
-      if (ownerId === user.get('id') || creatorId === user.get('id')) {
+      if (ownerId === user.id || creatorId === user.id) {
         return false;
       }
-      return !existingCollabs.includes(user.get('id'));
+      return !existingCollabs.includes(user.id);
     });
   }
 
+  // Combine passed students with child-workspace owners without mutating the
+  // students arg (the classic version called addObjects on it in place).
   get combinedUsers() {
-    return this.args.students.addObjects(this.childWorkspaceOwners);
+    const students = this.args.students || [];
+    const owners = this.childWorkspaceOwners || [];
+    const combined = [...students];
+    owners.forEach((owner) => {
+      if (owner && !combined.includes(owner)) {
+        combined.push(owner);
+      }
+    });
+    return combined;
   }
 
   @action updateAddType(val) {
@@ -117,13 +128,19 @@ export default class ParentWsCollabNewComponent extends Component {
   @action updateGlobalPermissionValue(val) {
     this.globalPermissionValue = val;
   }
+  @action clearMissingUserError() {
+    this.missingUserError = false;
+  }
+  @action clearExistingUserError() {
+    this.existingUserError = false;
+  }
   @action setCollab(val) {
     if (!val) {
       return;
     }
-    let existingCollab = this.args.workspace.get('collaborators') || [];
+    const existingCollab = this.args.workspace.collaborators || [];
     const user = this.store.peekRecord('user', val);
-    let alreadyCollab = existingCollab.includes(user.get('id'));
+    const alreadyCollab = existingCollab.includes(user.id);
 
     if (alreadyCollab) {
       this.existingUserError = true;
@@ -135,23 +152,19 @@ export default class ParentWsCollabNewComponent extends Component {
   }
 
   @action saveCollab() {
-    let collabs = this.collabsToAdd;
+    const collabs = this.collabsToAdd;
     if (!this.utils.isNonEmptyArray(collabs)) {
       return (this.missingUserError = true);
     }
-    let ws = this.args.workspace;
-    let permissions = ws.get('permissions');
+    const ws = this.args.workspace;
+    const permissions = ws.permissions;
 
     // Create new permissions array with new collaborators
-    let newPermissions = Array.isArray(permissions) ? [...permissions] : [];
-    let newCollaborators = Array.isArray(this.args.originalCollaborators)
-      ? [...this.args.originalCollaborators]
-      : [];
+    const newPermissions = Array.isArray(permissions) ? [...permissions] : [];
 
     collabs.forEach((collab) => {
-      newCollaborators.push(collab);
       newPermissions.push({
-        user: collab.get('id'),
+        user: collab.id,
         global: 'custom',
         submissions: { all: true, userOnly: false, submissionIds: [] },
         folders: 1,
@@ -160,9 +173,12 @@ export default class ParentWsCollabNewComponent extends Component {
       });
     });
 
-    // Update permissions using set instead of mutating
-    ws.set('permissions', newPermissions);
-    this.args.originalCollaborators = newCollaborators;
+    ws.permissions = newPermissions;
+    // Update the parent-owned collaborators array in place (the arg is
+    // read-only, so we can't reassign it).
+    if (Array.isArray(this.args.originalCollaborators)) {
+      this.args.originalCollaborators.addObjects(collabs);
+    }
 
     ws.save().then(() => {
       this.alert.showToast(

--- a/tests/integration/components/parent-ws-collab-new-test.js
+++ b/tests/integration/components/parent-ws-collab-new-test.js
@@ -1,0 +1,158 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { A } from '@ember/array';
+import templateOnly from '@ember/component/template-only';
+import Service from '@ember/service';
+
+module(
+  'Integration | Component | parent-ws-collab-new',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    function findButtonByText(text) {
+      return Array.from(document.querySelectorAll('button')).find(
+        (b) => b.textContent.trim() === text
+      );
+    }
+
+    hooks.beforeEach(function () {
+      const store = this.owner.lookup('service:store');
+
+      class UtilsStub extends Service {
+        isNonEmptyObject(o) {
+          return o && typeof o === 'object' && Object.keys(o).length > 0;
+        }
+        isNonEmptyArray(a) {
+          return Array.isArray(a) && a.length > 0;
+        }
+      }
+      class AlertStub extends Service {
+        showToast() {
+          return Promise.resolve();
+        }
+      }
+      this.owner.register('service:utility-methods', UtilsStub);
+      this.owner.register('service:sweet-alert', AlertStub);
+
+      const register = (name, tmpl) => {
+        this.owner.register(`template:components/${name}`, tmpl);
+        this.owner.register(`component:${name}`, templateOnly());
+      };
+      register('ui/radio-group', hbs`<div class='stub-radio'></div>`);
+      register('ui/checkbox-list', hbs`<div class='stub-checkbox-list'></div>`);
+      register(
+        'selectize-input',
+        hbs`<div class='stub-selectize'>
+          <button type='button' class='add-existing' {{on 'click' (fn @onItemAdd 'user-existing')}}>ex</button>
+          <button type='button' class='add-new' {{on 'click' (fn @onItemAdd 'user-new')}}>new</button>
+        </div>`
+      );
+      register(
+        'ui/error-box',
+        hbs`<div class='stub-error'>{{@error}}
+          <button type='button' class='dismiss' {{on 'click' @resetError}}>x</button>
+        </div>`
+      );
+
+      const owner = store.createRecord('user', { id: 'owner-1' });
+      store.createRecord('user', { id: 'user-existing', username: 'exists' });
+      store.createRecord('user', { id: 'user-new', username: 'newbie' });
+
+      // Seed one existing collaborator via permissions (the workspace's
+      // `collaborators` getter derives ids from it).
+      const workspace = store.createRecord('workspace', {
+        id: 'pws-1',
+        workspaceType: 'parent',
+        owner,
+        permissions: [
+          {
+            user: 'user-existing',
+            global: 'custom',
+            submissions: { all: true, userOnly: false, submissionIds: [] },
+          },
+        ],
+      });
+      workspace.save = () => Promise.resolve();
+
+      this.cancelCount = 0;
+      this.set('onCancel', () => {
+        this.cancelCount += 1;
+      });
+      this.set('workspace', workspace);
+      this.set('originalCollaborators', A([]));
+      this.set('students', A([]));
+      this.set('childWorkspaces', A([]));
+    });
+
+    async function renderComponent(context) {
+      return render(hbs`
+        <ParentWsCollabNew
+          @workspace={{this.workspace}}
+          @students={{this.students}}
+          @childWorkspaces={{this.childWorkspaces}}
+          @originalCollaborators={{this.originalCollaborators}}
+          @cancelEditCollab={{this.onCancel}}
+          @initialCollabOptions={{this.initialCollabOptions}}
+          @selectedCollaborators={{this.selectedCollaborators}}
+        />
+      `);
+    }
+
+    test('renders the individual add form with the permission group and Save/Cancel', async function (assert) {
+      await renderComponent(this);
+
+      assert.dom('#parent-ws-collab-new').exists();
+      assert.dom('.stub-selectize').exists('individual add shows the user search');
+      assert.ok(findButtonByText('Save'), 'has Save');
+      assert.ok(findButtonByText('Cancel'), 'has Cancel');
+    });
+
+    test('selecting an already-existing collaborator surfaces the existing-user error', async function (assert) {
+      await renderComponent(this);
+
+      assert.dom('.stub-error').doesNotExist();
+      await click('.add-existing');
+
+      assert.dom('.stub-error').includesText('already exists');
+    });
+
+    test('dismissing the existing-user error clears it', async function (assert) {
+      await renderComponent(this);
+      await click('.add-existing');
+      assert.dom('.stub-error').exists();
+
+      await click('.stub-error .dismiss');
+
+      assert.dom('.stub-error').doesNotExist();
+    });
+
+    test('saving with no user selected shows the missing-user error', async function (assert) {
+      await renderComponent(this);
+
+      await click(findButtonByText('Save'));
+
+      assert.dom('.stub-error').includesText('Please select a user');
+    });
+
+    test('saving a valid user appends a read-only permission, updates originalCollaborators in place, and closes', async function (assert) {
+      await renderComponent(this);
+
+      await click('.add-new');
+      await click(findButtonByText('Save'));
+
+      const perms = this.workspace.permissions;
+      const added = perms.find((p) => p.user === 'user-new');
+      assert.ok(added, 'a permission entry was appended for the new user');
+      assert.strictEqual(added.global, 'custom', 'parent collab is custom/read-only');
+      assert.strictEqual(added.feedback, 'approver', 'feedback workaround preserved');
+
+      assert.ok(
+        this.originalCollaborators.some((u) => u.id === 'user-new'),
+        'the new user was added to originalCollaborators in place (no arg reassignment)'
+      );
+      assert.strictEqual(this.cancelCount, 1, 'the form closes after saving');
+    });
+  }
+);


### PR DESCRIPTION
## Description

Finishes the `parent-ws-collab-new` cleanup. It was already a `@glimmer/component`, so this is the record-access + template cleanup : **and it fixes three real bugs** surfaced while reading it. Adds the component's first tests.

## Changes

- **Cleanup:** `.get()`/`.set()` → native access / reference APIs; `{{action}}` and `(mut …)` → `{{on}}` / method references + `clearMissingUserError` / `clearExistingUserError`.
- **Bug 1 — read-only arg reassignment:** `saveCollab` did `this.args.originalCollaborators = …`, which is invalid on a Glimmer component (args are read-only). Now it mutates the parent-owned array in place (`addObjects`), matching the sibling `workspace-info-collaborators-new`.
- **Bug 2 — getter side effect:** `combinedUsers` called `this.args.students.addObjects(…)`, mutating a passed arg on every read. Now it builds a fresh deduped array, and drops null child-workspace owners that would otherwise crash `usersToAdd`.
- **Bug 3 — missing `this.`:** template `{{#if isBulkAdd}}` → `{{#if this.isBulkAdd}}`.
- **Deliberately kept:** `workspace.creator?.id` stays a plain undefined read: the workspace model has **no `creator` relationship**, so `belongsTo('creator')` would throw, and the original `.get('creator.id')` was always `undefined` (the creator check is a no-op). Commented so it isn't "corrected" into `belongsTo`.

## Tests

- New suite `parent-ws-collab-new-test.js`
-  All tests pass