### PR TITLE
Upgrade/home page

### DIFF
--- a/app/components/home-page.hbs
+++ b/app/components/home-page.hbs
@@ -5,7 +5,7 @@
       @scrollIndicators='all'
       @widthConstraint='eq-container'
       @sorts={{this.sorts}}
-      @onUpdateSorts={{action (mut this.sorts)}}
+      @onUpdateSorts={{this.updateSorts}}
     />
     <t.body @rows={{@details}} as |b|>
       <b.row as |r|>

--- a/app/components/home-page.js
+++ b/app/components/home-page.js
@@ -7,21 +7,33 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 
 export default class HomePageComponent extends Component {
   @service router;
   @service('utility-methods') utils;
-  @action toResponse(thread) {
-    let response = thread.get('highestPriorityResponse');
+
+  // Ember Table writes the active sorts back here via @onUpdateSorts; it must be
+  // tracked so column sorting actually re-renders.
+  @tracked sorts = [];
+
+  @action
+  updateSorts(sorts) {
+    this.sorts = sorts;
+  }
+
+  @action
+  toResponse(thread) {
+    const response = thread.highestPriorityResponse;
     if (response) {
-      let responseId = response.get('id');
-      let submissionId = this.utils.getBelongsToId(response, 'submission');
+      const responseId = response.id;
+      const submissionId = this.utils.getBelongsToId(response, 'submission');
       this.router.transitionTo('responses.submission', submissionId, {
         queryParams: { responseId },
       });
     } else {
-      let submission = thread.get('highestPrioritySubmission');
+      const submission = thread.highestPrioritySubmission;
       this.router.transitionTo('responses.submission', submission);
     }
   }

--- a/tests/integration/components/home-page-test.js
+++ b/tests/integration/components/home-page-test.js
@@ -1,0 +1,117 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { A } from '@ember/array';
+import templateOnly from '@ember/component/template-only';
+import Service from '@ember/service';
+
+module('Integration | Component | home-page', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    // Capture router navigation.
+    this.transitions = [];
+    const transitions = this.transitions;
+    this.owner.register(
+      'service:router',
+      class extends Service {
+        transitionTo(...args) {
+          transitions.push(args);
+        }
+      }
+    );
+    this.owner.register(
+      'service:utility-methods',
+      class extends Service {
+        getBelongsToId(record, key) {
+          return record ? record[`${key}Id`] : null;
+        }
+      }
+    );
+
+    // Stub Ember Table's yielded block API just enough to render one feedback
+    // cell (so the toResponse link is reachable). Yields:
+    //   t -> { head, body } ; body(as |b|) -> { row } per row ;
+    //   row(as |r|) -> { cell } ; cell -> (cellValue, columnValue, rowValue).
+    const reg = (name, tmpl) => {
+      this.owner.register(`template:components/${name}`, tmpl);
+      this.owner.register(`component:${name}`, templateOnly());
+    };
+    reg(
+      'ember-table',
+      hbs`{{yield (hash head=(component 'et-head') body=(component 'et-body'))}}`
+    );
+    reg('et-head', hbs``);
+    reg(
+      'et-body',
+      hbs`{{#each @rows as |row|}}{{yield (hash row=(component 'et-row' row=row))}}{{/each}}`
+    );
+    reg('et-row', hbs`{{yield (hash cell=(component 'et-cell' row=@row))}}`);
+    reg(
+      'et-cell',
+      hbs`{{yield @row.label (hash name='Student Submission') @row}}`
+    );
+
+    this.set('tableColumns', []);
+    this.set('type', 'feedback');
+  });
+
+  async function renderComponent(context) {
+    return render(hbs`
+      <HomePage
+        @tableColumns={{this.tableColumns}}
+        @details={{this.details}}
+        @type={{this.type}}
+      />
+    `);
+  }
+
+  test('renders the dashboard table with a feedback link per row', async function (assert) {
+    this.set('details', A([{ label: 'Student A' }]));
+    await renderComponent(this);
+
+    assert.dom('.home--container').exists();
+    assert.dom('.home--container a').hasText('Student A');
+  });
+
+  test('clicking a feedback row with a response navigates to the response', async function (assert) {
+    this.set(
+      'details',
+      A([
+        {
+          label: 'Student A',
+          highestPriorityResponse: { id: 'resp-1', submissionId: 'sub-1' },
+        },
+      ])
+    );
+    await renderComponent(this);
+
+    await click('.home--container a');
+
+    assert.deepEqual(this.transitions, [
+      ['responses.submission', 'sub-1', { queryParams: { responseId: 'resp-1' } }],
+    ]);
+  });
+
+  test('clicking a feedback row with no response navigates to the submission', async function (assert) {
+    const submission = { id: 'sub-2' };
+    this.set(
+      'details',
+      A([
+        {
+          label: 'Student B',
+          highestPriorityResponse: null,
+          highestPrioritySubmission: submission,
+        },
+      ])
+    );
+    await renderComponent(this);
+
+    await click('.home--container a');
+
+    assert.deepEqual(this.transitions, [
+      ['responses.submission', submission],
+    ]);
+  });
+});


### PR DESCRIPTION
## Description

Cleans up the `home-page` dashboard component (already a Glimmer component around Ember Table) — the `.get()` / `{{action}}` modernization the audit flagged : and fixes a bug found along the way: **column sorting wasn't reactive.**

## Changes

- **Native access:** the three `.get()` reads in `toResponse` → `thread.highestPriorityResponse` / `response.id` /
  `thread.highestPrioritySubmission`. Safe — `controllers/index.js` already reads the same properties natively.
- **Fix — Ember Table sorting:** the table binds `@sorts={{this.sorts}}` and writes back via `@onUpdateSorts`, but `sorts` was never defined as tracked state, so those writes weren't reactive and sorting didn't re-render. Added `@tracked sorts = []` + an `updateSorts` action; template `(mut this.sorts)` → `{{this.updateSorts}}`.

## Tests

- New suite `home-page-test.js` (3 tests) — the component had **none**. The navigation lives inside an Ember Table cell, so the suite stubs the table's yielded block API (`t.head`/`t.body`/`b.row`/`r.cell`) enough to render one feedback cell and click it: renders the link per row; response → navigates to `responses.submission` with the `responseId` query param; no response → navigates to the submission.
- All tests pass