### PR TITLE
Auth cluster j query removal

### DIFF
--- a/app/components/confirm-email.js
+++ b/app/components/confirm-email.js
@@ -1,6 +1,5 @@
 import ErrorHandlingComponent from './error-handling';
 import { tracked } from '@glimmer/tracking';
-import $ from 'jquery';
 
 export default class ConfirmEmailComponent extends ErrorHandlingComponent {
   @tracked confirmTokenErrors = [];
@@ -10,27 +9,27 @@ export default class ConfirmEmailComponent extends ErrorHandlingComponent {
 
   constructor() {
     super(...arguments);
-    const token = this.args.token;
-    if (token) {
-      $.get({
-        url: `/auth/confirm/${token}`,
-      })
-        .then((res) => {
-          if (res.isValid) {
-            this.isTokenValid = true;
-          } else {
-            let isAlreadyConfirmed =
-              res.info === 'Email has already been confirmed';
-            if (isAlreadyConfirmed) {
-              this.isAlreadyConfirmed = true;
-              return;
-            }
-            this.invalidTokenError = res.info;
-          }
-        })
-        .catch((err) => {
-          this[err] = 'confirmTokenErrors';
-        });
+    if (this.args.token) {
+      this.verifyToken(this.args.token);
+    }
+  }
+
+  async verifyToken(token) {
+    try {
+      const response = await fetch(`/auth/confirm/${token}`);
+      if (!response.ok) {
+        throw new Error(`Confirmation failed (${response.status})`);
+      }
+      const res = await response.json();
+      if (res.isValid) {
+        this.isTokenValid = true;
+      } else if (res.info === 'Email has already been confirmed') {
+        this.isAlreadyConfirmed = true;
+      } else {
+        this.invalidTokenError = res.info;
+      }
+    } catch (err) {
+      this.confirmTokenErrors = [err?.message || 'Unable to confirm email'];
     }
   }
 

--- a/app/components/forgot-password.js
+++ b/app/components/forgot-password.js
@@ -1,7 +1,6 @@
 import ErrorHandlingComponent from './error-handling';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import $ from 'jquery';
 
 export default class ForgotPasswordComponent extends ErrorHandlingComponent {
   @tracked postErrors = [];
@@ -40,7 +39,7 @@ export default class ForgotPasswordComponent extends ErrorHandlingComponent {
     }
   }
 
-  @action handleRequest() {
+  @action async handleRequest() {
     const email = this.email;
     const username = this.username;
 
@@ -58,21 +57,24 @@ export default class ForgotPasswordComponent extends ErrorHandlingComponent {
       username,
     };
 
-    return $.post({
-      url: '/auth/forgot',
-      data: forgotPasswordData,
-    })
-      .then((res) => {
-        if (res.isSuccess) {
-          this.clearFields();
-          this.resetEmailSent = true;
-        } else {
-          this.forgotPasswordErr = res.info;
-        }
-      })
-      .catch((err) => {
-        this.handleErrors(err, 'postErrors');
+    try {
+      const response = await fetch('/auth/forgot', {
+        method: 'POST',
+        body: new URLSearchParams(forgotPasswordData),
       });
+      if (!response.ok) {
+        throw new Error(`Request failed (${response.status})`);
+      }
+      const res = await response.json();
+      if (res.isSuccess) {
+        this.clearFields();
+        this.resetEmailSent = true;
+      } else {
+        this.forgotPasswordErr = res.info;
+      }
+    } catch (err) {
+      this.handleErrors(err, 'postErrors');
+    }
   }
   @action resetMessages() {
     const messages = [

--- a/app/components/log-in.js
+++ b/app/components/log-in.js
@@ -1,9 +1,11 @@
 import ErrorHandlingComponent from './error-handling';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import $ from 'jquery';
+import { service } from '@ember/service';
 
 export default class LogInComponent extends ErrorHandlingComponent {
+  @service navigation;
+
   @tracked incorrectPassword = false;
   @tracked incorrectUsername = false;
   @tracked missingCredentials = false;
@@ -44,22 +46,24 @@ export default class LogInComponent extends ErrorHandlingComponent {
       username: this.username.trim(),
       password: this.password,
     };
-    $.post({
-      url: '/auth/login',
-      data: createUserData,
-    })
-      .then((res) => {
-        console.log(res);
-        if (res.message === 'Incorrect password') {
-          this.incorrectPassword = true;
-        } else if (res.message === 'Incorrect username') {
-          this.incorrectUsername = true;
-        } else {
-          window.location.href = '/';
-        }
-      })
-      .catch((err) => {
-        this.handleErrors(err, 'postErrors');
+    try {
+      const response = await fetch('/auth/login', {
+        method: 'POST',
+        body: new URLSearchParams(createUserData),
       });
+      if (!response.ok) {
+        throw new Error(`Login failed (${response.status})`);
+      }
+      const res = await response.json();
+      if (res.message === 'Incorrect password') {
+        this.incorrectPassword = true;
+      } else if (res.message === 'Incorrect username') {
+        this.incorrectUsername = true;
+      } else {
+        this.navigation.toHome({ fullReload: true });
+      }
+    } catch (err) {
+      this.handleErrors(err, 'postErrors');
+    }
   }
 }

--- a/app/components/sign-up.js
+++ b/app/components/sign-up.js
@@ -2,7 +2,6 @@ import UserSignupComponent from './user-signup';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import $ from 'jquery';
 import isNull from 'lodash-es/isNull';
 import filter from 'lodash-es/filter';
 import map from 'lodash-es/map';
@@ -23,23 +22,20 @@ export default class SignUpComponent extends UserSignupComponent {
   didConfirmOrgRequest = false;
   @service('string-similarity') similarity;
   @service('sweet-alert') alert;
+  @service navigation;
 
-  createUser(data) {
-    return new Promise((resolve, reject) => {
-      if (!data) {
-        return reject('Invalid data');
-      }
-      $.post({
-        url: '/auth/signup',
-        data: data,
-      })
-        .then((res) => {
-          return resolve(res);
-        })
-        .catch((err) => {
-          reject(err);
-        });
+  async createUser(data) {
+    if (!data) {
+      throw 'Invalid data';
+    }
+    const response = await fetch('/auth/signup', {
+      method: 'POST',
+      body: new URLSearchParams(data),
     });
+    if (!response.ok) {
+      throw new Error(`Signup failed (${response.status})`);
+    }
+    return response.json();
   }
   getSimilarOrgs(orgRequest) {
     let stopWords = [
@@ -59,7 +55,7 @@ export default class SignUpComponent extends UserSignupComponent {
       return [];
     }
 
-    let sliced = orgs.toArray().slice();
+    let sliced = orgs.slice();
 
     let requestCompare = this.similarity.convertStringForCompare(
       orgRequest,
@@ -81,7 +77,7 @@ export default class SignUpComponent extends UserSignupComponent {
       return [];
     }
 
-    let toArray = orgs.toArray();
+    let toArray = orgs.slice();
     let mapped = map(toArray, (org) => {
       return {
         id: org.id,
@@ -189,7 +185,7 @@ export default class SignUpComponent extends UserSignupComponent {
               null,
               false
             );
-            window.location.href = '/';
+            this.navigation.toHome({ fullReload: true });
           } else if (
             res.message === 'There already exists a user with that username'
           ) {
@@ -219,7 +215,7 @@ export default class SignUpComponent extends UserSignupComponent {
               null,
               false
             );
-            window.location.href = '/';
+            this.navigation.toHome({ fullReload: true });
           } else if (
             res.message === 'There already exists a user with that username'
           ) {
@@ -281,6 +277,7 @@ export default class SignUpComponent extends UserSignupComponent {
           text
         )
         .then((result) => {
+          const selectize = document.querySelector('select')?.selectize;
           if (result.value) {
             // user confirmed org request
             if (result.value === input) {
@@ -293,13 +290,13 @@ export default class SignUpComponent extends UserSignupComponent {
               return callback(ret);
             }
             // user selected an existing org
-            $('select')[0].selectize.setValue(result.value, true);
-            $('select')[0].selectize.removeOption(input);
+            selectize?.setValue(result.value, true);
+            selectize?.removeOption(input);
             return callback(null);
           } else {
             // user hit cancel
             // remove option from dropdown
-            $('select')[0].selectize.removeOption(input);
+            selectize?.removeOption(input);
             return callback(null);
           }
         });

--- a/app/components/unconfirmed-email.js
+++ b/app/components/unconfirmed-email.js
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
@@ -22,16 +21,19 @@ export default class UnconfirmedEmailComponent extends Component {
   }
 
   @action
-  sendEmail() {
-    $.get('/auth/resend/confirm')
-      .then((res) => {
-        if (res.isSuccess) {
-          this.emailSuccess = true;
-          this.errorHandling.removeMessages('emailErrors');
-        }
-      })
-      .catch((err) => {
-        this.errorHandling.handleErrors(err, 'emailErrors');
-      });
+  async sendEmail() {
+    try {
+      const response = await fetch('/auth/resend/confirm');
+      if (!response.ok) {
+        throw new Error(`Request failed (${response.status})`);
+      }
+      const res = await response.json();
+      if (res.isSuccess) {
+        this.emailSuccess = true;
+        this.errorHandling.removeMessages('emailErrors');
+      }
+    } catch (err) {
+      this.errorHandling.handleErrors(err, 'emailErrors');
+    }
   }
 }

--- a/tests/integration/components/forgot-password-test.js
+++ b/tests/integration/components/forgot-password-test.js
@@ -1,0 +1,81 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click, fillIn, settled } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import Service from '@ember/service';
+
+module('Integration | Component | forgot-password', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    // ErrorHandling superclass injects sweet-alert.
+    this.owner.register(
+      'service:sweet-alert',
+      class extends Service {
+        showToast() {}
+      }
+    );
+
+    // Stub fetch; each test sets fetchPayload.
+    this.fetchCalls = [];
+    this.fetchPayload = { isSuccess: true };
+    const self = this;
+    this.originalFetch = window.fetch;
+    window.fetch = function (url, opts) {
+      self.fetchCalls.push({ url, opts });
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(self.fetchPayload),
+      });
+    };
+  });
+
+  hooks.afterEach(function () {
+    window.fetch = this.originalFetch;
+  });
+
+  test('submitting with neither email nor username shows the missing-fields error', async function (assert) {
+    await render(hbs`<ForgotPassword />`);
+    await click('#request-reset-link');
+    await settled();
+
+    assert.dom('.error-message').hasText('Missing Required Fields');
+    assert.strictEqual(this.fetchCalls.length, 0, 'no request was made');
+  });
+
+  test('submitting both an email and a username shows the too-much-data error', async function (assert) {
+    await render(hbs`<ForgotPassword />`);
+    await fillIn('#email', 'teacher@school.edu');
+    await fillIn('#username', 'someuser');
+    await click('#request-reset-link');
+    await settled();
+
+    assert.dom('.error-message').includesText('only one');
+    assert.strictEqual(this.fetchCalls.length, 0, 'no request was made');
+  });
+
+  test('a successful request shows the confirmation and clears the fields', async function (assert) {
+    this.fetchPayload = { isSuccess: true };
+
+    await render(hbs`<ForgotPassword />`);
+    await fillIn('#email', 'teacher@school.edu');
+    await click('#request-reset-link');
+    await settled();
+
+    assert.strictEqual(this.fetchCalls[0].url, '/auth/forgot', 'posts to /auth/forgot');
+    assert.dom('.success-message').exists();
+    assert.dom('#email').hasValue('', 'the email field is cleared');
+  });
+
+  test('an unsuccessful request surfaces the server info message', async function (assert) {
+    this.fetchPayload = { isSuccess: false, info: 'No account matches that email' };
+
+    await render(hbs`<ForgotPassword />`);
+    await fillIn('#email', 'nobody@nowhere.com');
+    await click('#request-reset-link');
+    await settled();
+
+    assert.dom('.error-message').hasText('No account matches that email');
+  });
+});

--- a/tests/integration/components/log-in-test.js
+++ b/tests/integration/components/log-in-test.js
@@ -1,0 +1,94 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click, fillIn, settled } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import Service from '@ember/service';
+import templateOnly from '@ember/component/template-only';
+
+module('Integration | Component | log-in', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    // SocialSignin needs the mtAuth service; stub it out so log-in renders alone.
+    this.owner.register('template:components/social-signin', hbs``);
+    this.owner.register('component:social-signin', templateOnly());
+
+    // ErrorHandling superclass injects sweet-alert.
+    this.owner.register(
+      'service:sweet-alert',
+      class extends Service {
+        showToast() {}
+      }
+    );
+
+    // Spy on the navigation service so we can assert the redirect without reloading.
+    this.homeCalls = [];
+    const homeCalls = this.homeCalls;
+    this.owner.register(
+      'service:navigation',
+      class extends Service {
+        toHome(opts) {
+          homeCalls.push(opts);
+        }
+      }
+    );
+
+    // Stub fetch; each test sets fetchOk / fetchPayload.
+    this.fetchCalls = [];
+    this.fetchOk = true;
+    this.fetchPayload = {};
+    const self = this;
+    this.originalFetch = window.fetch;
+    window.fetch = function (url, opts) {
+      self.fetchCalls.push({ url, opts });
+      return Promise.resolve({
+        ok: self.fetchOk,
+        status: self.fetchOk ? 200 : 401,
+        json: () => Promise.resolve(self.fetchPayload),
+      });
+    };
+  });
+
+  hooks.afterEach(function () {
+    window.fetch = this.originalFetch;
+  });
+
+  test('submitting with no credentials shows the error and never calls the server', async function (assert) {
+    await render(hbs`<LogIn />`);
+    await click('.auth-button');
+    await settled();
+
+    assert.dom('.error-text').hasText('Incorrect username or password');
+    assert.strictEqual(this.fetchCalls.length, 0, 'no request was made');
+    assert.strictEqual(this.homeCalls.length, 0, 'did not navigate');
+  });
+
+  test('an "Incorrect password" response shows the password error and stays put', async function (assert) {
+    this.fetchOk = true;
+    this.fetchPayload = { message: 'Incorrect password' };
+
+    await render(hbs`<LogIn />`);
+    await fillIn('#username', 'teacher1');
+    await fillIn('#password', 'wrongpass');
+    await click('.auth-button');
+    await settled();
+
+    assert.strictEqual(this.fetchCalls[0].url, '/auth/login', 'posts to /auth/login');
+    assert.dom('.error-text').hasText('Incorrect Password');
+    assert.strictEqual(this.homeCalls.length, 0, 'stays on the login page');
+  });
+
+  test('a successful login navigates home with a full reload', async function (assert) {
+    this.fetchOk = true;
+    this.fetchPayload = { user: { id: '1' } };
+
+    await render(hbs`<LogIn />`);
+    await fillIn('#username', 'teacher1');
+    await fillIn('#password', 'correcthorse');
+    await click('.auth-button');
+    await settled();
+
+    assert.strictEqual(this.homeCalls.length, 1, 'navigated home once');
+    assert.deepEqual(this.homeCalls[0], { fullReload: true });
+  });
+});

--- a/tests/integration/components/unconfirmed-email-test.js
+++ b/tests/integration/components/unconfirmed-email-test.js
@@ -22,14 +22,14 @@ class MockSweetAlertService extends Service {
   }
 }
 
-// Stub jQuery GET request
-function mockJQueryGet(url) {
+// Stub the resend-confirmation fetch so the failure path surfaces the errors
+function mockFetch(url) {
   if (url === '/auth/resend/confirm') {
     return Promise.reject({
       errors: [{ detail: 'Email not found' }, { detail: 'Invalid request' }],
     });
   }
-  return Promise.resolve();
+  return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
 }
 
 module('Integration | Component | unconfirmed-email', function (hooks) {
@@ -39,17 +39,17 @@ module('Integration | Component | unconfirmed-email', function (hooks) {
     // Register mock CurrentUser service
     this.owner.register('service:current-user', MockCurrentUserService);
 
-    // Stub jQuery
-    this.originalJQueryGet = window.$.get;
-    window.$.get = mockJQueryGet;
+    // Stub fetch
+    this.originalFetch = window.fetch;
+    window.fetch = mockFetch;
 
     // Register mock SweetAlert service
     this.owner.register('service:sweet-alert', MockSweetAlertService);
   });
 
   hooks.afterEach(function () {
-    // Restore original jQuery
-    window.$.get = this.originalJQueryGet;
+    // Restore original fetch
+    window.fetch = this.originalFetch;
   });
 
   test('it uses the real ErrorHandlingService and displays errors correctly', async function (assert) {


### PR DESCRIPTION
## Description

Removes jQuery from the five auth components that still relied on it for their HTTP calls (`log-in`, `forgot-password`, `confirm-email`, `unconfirmed-email`,`sign-up`). This is the largest of the live jQuery holdouts and follows the
UPGRADE_NOTES goal of eliminating our own jQuery usage in favor of standard DOM / etch (jQuery itself stays only where selectize requires it).

Every request is converted to `fetch` using the same request shape the server already received (form-encoded body), and the post-auth redirects now go through the existing `navigation` service rather than `window.location.href`. No behavior
change is intended, each success / error branch is preserved.

## Changes

- **`fetch` instead of jQuery** in all five components (`$.get` / `$.post` →`fetch`), matching how other components already post to `/auth/*`. jQuery imports removed from each.
- **`navigation` service for redirects** — `log-in` (1) and `sign-up` (2) no longer hard-set `window.location.href = '/'`; they call `navigation.toHome({ fullReload: true })`, the same path the reset-password migration established.
- **`confirm-email` bug fix** — the old `.catch` assigned the error to `this[err]` (a nonsense dynamic key) instead of `confirmTokenErrors`, so confirmation failures never showed. Now sets the error array and displays a message.
- **`sign-up` extras folded in** — the three jQuery selectize calls that drive the organization dropdown converted to native element access; the two deprecated `toArray()` reads converted to `slice()`.
- **No `<Input>`/template changes** — this is a JS-side conversion; markup is untouched.

## Tests

- **Reworked** `unconfirmed-email-test.js` — stub `fetch` instead of `window.$.get` same failure payload; still asserts the two error messages render).
- **New** `log-in-test.js` (3) — stubs `fetch` + a spy `navigation` service: missing-credentials error with no request, incorrect-password error, and a successful login calling the home redirect.
- **New** `forgot-password-test.js` (4) — stubbed `fetch`: missing-fields, too-much-data, success-clears-fields, and the server info-message path.
- Auth being high-risk, the flows were also exercised by hand against the local sign-on stack (login with good/bad credentials, forgot → reset link, full signup including the similar-orgs modal, email confirmation, and resend).